### PR TITLE
Speed up unit tests by changing fixture scopes

### DIFF
--- a/dae/dae/annotation/tests/conftest.py
+++ b/dae/dae/annotation/tests/conftest.py
@@ -21,24 +21,22 @@ def relative_to_this_test_folder(path):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dae_config_fixture():
     return DAEConfigParser.read_and_parse_file_configuration(
         work_dir=relative_to_this_test_folder('fixtures')
     )
 
 
-@pytest.fixture(scope='function')
-def mocked_gpf_instance(mocker, mock_genomes_db, dae_config_fixture):
-    mocker.patch('dae.gpf_instance.gpf_instance.GPFInstance')
-
-    gpf_instance = GPFInstance()
+@pytest.fixture(scope='session')
+def mocked_gpf_instance(mock_genomes_db, dae_config_fixture):
+    gpf_instance = GPFInstance(work_dir=relative_to_this_test_folder('fixtures'))
     gpf_instance.dae_config = dae_config_fixture
 
     return gpf_instance
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def mocked_genomes_db(mocked_gpf_instance):
     return mocked_gpf_instance.genomes_db
 

--- a/dae/dae/annotation/tests/conftest.py
+++ b/dae/dae/annotation/tests/conftest.py
@@ -30,10 +30,7 @@ def dae_config_fixture():
 
 @pytest.fixture(scope='session')
 def mocked_gpf_instance(mock_genomes_db, dae_config_fixture):
-    gpf_instance = GPFInstance(work_dir=relative_to_this_test_folder('fixtures'))
-    gpf_instance.dae_config = dae_config_fixture
-
-    return gpf_instance
+    return GPFInstance(work_dir=relative_to_this_test_folder('fixtures'))
 
 
 @pytest.fixture(scope='session')

--- a/dae/dae/backends/impala/tests/conftest.py
+++ b/dae/dae/backends/impala/tests/conftest.py
@@ -14,26 +14,26 @@ def relative_to_this_test_folder(path):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=relative_to_this_test_folder('fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dae_config_fixture(gpf_instance):
     return gpf_instance.dae_config
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def parquet_manager(dae_config_fixture):
     return ParquetManager(dae_config_fixture.studies_db.dir)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_variants(variants_db_fixture):
     return variants_db_fixture.get('quads_f1_vcf').backend

--- a/dae/dae/backends/storage/tests/conftest.py
+++ b/dae/dae/backends/storage/tests/conftest.py
@@ -12,37 +12,37 @@ def relative_to_this_test_folder(path):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=relative_to_this_test_folder('fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def genotype_storage_factory(gpf_instance):
     return gpf_instance.genotype_storage_factory
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def filesystem_genotype_storage(genotype_storage_factory):
     return genotype_storage_factory.get_genotype_storage('genotype_filesystem')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def impala_genotype_storage(genotype_storage_factory):
     return genotype_storage_factory.get_genotype_storage('genotype_impala')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_vcf_config(variants_db_fixture):
     return variants_db_fixture.get_study_config('quads_f1_vcf')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_config(variants_db_fixture, impala_genotype_storage):
     impala_genotype_storage.impala_load_study(
         'quads_f1_impala',

--- a/dae/dae/common_reports/tests/conftest.py
+++ b/dae/dae/common_reports/tests/conftest.py
@@ -25,91 +25,91 @@ def datasets_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures/datasets'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     gpf_instance = GPFInstance(work_dir=fixtures_dir())
 
     return gpf_instance
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def vdb_fixture(gpf_instance):
     return gpf_instance.variants_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def common_report_facade(gpf_instance):
     return gpf_instance.common_report_facade
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def study1(vdb_fixture):
     return vdb_fixture.get_study_wdae_wrapper("Study1")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def study2(vdb_fixture):
     return vdb_fixture.get_study_wdae_wrapper("Study2")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def study4(vdb_fixture):
     return vdb_fixture.get_study_wdae_wrapper("Study4")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dataset1(vdb_fixture):
     return vdb_fixture.get_dataset_wdae_wrapper("Dataset1")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def study1_config(vdb_fixture):
     return vdb_fixture.get_study_config("Study1")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dataset2_config(vdb_fixture):
     return vdb_fixture.get_dataset_config("Dataset2")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dataset3_config(vdb_fixture):
     return vdb_fixture.get_dataset_config("Dataset3")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dataset4_config(vdb_fixture):
     return vdb_fixture.get_dataset_config("Dataset4")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def groups():
     return {
         'Role and Diagnosis': ['role', 'phenotype']
     }
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def selected_people_groups(groups):
     return ['phenotype']
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def people_groups(study1_config):
     return study1_config.people_group_config.people_group
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def people_groups_info(study1, selected_people_groups, people_groups):
     return PeopleGroupsInfo(study1, selected_people_groups, people_groups)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def filter_role():
     return Filter('role', 'mom', column_value='Mother')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def filter_people_group():
     return Filter('phenotype', 'pheno', column_value='Pheno')
 
@@ -124,13 +124,13 @@ def filter_objects(study1, people_groups_info, groups):
     return FilterObjects.get_filter_objects(study1, people_groups_info, groups)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def families_groups(study1):
     return [study1.families['f4'], study1.families['f5'],
             study1.families['f7'], study1.families['f8']]
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def denovo_variants_ds1(dataset1):
     denovo_variants = dataset1.query_variants(
         limit=None,
@@ -143,7 +143,7 @@ def denovo_variants_ds1(dataset1):
     return denovo_variants
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def common_reports_config(
         study1, study1_config, people_groups, selected_people_groups, groups):
     common_report_config = \
@@ -164,12 +164,12 @@ def common_reports_config(
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def generate_common_reports(common_report_facade):
     common_report_facade.generate_all_common_reports()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def remove_common_reports(common_report_facade):
     all_configs = common_report_facade.get_all_common_report_configs()
     temp_files = [config.file_path for config in all_configs]

--- a/dae/dae/conftest.py
+++ b/dae/dae/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 import os
 import glob
@@ -47,6 +48,13 @@ def relative_to_this_test_folder(path):
 
 
 @pytest.fixture(scope='session')
+def monkeysession(request):
+    mp = MonkeyPatch()
+    request.addfinalizer(mp.undo)
+    return mp
+
+
+@pytest.fixture(scope='session')
 def global_gpf_instance():
     return GPFInstance()
 
@@ -76,34 +84,38 @@ def default_gene_models(global_gpf_instance):
     return global_gpf_instance.genomes_db.get_gene_models()
 
 
-@pytest.fixture(scope='function')
-def mock_genomes_db(mocker, default_gene_models, default_genome):
+@pytest.fixture(scope='session')
+def mock_genomes_db(monkeysession, default_gene_models, default_genome):
     # genome = mocker.Mock()
     # genome.getSequence = lambda _, start, end: 'A' * (end - start + 1)
 
-    mocker.patch(
-        'dae.GenomesDB.GenomesDB.__init__', return_value=None
+    def fake_init(self, dae_dir, conf_file=None):
+        self.dae_dir = None
+        self.config = None
+
+    monkeysession.setattr(
+        'dae.GenomesDB.GenomesDB.__init__', fake_init
     )
 
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome',
-        return_value=default_genome
+        lambda self: default_genome
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome_from_file',
-        return_value=default_genome
+        lambda self, _=None: default_genome
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_gene_models',
-        return_value=default_gene_models
+        lambda self, _=None: default_gene_models
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome_file',
-        return_value='./genomes/GATK_ResourceBundle_5777_b37_phiX174/chrAll.fa'
+        lambda self, _=None: './genomes/GATK_ResourceBundle_5777_b37_phiX174/chrAll.fa'
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_gene_model_id',
-        return_value='RefSeq2013'
+        lambda self: 'RefSeq2013'
     )
 
 

--- a/dae/dae/conftest.py
+++ b/dae/dae/conftest.py
@@ -19,22 +19,15 @@ from dae.backends.configure import Configure
 from dae.backends.dae.loader import RawDaeLoader
 from dae.backends.dae.raw_dae import RawDAE, RawDenovo
 
-from dae.backends.vcf.raw_vcf import RawVcfVariants
 from dae.backends.vcf.loader import RawVcfLoader
-
-from dae.backends.vcf.annotate_allele_frequencies import \
-    VcfAlleleFrequencyAnnotator
 
 from dae.backends.import_commons import \
     construct_import_annotation_pipeline
-from dae.tools.vcf2parquet import import_vcf
 from dae.pedigrees.pedigree_reader import PedigreeReader
 from dae.pedigrees.family import FamiliesData
 from dae.utils.helpers import pedigree_from_path
 from dae.backends.impala.parquet_io import ParquetManager
 from dae.backends.storage.impala_genotype_storage import ImpalaGenotypeStorage
-
-from dae.backends.import_commons import construct_import_annotation_pipeline
 
 from dae.tools.vcf2parquet import vcf2parquet
 
@@ -86,8 +79,6 @@ def default_gene_models(global_gpf_instance):
 
 @pytest.fixture(scope='session')
 def mock_genomes_db(monkeysession, default_gene_models, default_genome):
-    # genome = mocker.Mock()
-    # genome.getSequence = lambda _, start, end: 'A' * (end - start + 1)
 
     def fake_init(self, dae_dir, conf_file=None):
         self.dae_dir = None
@@ -111,7 +102,8 @@ def mock_genomes_db(monkeysession, default_gene_models, default_genome):
     )
     monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome_file',
-        lambda self, _=None: './genomes/GATK_ResourceBundle_5777_b37_phiX174/chrAll.fa'
+        lambda self, _=None:
+            './genomes/GATK_ResourceBundle_5777_b37_phiX174/chrAll.fa'
     )
     monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_gene_model_id',
@@ -389,7 +381,8 @@ def variants_vcf(genomes_db, default_annotation_pipeline):
         fvars = RawVcfLoader.load_raw_vcf_variants(
             ped_df, conf.vcf.vcf
         )
-        fvars.annot_df = default_annotation_pipeline.annotate_df(fvars.annot_df)
+        fvars.annot_df = \
+            default_annotation_pipeline.annotate_df(fvars.annot_df)
         RawVcfLoader.save_annotation_file(fvars.annot_df, conf.vcf.annotation)
 
         return fvars

--- a/dae/dae/enrichment_tool/tests/conftest.py
+++ b/dae/dae/enrichment_tool/tests/conftest.py
@@ -14,37 +14,37 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def f1_trio_enrichment_config(variants_db_fixture):
     return EnrichmentConfigParser.parse(
         variants_db_fixture.get_config('f1_trio'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def f1_trio(variants_db_fixture):
     return variants_db_fixture.get('f1_trio')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def f1_trio_coding_len_background(f1_trio_enrichment_config):
     return CodingLenBackground(f1_trio_enrichment_config)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def f1_trio_samocha_background(f1_trio_enrichment_config):
     return SamochaBackground(f1_trio_enrichment_config)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def background_facade(gpf_instance):
     return gpf_instance.background_facade

--- a/dae/dae/gene/tests/conftest.py
+++ b/dae/dae/gene/tests/conftest.py
@@ -29,42 +29,42 @@ def mock_property(mocker):
     return result
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dae_config_fixture(gpf_instance):
     return gpf_instance.dae_config
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gene_info_config(gpf_instance):
     return gpf_instance.gene_info_config
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def weights_factory(gpf_instance):
     return gpf_instance.weights_factory
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def score_config(gpf_instance):
     return gpf_instance.score_config
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def scores_factory(gpf_instance):
     return gpf_instance.scores_factory
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def denovo_gene_set_facade(gpf_instance):
     return gpf_instance.denovo_gene_set_facade
 
@@ -89,7 +89,7 @@ def gene_info_cache_dir():
     shutil.rmtree(cache_dir)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def calc_gene_sets(request, denovo_gene_sets, denovo_gene_set_f4):
     for dgs in denovo_gene_sets + [denovo_gene_set_f4]:
         dgs.load(build_cache=True)
@@ -112,7 +112,7 @@ def get_denovo_gene_set_by_id(variants_db_fixture, dgs_id):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def denovo_gene_sets(variants_db_fixture):
     return [
         get_denovo_gene_set_by_id(variants_db_fixture, 'f1_group'),
@@ -121,12 +121,12 @@ def denovo_gene_sets(variants_db_fixture):
     ]
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def denovo_gene_set_f4(variants_db_fixture):
     return get_denovo_gene_set_by_id(variants_db_fixture, 'f4_trio')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def f4_trio_denovo_gene_set_config(variants_db_fixture):
     return DenovoGeneSetConfigParser.parse(
         variants_db_fixture.get_config('f4_trio')

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -21,112 +21,107 @@ from dae.backends.storage.genotype_storage_factory import \
     GenotypeStorageFactory
 
 
+def cached(prop):
+    cached_val_name = '_' + prop.__name__
+
+    def wrap(self):
+        if getattr(self, cached_val_name, None) is None:
+            setattr(self, cached_val_name, prop(self))
+        return getattr(self, cached_val_name)
+
+    return wrap
+
+
 class GPFInstance(object):
 
-    def __init__(self, config_file='DAE.conf', work_dir=None, defaults=None):
+    def __init__(self, config_file='DAE.conf', work_dir=None, defaults=None,
+                 load_eagerly=False):
         self.dae_config = DAEConfigParser.read_and_parse_file_configuration(
             config_file=config_file, work_dir=work_dir, defaults=defaults
         )
-        self.genomes_db_ = None
-        self.pheno_factory_ = None
-        self.gene_info_config_ = None
-        self.weights_factory_ = None
-        self.score_config_ = None
-        self.scores_factory_ = None
-        self.genotype_storage_factory_ = None
-        self.variants_db_ = None
-        self.common_report_facade_ = None
-        self.gene_sets_collections_ = None
-        self.denovo_gene_set_facade_ = None
-        self.background_facade_ = None
+
+        if load_eagerly:
+            self.genomes_db
+            self.pheno_factory
+            self.gene_info_config
+            self.weights_factory
+            self.score_config
+            self.scores_factory
+            self.genotype_storage_factory
+            self.variants_db
+            self.common_report_facade
+            self.gene_sets_collections
+            self.denovo_gene_set_facade
+            self.background_facade
 
     @property
+    @cached
     def genomes_db(self):
-        if self.genomes_db_ is None:
-            self.genomes_db_ = GenomesDB(
-                self.dae_config.dae_data_dir,
-                self.dae_config.genomes_db.conf_file
-            )
-        return self.genomes_db_
+        return GenomesDB(
+            self.dae_config.dae_data_dir,
+            self.dae_config.genomes_db.conf_file
+        )
 
     @property
+    @cached
     def pheno_factory(self):
-        if self.pheno_factory_ is None:
-            self.pheno_factory_ = PhenoFactory(dae_config=self.dae_config)
-        return self.pheno_factory_
+        return PhenoFactory(dae_config=self.dae_config)
 
     @property
+    @cached
     def gene_info_config(self):
-        if self.gene_info_config_ is None:
-            self.gene_info_config_ = \
-                GeneInfoConfigParser.read_and_parse_file_configuration(
-                    self.dae_config.gene_info_db.conf_file,
-                    self.dae_config.dae_data_dir
-                )
-        return self.gene_info_config_
+        return GeneInfoConfigParser.read_and_parse_file_configuration(
+            self.dae_config.gene_info_db.conf_file,
+            self.dae_config.dae_data_dir
+        )
 
     @property
+    @cached
     def weights_factory(self):
-        if self.weights_factory_ is None:
-            self.weights_factory_ = \
-                WeightsFactory(config=self.gene_info_config.gene_weights)
-        return self.weights_factory_
+        return WeightsFactory(config=self.gene_info_config.gene_weights)
 
     @property
+    @cached
     def score_config(self):
-        if self.score_config_ is None:
-            self.score_config_ = \
-                ScoreConfigParser.read_and_parse_file_configuration(
-                    self.dae_config.genomic_scores_db.conf_file,
-                    self.dae_config.dae_data_dir
-                )
-        return self.score_config_
+        return ScoreConfigParser.read_and_parse_file_configuration(
+            self.dae_config.genomic_scores_db.conf_file,
+            self.dae_config.dae_data_dir
+        )
 
     @property
+    @cached
     def scores_factory(self):
-        if self.scores_factory_ is None:
-            self.scores_factory_ = ScoresFactory(self.score_config)
-        return self.scores_factory_
+        return ScoresFactory(self.score_config)
 
     @property
+    @cached
     def genotype_storage_factory(self):
-        if self.genotype_storage_factory_ is None:
-            self.genotype_storage_factory_ = GenotypeStorageFactory(
-                self.dae_config)
-        return self.genotype_storage_factory_
+        return GenotypeStorageFactory(self.dae_config)
 
     @property
+    @cached
     def variants_db(self):
-        if self.variants_db_ is None:
-            self.variants_db_ = VariantsDb(
-                self.dae_config, self.pheno_factory, self.weights_factory,
-                self.genomes_db, self.genotype_storage_factory
-            )
-        return self.variants_db_
+        return VariantsDb(
+            self.dae_config, self.pheno_factory, self.weights_factory,
+            self.genomes_db, self.genotype_storage_factory
+        )
 
     @property
+    @cached
     def common_report_facade(self):
-        if self.common_report_facade_ is None:
-            self.common_report_facade_ = CommonReportFacade(self.variants_db)
-        return self.common_report_facade_
+        return CommonReportFacade(self.variants_db)
 
     @property
+    @cached
     def gene_sets_collections(self):
-        if self.gene_sets_collections_ is None:
-            self.gene_sets_collections_ = \
-                GeneSetsCollections(self.variants_db, self.gene_info_config)
-        return self.gene_sets_collections_
+        return GeneSetsCollections(self.variants_db, self.gene_info_config)
 
     @property
+    @cached
     def denovo_gene_set_facade(self):
-        if self.denovo_gene_set_facade_ is None:
-            self.denovo_gene_set_facade_ = DenovoGeneSetFacade(
-                self.variants_db
-            )
-        return self.denovo_gene_set_facade_
+        return DenovoGeneSetFacade(self.variants_db)
 
     @property
+    @cached
     def background_facade(self):
-        if self.background_facade_ is None:
-            self.background_facade_ = BackgroundFacade(self.variants_db)
-        return self.background_facade_
+        return BackgroundFacade(self.variants_db)

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -27,40 +27,106 @@ class GPFInstance(object):
         self.dae_config = DAEConfigParser.read_and_parse_file_configuration(
             config_file=config_file, work_dir=work_dir, defaults=defaults
         )
+        self.genomes_db_ = None
+        self.pheno_factory_ = None
+        self.gene_info_config_ = None
+        self.weights_factory_ = None
+        self.score_config_ = None
+        self.scores_factory_ = None
+        self.genotype_storage_factory_ = None
+        self.variants_db_ = None
+        self.common_report_facade_ = None
+        self.gene_sets_collections_ = None
+        self.denovo_gene_set_facade_ = None
+        self.background_facade_ = None
 
-        self.genomes_db = GenomesDB(
-            self.dae_config.dae_data_dir,
-            self.dae_config.genomes_db.conf_file
-        )
-
-        self.pheno_factory = PhenoFactory(dae_config=self.dae_config)
-
-        self.gene_info_config = \
-            GeneInfoConfigParser.read_and_parse_file_configuration(
-                self.dae_config.gene_info_db.conf_file,
-                self.dae_config.dae_data_dir
+    @property
+    def genomes_db(self):
+        if self.genomes_db_ is None:
+            self.genomes_db_ = GenomesDB(
+                self.dae_config.dae_data_dir,
+                self.dae_config.genomes_db.conf_file
             )
-        self.weights_factory = \
-            WeightsFactory(config=self.gene_info_config.gene_weights)
+        return self.genomes_db_
 
-        self.score_config = \
-            ScoreConfigParser.read_and_parse_file_configuration(
-                self.dae_config.genomic_scores_db.conf_file,
-                self.dae_config.dae_data_dir
+    @property
+    def pheno_factory(self):
+        if self.pheno_factory_ is None:
+            self.pheno_factory_ = PhenoFactory(dae_config=self.dae_config)
+        return self.pheno_factory_
+
+    @property
+    def gene_info_config(self):
+        if self.gene_info_config_ is None:
+            self.gene_info_config_ = \
+                GeneInfoConfigParser.read_and_parse_file_configuration(
+                    self.dae_config.gene_info_db.conf_file,
+                    self.dae_config.dae_data_dir
+                )
+        return self.gene_info_config_
+
+    @property
+    def weights_factory(self):
+        if self.weights_factory_ is None:
+            self.weights_factory_ = \
+                WeightsFactory(config=self.gene_info_config.gene_weights)
+        return self.weights_factory_
+
+    @property
+    def score_config(self):
+        if self.score_config_ is None:
+            self.score_config_ = \
+                ScoreConfigParser.read_and_parse_file_configuration(
+                    self.dae_config.genomic_scores_db.conf_file,
+                    self.dae_config.dae_data_dir
+                )
+        return self.score_config_
+
+    @property
+    def scores_factory(self):
+        if self.scores_factory_ is None:
+            self.scores_factory_ = ScoresFactory(self.score_config)
+        return self.scores_factory_
+
+    @property
+    def genotype_storage_factory(self):
+        if self.genotype_storage_factory_ is None:
+            self.genotype_storage_factory_ = GenotypeStorageFactory(
+                self.dae_config)
+        return self.genotype_storage_factory_
+
+    @property
+    def variants_db(self):
+        if self.variants_db_ is None:
+            self.variants_db_ = VariantsDb(
+                self.dae_config, self.pheno_factory, self.weights_factory,
+                self.genomes_db, self.genotype_storage_factory
             )
-        self.scores_factory = ScoresFactory(self.score_config)
+        return self.variants_db_
 
-        self.genotype_storage_factory = GenotypeStorageFactory(self.dae_config)
+    @property
+    def common_report_facade(self):
+        if self.common_report_facade_ is None:
+            self.common_report_facade_ = CommonReportFacade(self.variants_db)
+        return self.common_report_facade_
 
-        self.variants_db = VariantsDb(
-            self.dae_config, self.pheno_factory, self.weights_factory,
-            self.genomes_db, self.genotype_storage_factory
-        )
+    @property
+    def gene_sets_collections(self):
+        if self.gene_sets_collections_ is None:
+            self.gene_sets_collections_ = \
+                GeneSetsCollections(self.variants_db, self.gene_info_config)
+        return self.gene_sets_collections_
 
-        self.common_report_facade = CommonReportFacade(self.variants_db)
+    @property
+    def denovo_gene_set_facade(self):
+        if self.denovo_gene_set_facade_ is None:
+            self.denovo_gene_set_facade_ = DenovoGeneSetFacade(
+                self.variants_db
+            )
+        return self.denovo_gene_set_facade_
 
-        self.gene_sets_collections = \
-            GeneSetsCollections(self.variants_db, self.gene_info_config)
-        self.denovo_gene_set_facade = DenovoGeneSetFacade(self.variants_db)
-
-        self.background_facade = BackgroundFacade(self.variants_db)
+    @property
+    def background_facade(self):
+        if self.background_facade_ is None:
+            self.background_facade_ = BackgroundFacade(self.variants_db)
+        return self.background_facade_

--- a/dae/dae/pheno_tool/tests/test_pheno_tool.py
+++ b/dae/dae/pheno_tool/tests/test_pheno_tool.py
@@ -165,7 +165,6 @@ def test_join_pheno_df_with_empty_pheno_df():
         PhenoTool.join_pheno_df_with_variants(pheno_df, variants)
 
 
-@pytest.mark.skip
 def test_normalize_df():
     pheno_df = pd.DataFrame([{'person_id': 112233, 'i1.m1': 1e6,
                               'i1.m2': 1e3},

--- a/dae/dae/pheno_tool/tests/test_pheno_tool.py
+++ b/dae/dae/pheno_tool/tests/test_pheno_tool.py
@@ -165,6 +165,7 @@ def test_join_pheno_df_with_empty_pheno_df():
         PhenoTool.join_pheno_df_with_variants(pheno_df, variants)
 
 
+@pytest.mark.skip
 def test_normalize_df():
     pheno_df = pd.DataFrame([{'person_id': 112233, 'i1.m1': 1e6,
                               'i1.m2': 1e3},

--- a/dae/dae/studies/tests/conftest.py
+++ b/dae/dae/studies/tests/conftest.py
@@ -22,52 +22,52 @@ def datasets_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures/datasets'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def mocked_gene_models(gpf_instance):
     return gpf_instance.genomes_db.get_gene_models()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dae_config_fixture(gpf_instance):
     return gpf_instance.dae_config
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def pheno_factory(gpf_instance):
     return gpf_instance.pheno_factory
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def weights_factory(gpf_instance):
     return gpf_instance.weights_factory
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def genotype_storage_factory(gpf_instance):
     return gpf_instance.genotype_storage_factory
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def study_configs(variants_db_fixture):
     return variants_db_fixture.study_configs
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_config(variants_db_fixture):
     return variants_db_fixture.get_study_config('quads_f1')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f2_config(variants_db_fixture):
     return variants_db_fixture.get_study_config('quads_f2')
 
@@ -80,90 +80,90 @@ def load_study(variants_db_fixture, study_configs, study_name):
     return result
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def inheritance_trio(variants_db_fixture, study_configs):
     return load_study(variants_db_fixture, study_configs, 'inheritance_trio')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1(variants_db_fixture, study_configs):
     return load_study(variants_db_fixture, study_configs, 'quads_f1')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f2(variants_db_fixture, study_configs):
     return load_study(variants_db_fixture, study_configs, 'quads_f2')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_variant_types(variants_db_fixture, study_configs):
     return load_study(
         variants_db_fixture, study_configs, 'quads_variant_types')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_two_families(variants_db_fixture, study_configs):
     return load_study(variants_db_fixture, study_configs, 'quads_two_families')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_child(variants_db_fixture, study_configs):
     return load_study(variants_db_fixture, study_configs, 'quads_in_child')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_parent(variants_db_fixture, study_configs):
     return load_study(variants_db_fixture, study_configs, 'quads_in_parent')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def inheritance_trio_wrapper(inheritance_trio, pheno_factory, weights_factory):
     return StudyWrapper(inheritance_trio, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_wrapper(quads_f1, pheno_factory, weights_factory):
     return StudyWrapper(quads_f1, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f2_wrapper(quads_f2, pheno_factory, weights_factory):
     return StudyWrapper(quads_f2, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_variant_types_wrapper(
         quads_variant_types, pheno_factory, weights_factory):
     return StudyWrapper(quads_variant_types, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_two_families_wrapper(
         quads_two_families, pheno_factory, weights_factory):
     return StudyWrapper(quads_two_families, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_child_wrapper(quads_in_child, pheno_factory, weights_factory):
     return StudyWrapper(quads_in_child, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_parent_wrapper(quads_in_parent, pheno_factory, weights_factory):
     return StudyWrapper(quads_in_parent, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dataset_configs(variants_db_fixture):
     return variants_db_fixture.dataset_configs
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_composite_dataset_config(variants_db_fixture):
     return variants_db_fixture.get_dataset_config('quads_composite_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def composite_dataset_config(variants_db_fixture):
     return variants_db_fixture.get_dataset_config('composite_dataset_ds')
 
@@ -177,13 +177,13 @@ def load_dataset(variants_db_fixture, dataset_configs, dataset_name):
     return result
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def inheritance_trio_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(
         variants_db_fixture, dataset_configs, 'inheritance_trio_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def inheritance_trio_dataset_wrapper(
         inheritance_trio_dataset, pheno_factory, weights_factory):
     return StudyWrapper(
@@ -191,13 +191,13 @@ def inheritance_trio_dataset_wrapper(
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_two_families_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(
         variants_db_fixture, dataset_configs, 'quads_two_families_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_two_families_dataset_wrapper(
         quads_two_families_dataset, pheno_factory, weights_factory):
     return StudyWrapper(
@@ -205,33 +205,33 @@ def quads_two_families_dataset_wrapper(
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(variants_db_fixture, dataset_configs, 'quads_f1_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f1_dataset_wrapper(quads_f1_dataset, pheno_factory, weights_factory):
     return StudyWrapper(quads_f1_dataset, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f2_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(variants_db_fixture, dataset_configs, 'quads_f2_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_f2_dataset_wrapper(quads_f2_dataset, pheno_factory, weights_factory):
     return StudyWrapper(quads_f2_dataset, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_variant_types_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(
         variants_db_fixture, dataset_configs, 'quads_variant_types_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_variant_types_dataset_wrapper(
         quads_variant_types_dataset, pheno_factory, weights_factory):
     return StudyWrapper(
@@ -239,25 +239,25 @@ def quads_variant_types_dataset_wrapper(
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_child_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(
         variants_db_fixture, dataset_configs, 'quads_in_child_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_child_dataset_wrapper(
         quads_in_child_dataset, pheno_factory, weights_factory):
     return StudyWrapper(quads_in_child_dataset, pheno_factory, weights_factory)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_parent_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(
         variants_db_fixture, dataset_configs, 'quads_in_parent_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def quads_in_parent_dataset_wrapper(
         quads_in_parent_dataset, pheno_factory, weights_factory):
     return StudyWrapper(
@@ -265,13 +265,13 @@ def quads_in_parent_dataset_wrapper(
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def composite_dataset(variants_db_fixture, dataset_configs):
     return load_dataset(
         variants_db_fixture, dataset_configs, 'composite_dataset_ds')
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def composite_dataset_wrapper(
         composite_dataset, pheno_factory, weights_factory):
     return StudyWrapper(composite_dataset, pheno_factory, weights_factory)

--- a/dae/dae/tools/tests/conftest.py
+++ b/dae/dae/tools/tests/conftest.py
@@ -17,7 +17,7 @@ def relative_to_this_test_folder(path):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=relative_to_this_test_folder('fixtures'))
 

--- a/wdae/wdae/common_reports_api/tests/conftest.py
+++ b/wdae/wdae/common_reports_api/tests/conftest.py
@@ -11,17 +11,17 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def common_report_facade(gpf_instance):
     return gpf_instance.common_report_facade
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def use_common_reports(common_report_facade):
     all_configs = common_report_facade.get_all_common_report_configs()
     temp_files = [config.file_path for config in all_configs]

--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -6,6 +7,13 @@ from django.contrib.auth.models import Group
 from users_api.models import WdaeUser
 
 from dae.gpf_instance.gpf_instance import GPFInstance
+
+
+@pytest.fixture(scope='session')
+def monkeysession(request):
+    mp = MonkeyPatch()
+    request.addfinalizer(mp.undo)
+    return mp
 
 
 @pytest.fixture()
@@ -77,32 +85,38 @@ def default_gene_models(global_gpf_instance):
     return global_gpf_instance.genomes_db.get_gene_models()
 
 
-@pytest.fixture(scope='function')
-def mock_genomes_db(mocker, default_gene_models):
-    genome = mocker.Mock()
-    genome.getSequence = lambda _, start, end: 'A' * (end - start + 1)
+@pytest.fixture(scope='session')
+def mock_genomes_db(monkeysession, default_gene_models):
+    class FakeGenome:
+        def getSequence(_, start, end):
+            return 'A' * (end - start + 1)
 
-    mocker.patch(
-        'dae.GenomesDB.GenomesDB.__init__', return_value=None
+    def fake_init(self, dae_dir, conf_file=None):
+        self.dae_dir = None
+        self.config = None
+
+    monkeysession.setattr(
+        'dae.GenomesDB.GenomesDB.__init__', fake_init
     )
 
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome',
-        return_value=genome
+        lambda self: FakeGenome()
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome_from_file',
-        return_value=genome
+        lambda self, _=None: FakeGenome()
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_gene_models',
-        return_value=default_gene_models
+        lambda self, _=None: default_gene_models
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome_file',
-        return_value='./genomes/GATK_ResourceBundle_5777_b37_phiX174/chrAll.fa'
+        lambda self, _=None:
+            './genomes/GATK_ResourceBundle_5777_b37_phiX174/chrAll.fa'
     )
-    mocker.patch(
+    monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_gene_model_id',
-        return_value='RefSeq2013'
+        lambda self: 'RefSeq2013'
     )

--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -86,10 +86,12 @@ def default_gene_models(global_gpf_instance):
 
 
 @pytest.fixture(scope='session')
-def mock_genomes_db(monkeysession, default_gene_models):
-    class FakeGenome:
-        def getSequence(_, start, end):
-            return 'A' * (end - start + 1)
+def default_genome(global_gpf_instance):
+    return global_gpf_instance.genomes_db.get_genome()
+
+
+@pytest.fixture(scope='session')
+def mock_genomes_db(monkeysession, default_gene_models, default_genome):
 
     def fake_init(self, dae_dir, conf_file=None):
         self.dae_dir = None
@@ -101,11 +103,11 @@ def mock_genomes_db(monkeysession, default_gene_models):
 
     monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome',
-        lambda self: FakeGenome()
+        lambda self: default_genome
     )
     monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_genome_from_file',
-        lambda self, _=None: FakeGenome()
+        lambda self, _=None: default_genome
     )
     monkeysession.setattr(
         'dae.GenomesDB.GenomesDB.get_gene_models',

--- a/wdae/wdae/datasets_api/tests/conftest.py
+++ b/wdae/wdae/datasets_api/tests/conftest.py
@@ -10,7 +10,7 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 

--- a/wdae/wdae/enrichment_api/tests/conftest.py
+++ b/wdae/wdae/enrichment_api/tests/conftest.py
@@ -16,12 +16,12 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
@@ -43,18 +43,18 @@ def mock_gpf_instance(db, mocker, gpf_instance):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def background_facade(gpf_instance):
     return gpf_instance.background_facade
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def f1_trio(variants_db_fixture):
     f1_trio = variants_db_fixture.get('f1_trio')
     return f1_trio
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def enrichment_builder(f1_trio, background_facade):
     enrichment_config = \
         background_facade.get_study_enrichment_config('f1_trio')
@@ -68,7 +68,7 @@ def enrichment_builder(f1_trio, background_facade):
     return builder
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def enrichment_serializer(background_facade, enrichment_builder):
     enrichment_config = \
         background_facade.get_study_enrichment_config('f1_trio')

--- a/wdae/wdae/gene_sets/tests/conftest.py
+++ b/wdae/wdae/gene_sets/tests/conftest.py
@@ -13,12 +13,12 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def variants_db_fixture(gpf_instance):
     return gpf_instance.variants_db
 
@@ -36,7 +36,7 @@ def mock_gpf_instance(db, mocker, gpf_instance):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def calc_gene_sets(request, denovo_gene_sets):
     for dgs in denovo_gene_sets:
         dgs.load(build_cache=True)
@@ -60,7 +60,7 @@ def get_denovo_gene_set_by_id(variants_db_fixture, dgs_id):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def denovo_gene_sets(variants_db_fixture):
     return [
         get_denovo_gene_set_by_id(variants_db_fixture, 'f1_group'),

--- a/wdae/wdae/gene_weights/tests/conftest.py
+++ b/wdae/wdae/gene_weights/tests/conftest.py
@@ -10,12 +10,12 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def dae_config_fixture(gpf_instance):
     return gpf_instance.dae_config
 
@@ -33,6 +33,6 @@ def mock_gpf_instance(db, mocker, gpf_instance):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def weights_factory(gpf_instance):
     return gpf_instance.weights_factory

--- a/wdae/wdae/genomic_scores_api/tests/conftest.py
+++ b/wdae/wdae/genomic_scores_api/tests/conftest.py
@@ -11,7 +11,7 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 

--- a/wdae/wdae/genotype_browser/tests/conftest.py
+++ b/wdae/wdae/genotype_browser/tests/conftest.py
@@ -10,7 +10,7 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -20,7 +20,7 @@ def get_gpf_instance():
         _gpf_instance_lock.acquire()
         try:
             if _gpf_instance is None:
-                gpf_instance = GPFInstance()
+                gpf_instance = GPFInstance(load_eagerly=True)
                 reload_datasets(gpf_instance.variants_db)
                 _gpf_instance = gpf_instance
         finally:

--- a/wdae/wdae/pheno_browser_api/tests/conftest.py
+++ b/wdae/wdae/pheno_browser_api/tests/conftest.py
@@ -10,7 +10,7 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 

--- a/wdae/wdae/pheno_tool_api/tests/conftest.py
+++ b/wdae/wdae/pheno_tool_api/tests/conftest.py
@@ -10,7 +10,7 @@ def fixtures_dir():
         os.path.join(os.path.dirname(__file__), 'fixtures'))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def gpf_instance(mock_genomes_db):
     return GPFInstance(work_dir=fixtures_dir())
 


### PR DESCRIPTION
Changed the scope of the mock genomes DB fixture to 'session', as well
as the scope of other fixtures

Changed GPFInstance to load its attributes lazily