### PR TITLE
Some fixes to variants querying

### DIFF
--- a/dae/dae/studies/helpers.py
+++ b/dae/dae/studies/helpers.py
@@ -156,8 +156,10 @@ def get_variants_web(
         dataset, query, genotype_attrs, weights_loader,
         variants_hard_max=2000):
 
-    if 'geneSet' in query:
-        query.pop('geneSet')
+    # impala columns are lowercase
+    if 'genomicScores' in query:
+        for gs in query['genomicScores']:
+            gs['metric'] = gs['metric'].lower()
 
     variants = dataset.query_variants(weights_loader, **query)
     people_group_id = query.get('peopleGroup', {}).get('id', None)

--- a/dae/dae/studies/study.py
+++ b/dae/dae/studies/study.py
@@ -61,7 +61,22 @@ class Study(StudyBase):
                 self.name not in kwargs['studyFilters']:
             return
         else:
-            for variant in self.backend.query_variants(**kwargs):
+            for variant in self.backend.query_variants(
+                    regions=kwargs.get('regions'),
+                    genes=kwargs.get('genes'),
+                    effect_types=kwargs.get('effect_types'),
+                    family_ids=kwargs.get('family_ids'),
+                    person_ids=kwargs.get('person_ids'),
+                    inheritance=kwargs.get('inheritance'),
+                    roles=kwargs.get('roles'),
+                    sexes=kwargs.get('sexes'),
+                    variant_type=kwargs.get('variant_type'),
+                    real_attr_filter=kwargs.get('real_attr_filter'),
+                    ultra_rare=kwargs.get('ultra_rare'),
+                    return_reference=kwargs.get('return_reference'),
+                    return_unknown=kwargs.get('return_unknown'),
+                    limit=kwargs.get('limit')
+                    ):
                 for allele in variant.alleles:
                     allele.update_attributes({'studyName': self.name})
                 yield variant

--- a/jenkins_data.sh
+++ b/jenkins_data.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 
-wget -c https://iossifovlab.com/distribution/public/data-hg19-startup.tar.gz
+wget -c https://iossifovlab.com/distribution/public/data-hg19-startup-latest.tar.gz
 
-data_tar_time=`stat -c %Y data-hg19-startup.tar.gz`
+data_tar_time=`stat -c %Y data-hg19-startup-latest.tar.gz`
 data_dir_time=`stat -c %Y data-hg19-startup`
 if [ ! -d 'data-hg19-startup' ] || [ $data_tar_time -nt $data_dir_time ];
 then
-    tar zxf data-hg19-startup.tar.gz
+    tar zxf data-hg19-startup-latest.tar.gz
 fi
 


### PR DESCRIPTION
Backend's query_variants now gets an explicit set of keyword arguments instead of a
kwargs dict with all keyword arguments; This was done to fix errors
with excess keyword arguments getting passed to the backend

The genomicScores filter's name of the genomic score being filtered is
now converted to lowercase due to the way Impala stores column names

minor jenkins_data update