### PR TITLE
Support for generating snakemake files that can run on a kubernetes cluster.

### DIFF
--- a/dae/dae/backends/impala/import_commons.py
+++ b/dae/dae/backends/impala/import_commons.py
@@ -728,18 +728,9 @@ class BatchImporter:
             .build_genotype_storage(argv)
         return self
 
-    def _create_output_directory(self, argv):
-        dirname = argv.output
-        if dirname is None:
-            dirname = "."
-        dirname = os.path.abspath(dirname)
-
-        os.makedirs(dirname, exist_ok=True)
-        os.makedirs(os.path.join(dirname, "logs"), exist_ok=True)
-        return dirname
 
     def generate_instructions(self, argv):
-        dirname = self._create_output_directory(argv)
+        dirname = argv.output
         context = self.build_context(argv)
         if argv.tool == "make":
             generator = MakefileGenerator()
@@ -756,7 +747,7 @@ class BatchImporter:
             outfile.write(content)
 
     def build_context(self, argv):
-        outdir = self._create_output_directory(argv)
+        outdir = argv.output
         study_id = self.study_id
 
         context = {

--- a/dae/dae/backends/impala/import_commons.py
+++ b/dae/dae/backends/impala/import_commons.py
@@ -5,6 +5,7 @@ import argparse
 import time
 import logging
 import shutil
+import fsspec
 
 import toml
 from box import Box
@@ -821,7 +822,6 @@ class BatchImporter:
 
     def generate_study_config(self, argv):
         dirname = argv.output
-        assert os.path.exists(dirname)
 
         config_dict = {
             "id": self.study_id,
@@ -852,7 +852,7 @@ class BatchImporter:
 
         config_builder = StudyConfigBuilder(config_dict)
         config = config_builder.build_config()
-        with open(os.path.join(
+        with fsspec.open(os.path.join(
                 dirname, f"{self.study_id}.conf"), "w") as outfile:
             outfile.write(config)
 

--- a/dae/dae/backends/impala/parquet_io.py
+++ b/dae/dae/backends/impala/parquet_io.py
@@ -6,6 +6,7 @@ import hashlib
 import itertools
 import logging
 from copy import copy
+from urllib.parse import urlparse
 
 import toml
 from box import Box
@@ -14,6 +15,7 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 import configparser
+import fsspec
 
 from dae.utils.variant_utils import GENOTYPE_TYPE
 from dae.variants.attributes import TransmissionType
@@ -332,9 +334,8 @@ class ParquetPartitionDescriptor(PartitionDescriptor):
             config["frequency_bin"]["rare_boundary"] = str(self._rare_boundary)
 
         filename = os.path.join(self.output, "_PARTITION_DESCRIPTION")
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-        with open(filename, "w") as configfile:
+        with fsspec.open(filename, "w") as configfile:
             config.write(configfile)
 
     def generate_file_access_glob(self):
@@ -376,10 +377,14 @@ class ContinuousParquetFileWriter:
             annotation_schema, extra_attributes)
         self.schema = self.serializer.schema
 
-        dirname = os.path.dirname(filepath)
-        if dirname and not os.path.exists(dirname):
-            os.makedirs(dirname)
-        self.dirname = dirname
+        if filesystem is not None:
+            filesystem.create_dir(filepath)
+            self.dirname = filepath
+        else:
+            dirname = os.path.dirname(filepath)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            self.dirname = dirname
 
         self._writer = pq.ParquetWriter(
             filepath, self.schema, compression="snappy", filesystem=filesystem
@@ -438,8 +443,7 @@ class VariantsParquetWriter:
             partition_descriptor,
             bucket_index=1,
             rows=100_000,
-            include_reference=True,
-            filesystem=None):
+            include_reference=True):
 
         self.variants_loader = variants_loader
         self.families = variants_loader.families
@@ -447,7 +451,6 @@ class VariantsParquetWriter:
 
         self.bucket_index = bucket_index
         self.rows = rows
-        self.filesystem = filesystem
 
         self.include_reference = include_reference
 
@@ -515,10 +518,15 @@ class VariantsParquetWriter:
         filename = self.partition_descriptor.variant_filename(family_allele)
 
         if filename not in self.data_writers:
+            if urlparse(filename).scheme:
+                filesystem, path = pa.fs.FileSystem.from_uri(filename)
+            else:
+                filesystem, path = None, filename
+
             self.data_writers[filename] = ContinuousParquetFileWriter(
-                filename,
+                path,
                 self.variants_loader,
-                filesystem=self.filesystem,
+                filesystem=filesystem,
                 rows=self.rows,
             )
         return self.data_writers[filename]
@@ -638,18 +646,14 @@ class VariantsParquetWriter:
         for k, v in schema.items():
             config["blob"][k] = v
 
-        if os.path.isdir(self.partition_descriptor.output):
-            path = self.partition_descriptor.output
-        else:
-            path = os.path.dirname(self.partition_descriptor.output)
-        filename = os.path.join(path, "_VARIANTS_SCHEMA")
+        filename = os.path.join(self.partition_descriptor.output, "_VARIANTS_SCHEMA")
 
         config["extra_attributes"] = {}
         extra_attributes = self.serializer.extra_attributes
         for attr in extra_attributes:
             config["extra_attributes"][attr] = "string"
 
-        with open(filename, "w") as configfile:
+        with fsspec.open(filename, "w") as configfile:
             content = toml.dumps(config)
             configfile.write(content)
 

--- a/dae/dae/backends/impala/parquet_io.py
+++ b/dae/dae/backends/impala/parquet_io.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 from copy import copy
 from urllib.parse import urlparse
+from fsspec.core import url_to_fs
 
 import toml
 from box import Box
@@ -152,10 +153,12 @@ class ParquetPartitionDescriptor(PartitionDescriptor):
 
     @staticmethod
     def from_config(config_path, root_dirname=""):
-        assert os.path.exists(config_path), config_path
+        fs, _ = url_to_fs(config_path)
+        assert fs.exists(config_path), config_path
 
         config = configparser.ConfigParser()
-        config.read(config_path)
+        with fs.open(config_path, "rt") as f:
+            config.read_file(f, config_path)
         assert config["region_bin"] is not None
 
         chromosomes = list(

--- a/dae/dae/backends/raw/loader.py
+++ b/dae/dae/backends/raw/loader.py
@@ -24,6 +24,7 @@ from dae.variants.attributes import Sex, GeneticModel
 from dae.variants.attributes import TransmissionType
 
 from dae.utils.variant_utils import get_locus_ploidy, best2gt
+from dae.utils import fs_utils
 
 
 logger = logging.getLogger(__name__)
@@ -212,7 +213,7 @@ class VariantsLoader(CLILoader):
         super().__init__(params=params)
         assert isinstance(families, FamiliesData)
         self.families = families
-        assert all([os.path.exists(fn) for fn in filenames]), filenames
+        assert all([fs_utils.exists(fn) for fn in filenames]), filenames
         self.filenames = filenames
 
         assert isinstance(transmission_type, TransmissionType)

--- a/dae/dae/backends/vcf/loader.py
+++ b/dae/dae/backends/vcf/loader.py
@@ -1,7 +1,7 @@
 import os
 import itertools
-import glob
 import logging
+from fsspec.core import url_to_fs
 
 from collections import Counter
 
@@ -11,6 +11,7 @@ import pysam
 
 from dae.utils.helpers import str2bool
 from dae.genome.genomes_db import Genome
+from dae.utils import fs_utils
 
 from dae.utils.variant_utils import is_all_reference_genotype, \
     is_all_unknown_genotype, \
@@ -284,7 +285,7 @@ class SingleVcfLoader(VariantsGenotypesLoader):
         seqnames = list(self.vcfs[0].header.contigs)
         filename = self.filenames[0]
         tabix_index_filename = f"{filename}.tbi"
-        if not os.path.exists(tabix_index_filename):
+        if not fs_utils.exists(tabix_index_filename):
             return seqnames
 
         try:
@@ -774,7 +775,22 @@ class VcfLoader(VariantsGenotypesLoader):
         ))
         return arguments
 
-    def _collect_filenames(self, params, vcf_files):
+    @staticmethod
+    def _glob(globname):
+        from urllib.parse import urlparse
+
+        fs, _ = url_to_fs(globname)
+        filenames = fs.glob(globname)
+        # fs.glob strips the protocol at the beginning. We need to add it back
+        # otherwise there is no way to know the correct fs down the pipeline
+        scheme = urlparse(globname).scheme
+        if scheme:
+            filenames = [f"{scheme}://{fn}" for fn in filenames]
+
+        return filenames
+
+    @staticmethod
+    def _collect_filenames(params, vcf_files):
         if params.get("vcf_chromosomes", None):
             vcf_chromosomes = [
                 wc.strip() for wc in params.get("vcf_chromosomes").split(";")
@@ -804,8 +820,7 @@ class VcfLoader(VariantsGenotypesLoader):
         for batches_globnames in glob_filenames:
             batches_result = []
             for globname in batches_globnames:
-
-                filenames = glob.glob(globname)
+                filenames = VcfLoader._glob(globname)
                 if len(filenames) == 0:
                     continue
                 assert len(filenames) == 1, (globname, filenames)

--- a/dae/dae/configuration/gpf_config_parser.py
+++ b/dae/dae/configuration/gpf_config_parser.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import logging
+import fsspec
 
 import yaml
 import toml
@@ -70,7 +71,7 @@ class GPFConfigParser:
 
     @classmethod
     def _get_file_contents(cls, filename: str) -> str:
-        with open(filename, "r") as infile:
+        with fsspec.open(filename, "r") as infile:
             return infile.read()
 
     @classmethod

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -1,0 +1,6 @@
+from fsspec.core import url_to_fs
+
+
+def exists(filename):
+    fs, relative_path = url_to_fs(filename)
+    return fs.exists(relative_path)

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -24,3 +24,4 @@ dependencies:
   - pytest-django=4.4.0
   - pylint=2.9.1
   - pre-commit=2.13.0
+  - moto=2.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,8 @@ dependencies:
   - matplotlib=3.4.2
   - pandas=1.3.4
   - pyarrow=6.0.1
-  - fsspec=2021.11.0
+  - fsspec=2021.11.1
+  - s3fs=2021.11.1
   - pyliftover=0.4
   - python=3.9
   - python-box=5.3.0


### PR DESCRIPTION
Most of the changes relate to supporting reading/writing files from/to s3 in our tools (like `vcf2parquet`, `ped2ped` and so on). Only the tools required to run parquet generation for SFARI_SPARK_WES_1 on a kubernetes cluster have been updated. The rest of the tools will be updated in future PRs.

The actual generation of the kubernetes compliant snakemake files is done by a new tool `snakemake-kubernetes` in `impala_batch_import.py`. The new tool was created because modifying the existing `snakemake` tool was simply too difficult and hacky.