### PR TITLE
Modify variant streaming iterator_to_json method

### DIFF
--- a/wdae/wdae/utils/streaming_response_util.py
+++ b/wdae/wdae/utils/streaming_response_util.py
@@ -14,5 +14,17 @@ def convert(obj):
 
 
 def iterator_to_json(variants):
-    for v in variants:
-        yield json.dumps(v, default=convert)
+    yield '['
+    curr = next(variants, None)
+    post = next(variants, None)
+    while curr is not None:
+        yieldval = json.dumps(curr, default=convert)
+        if post is None:
+            yield yieldval
+            break
+        else:
+            yield yieldval + ','
+        curr = post
+        post = next(variants, None)
+    yield ']'
+    return 0


### PR DESCRIPTION
Sending variants as one large array instead of discrete objects
This is done to utilise oboe.js' ability to know when a request has
finalized