### PR TITLE
Add histogram computation capabilities to the grr cli

### DIFF
--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -41,16 +41,16 @@ def cli_browse(args=None):
                   sum([fs for _, fs, _ in gr.get_files()]), gr.get_id()))
 
 
-def cli_manage(args=None):
-    if not args:
-        args = sys.argv[1:]
+def cli_manage():
+    desc = "Genomic Resource Repository Management Tool"
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument('command', type=str, choices=['index', 'list'],
+                        help='Command to execute')
+    parser.add_argument('repo_dir', type=str,
+                        help='Path to the GR Repo')
+    args = parser.parse_args()
 
-    if len(args) != 2:
-        print("Need two arguments: <command> and <repository directory>. "
-              "The supported commands are index and list.")
-        return
-
-    cmd, dr = args
+    cmd, dr = args.command, args.repo_dir
 
     dr = pathlib.Path(dr)
     GRR = GenomicResourceDirRepo("", dr)

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -94,8 +94,8 @@ def cli_manage(cli_args=None):
         if gr is None:
             print(f"Cannot find resource {args.resource}")
             sys.exit(1)
-        builder = HistogramBuilder()
-        histograms = builder.build(gr)
+        builder = HistogramBuilder(gr)
+        histograms = builder.build()
         resource_path = pathlib.Path(args.resource)
         hist_out_dir = dr / resource_path / 'histograms'
         print(f"Saving histograms in {hist_out_dir}")

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import logging
 import pathlib
@@ -67,6 +66,9 @@ def cli_manage(cli_args=None):
                              help='Path to the GR Repo')
     parser_hist.add_argument('resource', type=str,
                              help='Resource to generate histograms for')
+    parser_hist.add_argument('-j', '--jobs', type=int, default=None,
+                             help='Number of jobs to run in parallel. \
+ Defaults to the number of processors on the machine')
 
     args = parser.parse_args(cli_args)
 
@@ -94,7 +96,7 @@ def cli_manage(cli_args=None):
         if gr is None:
             print(f"Cannot find resource {args.resource}")
             sys.exit(1)
-        builder = HistogramBuilder(gr)
+        builder = HistogramBuilder(gr, args.jobs)
         histograms = builder.build()
         resource_path = pathlib.Path(args.resource)
         hist_out_dir = dr / resource_path / 'histograms'

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -105,23 +105,18 @@ class GenomicScore(abc.ABC):
 
     def fetch_region(self, chrom: str, pos_begin: int, pos_end: int,
                      scores: List[str]) \
-            -> dict[str, Generator[Number, None, None]]:
+            -> Generator[dict[str, Number], None, None]:
         if chrom not in self.get_all_chromosomes():
             raise ValueError(
                 f"{chrom} is not among the available chromosomes.")
 
-        res = {}
-        for scr_id in scores:
-            res[scr_id] = self.iter_lines(chrom, pos_begin, pos_end, scr_id)
-        return res
-
-    def iter_lines(self, chrom: str, pos_begin: int, pos_end: int,
-                   scr_id: str) -> Generator[Number, None, None]:
         line_iter = self._fetch_lines(chrom, pos_begin, pos_end)
         for line in line_iter:
             line_pos_begin, line_pos_end = self._line_to_begin_end(line)
 
-            val = line.get_score_value(scr_id)
+            val = {}
+            for scr_id in scores:
+                val[scr_id] = line.get_score_value(scr_id)
 
             if pos_begin is not None:
                 left = max(pos_begin, line_pos_begin)
@@ -134,7 +129,6 @@ class GenomicScore(abc.ABC):
 
             for i in range(left, right+1):
                 yield val
-
 
 
 class PositionScore(GenomicScore):

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -103,38 +103,6 @@ class GenomicScore(abc.ABC):
     def get_all_scores(self):
         return list(self.score_columns)
 
-
-class PositionScore(GenomicScore):
-    def __init__(self, resourceId: str, version: tuple,
-                 repo: GenomicResourceRealRepo,
-                 config=None):
-        super().__init__(resourceId, version, repo, config)
-
-    @staticmethod
-    def get_resource_type():
-        return "position_score"
-
-    def fetch_scores(
-            self, chrom: str, position: int, scores: List[str] = None):
-
-        if chrom not in self.get_all_chromosomes():
-            raise ValueError(
-                f"{chrom} is not among the available chromosomes.")
-
-        line = list(self._fetch_lines(chrom, position, position))
-        if not line:
-            return None
-
-        if len(line) != 1:
-            raise ValueError(
-                f"The resource {self.score_id()} has "
-                f"more than one ({len(line)}) lines for position "
-                f"{chrom}:{position}")
-        line = line[0]
-
-        requested_scores = scores if scores else self.get_all_scores()
-        return {scr: line.get_score_value(scr) for scr in requested_scores}
-
     def fetch_region(self, chrom: str, pos_begin: int, pos_end: int,
                      scores: List[str]) \
             -> dict[str, Generator[Number, None, None]]:
@@ -166,6 +134,39 @@ class PositionScore(GenomicScore):
 
             for i in range(left, right+1):
                 yield val
+
+
+
+class PositionScore(GenomicScore):
+    def __init__(self, resourceId: str, version: tuple,
+                 repo: GenomicResourceRealRepo,
+                 config=None):
+        super().__init__(resourceId, version, repo, config)
+
+    @staticmethod
+    def get_resource_type():
+        return "position_score"
+
+    def fetch_scores(
+            self, chrom: str, position: int, scores: List[str] = None):
+
+        if chrom not in self.get_all_chromosomes():
+            raise ValueError(
+                f"{chrom} is not among the available chromosomes.")
+
+        line = list(self._fetch_lines(chrom, position, position))
+        if not line:
+            return None
+
+        if len(line) != 1:
+            raise ValueError(
+                f"The resource {self.score_id()} has "
+                f"more than one ({len(line)}) lines for position "
+                f"{chrom}:{position}")
+        line = line[0]
+
+        requested_scores = scores if scores else self.get_all_scores()
+        return {scr: line.get_score_value(scr) for scr in requested_scores}
 
     def fetch_scores_agg(
             self, chrom: str, pos_begin: int, pos_end: int,

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import abc
 import logging
+from numbers import Number
 
-from typing import List, Tuple, cast
+from typing import Generator, List, Tuple, cast
 
 from . import GenomicResource
 from .repository import GenomicResourceRealRepo
@@ -90,13 +91,11 @@ class GenomicScore(abc.ABC):
         return self.table.get_column_names()
 
     def _fetch_lines(self, chrom, pos_begin, pos_end):
-        records = list(self.table.get_records_in_region(
-            chrom, pos_begin, pos_end))
+        records = self.table.get_records_in_region(
+            chrom, pos_begin, pos_end)
 
-        return [
-            ScoreLine(record, self.score_columns, self.special_columns)
-            for record in records
-        ]
+        for record in records:
+            yield ScoreLine(record, self.score_columns, self.special_columns)
 
     def get_all_chromosomes(self):
         return self.table.get_chromosomes()
@@ -122,7 +121,7 @@ class PositionScore(GenomicScore):
             raise ValueError(
                 f"{chrom} is not among the available chromosomes.")
 
-        line = self._fetch_lines(chrom, position, position)
+        line = list(self._fetch_lines(chrom, position, position))
         if not line:
             return None
 
@@ -135,6 +134,38 @@ class PositionScore(GenomicScore):
 
         requested_scores = scores if scores else self.get_all_scores()
         return {scr: line.get_score_value(scr) for scr in requested_scores}
+
+    def fetch_region(self, chrom: str, pos_begin: int, pos_end: int,
+                     scores: List[str]) \
+            -> dict[str, Generator[Number, None, None]]:
+        if chrom not in self.get_all_chromosomes():
+            raise ValueError(
+                f"{chrom} is not among the available chromosomes.")
+
+        res = {}
+        for scr_id in scores:
+            res[scr_id] = self.iter_lines(chrom, pos_begin, pos_end, scr_id)
+        return res
+
+    def iter_lines(self, chrom: str, pos_begin: int, pos_end: int,
+                   scr_id: str) -> Generator[Number, None, None]:
+        line_iter = self._fetch_lines(chrom, pos_begin, pos_end)
+        for line in line_iter:
+            line_pos_begin, line_pos_end = self._line_to_begin_end(line)
+
+            val = line.get_score_value(scr_id)
+
+            if pos_begin is not None:
+                left = max(pos_begin, line_pos_begin)
+            else:
+                left = line_pos_begin
+            if pos_end is not None:
+                right = min(pos_end, line_pos_end)
+            else:
+                right = line_pos_end
+
+            for i in range(left, right+1):
+                yield val
 
     def fetch_scores_agg(
             self, chrom: str, pos_begin: int, pos_end: int,
@@ -152,7 +183,7 @@ class PositionScore(GenomicScore):
             raise ValueError(
                 f"{chrom} is not among the available chromosomes.")
 
-        score_lines = self._fetch_lines(chrom, pos_begin, pos_end)
+        score_lines = list(self._fetch_lines(chrom, pos_begin, pos_end))
 
         requested_scores = scores if scores else self.get_all_scores()
         aggregators = {}
@@ -216,7 +247,7 @@ class NPScore(GenomicScore):
                 f"{chrom} is not among the available chromosomes for "
                 f"NP Score resource {self.score_id()}")
 
-        lines = self._fetch_lines(chrom, position, position)
+        lines = list(self._fetch_lines(chrom, position, position))
         if not lines:
             return None
 
@@ -244,7 +275,7 @@ class NPScore(GenomicScore):
                 f"{chrom} is not among the available chromosomes for "
                 f"NP Score resource {self.score_id()}")
 
-        score_lines = self._fetch_lines(chrom, pos_begin, pos_end)
+        score_lines = list(self._fetch_lines(chrom, pos_begin, pos_end))
         if not score_lines:
             return None
 
@@ -326,7 +357,7 @@ class AlleleScore(GenomicScore):
                 f"{chrom} is not among the available chromosomes for "
                 f"NP Score resource {self.score_id()}")
 
-        lines = self._fetch_lines(chrom, position, position)
+        lines = list(self._fetch_lines(chrom, position, position))
         if not lines:
             return None
 
@@ -479,3 +510,16 @@ def open_allele_score_from_resource(
         extra_special_columns={"reference": str, "alternative": str})
 
     return cast(AlleleScore, result)
+
+
+def open_score_from_resource(resource: GenomicResource) -> GenomicScore:
+    type_to_ctor = {
+        PositionScore.get_resource_type(): open_position_score_from_resource,
+        NPScore.get_resource_type(): open_np_score_from_resource,
+        AlleleScore.get_resource_type(): open_allele_score_from_resource,
+    }
+    ctor = type_to_ctor.get(resource.get_type())
+    if ctor is None:
+        raise ValueError(f"Resource {resource.get_id()} is not of score type")
+
+    return ctor(resource)

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -30,9 +30,9 @@ class Histogram:
         elif self.x_scale == "log":
             assert x_min_log is not None
             self.bins = np.array([
-                x_min_log,
+                self.x_min,
                 * np.logspace(
-                    np.log10(self.x_min),
+                    np.log10(self.x_min_log),
                     np.log10(self.x_max),
                     bins_count
                 )])

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -158,8 +158,8 @@ class HistogramBuilder:
     def save(self, histograms, out_dir):
         os.makedirs(out_dir, exist_ok=True)
         for score, histogram in histograms.items():
-            df = pd.DataFrame({score: histogram.bars,
-                               'scores': histogram.bins[:-1]})
+            df = pd.DataFrame({'bars': histogram.bars,
+                               'bins': histogram.bins[:-1]})
             hist_name = f"{score}.csv"
             df.to_csv(os.path.join(out_dir, hist_name), index=None)
 

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -171,11 +171,9 @@ class HistogramBuilder:
         score_names = list(histograms.keys())
 
         score = open_score_from_resource(self.resource)
-        score_to_values = \
-            score.fetch_region(chrom, None, None, score_names)
-        for scr_id, vals_iter in score_to_values.items():
-            hist = histograms[scr_id]
-            for v in vals_iter:
+        for rec in score.fetch_region(chrom, None, None, score_names):
+            for scr_id, v in rec.items():
+                hist = histograms[scr_id]
                 if v is not None:  # None designates missing values
                     hist.add_value(v)
 
@@ -220,10 +218,8 @@ class HistogramBuilder:
         score = open_score_from_resource(self.resource)
         limits = np.iinfo(np.int64)
         scr_min, scr_max = limits.max, limits.min
-        score_to_values = \
-            score.fetch_region(chrom, None, None, [score_id])
-        vals_iter = score_to_values[score_id]
-        for v in vals_iter:
+        for rec in score.fetch_region(chrom, None, None, [score_id]):
+            v = rec[score_id]
             if v is not None:  # None designates missing values
                 scr_min = min(scr_min, v)
                 scr_max = max(scr_max, v)

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -44,7 +44,7 @@ class Histogram:
 
         self.y_scale = y_scale
 
-        self.bars = np.zeros(bins_count, dtype=np.int32)
+        self.bars = np.zeros(bins_count, dtype=np.int64)
 
     @staticmethod
     def from_config(conf):
@@ -76,7 +76,7 @@ class Histogram:
         )
 
         hist.bins = np.array(d["bins"])
-        hist.bars = np.array(d["bars"], dtype=np.int32)
+        hist.bars = np.array(d["bars"], dtype=np.int64)
 
         return hist
 

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -25,7 +25,7 @@ class Histogram:
             self.bins = np.linspace(
                 self.x_min,
                 self.x_max,
-                bins_count,
+                bins_count + 1,
             )
         elif self.x_scale == "log":
             assert x_min_log is not None
@@ -34,7 +34,7 @@ class Histogram:
                 * np.logspace(
                     np.log10(self.x_min),
                     np.log10(self.x_max),
-                    bins_count - 1
+                    bins_count
                 )])
         else:
             assert False, f"unexpected xscale: {self.x_scale}"
@@ -44,7 +44,7 @@ class Histogram:
 
         self.y_scale = y_scale
 
-        self.bars = np.zeros(bins_count - 1, dtype=np.int32)
+        self.bars = np.zeros(bins_count, dtype=np.int32)
 
     @staticmethod
     def from_config(conf):

--- a/dae/dae/genomic_resources/tests/test_allele_score.py
+++ b/dae/dae/genomic_resources/tests/test_allele_score.py
@@ -61,17 +61,23 @@ def test_allele_score_fetch_region():
     })
     score = open_allele_score_from_resource(res)
 
-    def expand(d):
-        return {k: list(v) for k, v in d.items()}
-
     # The in-mem table will sort the records. In this example it will sort
     # the alternatives column (previous columns are the same). That is why
     # the scores (freq) appear out of order
-    assert expand(score.fetch_region("1", 10, 11, ["freq"])) == \
-        {"freq": [0.04, 0.03, 0.02]}
+    assert list(score.fetch_region("1", 10, 11, ["freq"])) == \
+        [{"freq": 0.04},
+         {"freq": 0.03},
+         {"freq": 0.02}]
 
-    assert expand(score.fetch_region("1", 10, 16, ["freq"])) == \
-        {"freq": [0.04, 0.03, 0.02, 0.05, 0.04, 0.03]}
+    assert list(score.fetch_region("1", 10, 16, ["freq"])) == \
+        [{"freq": 0.04},
+         {"freq": 0.03},
+         {"freq": 0.02},
+         {"freq": 0.05},
+         {"freq": 0.04},
+         {"freq": 0.03}]
 
-    assert expand(score.fetch_region("2", None, None, ["freq"])) == \
-        {"freq": [0.05, None, 0.03]}
+    assert list(score.fetch_region("2", None, None, ["freq"])) == \
+        [{"freq": 0.05},
+         {"freq": None},
+         {"freq": 0.03}]

--- a/dae/dae/genomic_resources/tests/test_allele_score.py
+++ b/dae/dae/genomic_resources/tests/test_allele_score.py
@@ -32,3 +32,46 @@ def test_the_simplest_allele_score():
     score = open_allele_score_from_resource(res)
     assert score.get_all_scores() == ["freq"]
     assert score.fetch_scores("1", 10, "A", "C") == {"freq": 0.03}
+
+
+def test_allele_score_fetch_region():
+    res: GenomicResource = build_a_test_resource({
+        GR_CONF_FILE_NAME: '''
+            type: allele_score
+            table:
+                filename: data.mem
+            scores:
+                - id: freq
+                  type: float
+                  desc: ""
+                  name: freq
+        ''',
+        "data.mem": '''
+            chrom  pos_begin  reference  alternative  freq
+            1      10         A          G            0.02
+            1      10         A          C            0.03
+            1      10         A          A            0.04
+            1      16         CA         G            0.03
+            1      16         C          T            0.04
+            1      16         C          A            0.05
+            2      16         CA         G            0.03
+            2      16         C          T            EMPTY
+            2      16         C          A            0.05
+        '''
+    })
+    score = open_allele_score_from_resource(res)
+
+    def expand(d):
+        return {k: list(v) for k, v in d.items()}
+
+    # The in-mem table will sort the records. In this example it will sort
+    # the alternatives column (previous columns are the same). That is why
+    # the scores (freq) appear out of order
+    assert expand(score.fetch_region("1", 10, 11, ["freq"])) == \
+        {"freq": [0.04, 0.03, 0.02]}
+
+    assert expand(score.fetch_region("1", 10, 16, ["freq"])) == \
+        {"freq": [0.04, 0.03, 0.02, 0.05, 0.04, 0.03]}
+
+    assert expand(score.fetch_region("2", None, None, ["freq"])) == \
+        {"freq": [0.05, None, 0.03]}

--- a/dae/dae/genomic_resources/tests/test_np_score.py
+++ b/dae/dae/genomic_resources/tests/test_np_score.py
@@ -95,3 +95,54 @@ def test_np_score_aggregation():
         non_default_pos_aggregators={"cadd_test": "min"},
         non_default_nuc_aggregators={"cadd_test": "min"}) == \
         {"cadd_test": 0}
+
+
+def test_np_score_fetch_region():
+    res: GenomicResource = build_a_test_resource({
+        GR_CONF_FILE_NAME: '''
+            type: np_score
+            table:
+                filename: data.mem
+            scores:
+                - id: cadd_raw
+                  type: float
+                  desc: ""
+                  name: s1
+
+                - id: cadd_test
+                  type: int
+                  position_aggregator: max
+                  nucleotide_aggregator: mean
+                  na_values: "-1"
+                  desc: ""
+                  name: s2
+        ''',
+        "data.mem": '''
+            chrom  pos_begin  pos_end  reference  alternative  s1    s2
+            1      10         15       A          G            0.02  2
+            1      10         15       A          C            0.03  -1
+            1      10         15       A          T            0.04  4
+            1      16         19       C          G            0.03  3
+            1      16         19       C          T            0.04  EMPTY
+            1      16         19       C          A            0.05  0
+            2      16         19       C          A            0.03  3
+            2      16         19       C          T            0.04  3
+            2      16         19       C          G            0.05  4
+        '''
+    })
+    score = open_np_score_from_resource(res)
+
+    def expand(d):
+        return {k: list(v) for k, v in d.items()}
+
+    # The in-mem table will sort the records. In this example it will sort
+    # the alternatives column (previous columns are the same). That is why
+    # the scores (freq) appear out of order
+    assert expand(score.fetch_region("1", 14, 16, ["cadd_raw"])) == \
+        {"cadd_raw": [0.03, 0.03, 0.02, 0.02, 0.04, 0.04, 0.05, 0.03, 0.04]}
+
+    assert expand(score.fetch_region("1", 14, 16, ["cadd_test"])) == \
+        {"cadd_test": [None, None, 2, 2, 4, 4, 0, 3, None]}
+
+    assert expand(score.fetch_region("2", 13, 17, ["cadd_test"])) == \
+        {"cadd_test": [3, 3, 4, 4, 3, 3]}

--- a/dae/dae/genomic_resources/tests/test_np_score.py
+++ b/dae/dae/genomic_resources/tests/test_np_score.py
@@ -132,17 +132,35 @@ def test_np_score_fetch_region():
     })
     score = open_np_score_from_resource(res)
 
-    def expand(d):
-        return {k: list(v) for k, v in d.items()}
-
     # The in-mem table will sort the records. In this example it will sort
     # the alternatives column (previous columns are the same). That is why
     # the scores (freq) appear out of order
-    assert expand(score.fetch_region("1", 14, 16, ["cadd_raw"])) == \
-        {"cadd_raw": [0.03, 0.03, 0.02, 0.02, 0.04, 0.04, 0.05, 0.03, 0.04]}
+    assert list(score.fetch_region("1", 14, 16, ["cadd_raw"])) == \
+        [{"cadd_raw": 0.03},
+         {"cadd_raw": 0.03},
+         {"cadd_raw": 0.02},
+         {"cadd_raw": 0.02},
+         {"cadd_raw": 0.04},
+         {"cadd_raw": 0.04},
+         {"cadd_raw": 0.05},
+         {"cadd_raw": 0.03},
+         {"cadd_raw": 0.04}]
 
-    assert expand(score.fetch_region("1", 14, 16, ["cadd_test"])) == \
-        {"cadd_test": [None, None, 2, 2, 4, 4, 0, 3, None]}
+    assert list(score.fetch_region("1", 14, 16, ["cadd_test"])) == \
+        [{"cadd_test": None},
+         {"cadd_test": None},
+         {"cadd_test": 2},
+         {"cadd_test": 2},
+         {"cadd_test": 4},
+         {"cadd_test": 4},
+         {"cadd_test": 0},
+         {"cadd_test": 3},
+         {"cadd_test": None}]
 
-    assert expand(score.fetch_region("2", 13, 17, ["cadd_test"])) == \
-        {"cadd_test": [3, 3, 4, 4, 3, 3]}
+    assert list(score.fetch_region("2", 13, 17, ["cadd_test"])) == \
+        [{"cadd_test": 3},
+         {"cadd_test": 3},
+         {"cadd_test": 4},
+         {"cadd_test": 4},
+         {"cadd_test": 3},
+         {"cadd_test": 3}]

--- a/dae/dae/genomic_resources/tests/test_position_score.py
+++ b/dae/dae/genomic_resources/tests/test_position_score.py
@@ -183,7 +183,7 @@ def test_build_score_from_resource_with_pos_resource():
     assert isinstance(score, PositionScore)
 
 
-def test_fetch_region():
+def test_position_score_fetch_region():
     res: GenomicResource = build_a_test_resource({
         GR_CONF_FILE_NAME: '''
             type: position_score
@@ -212,14 +212,25 @@ def test_fetch_region():
     })
     score = open_position_score_from_resource(res)
 
-    def expand(d):
-        return {k: list(v) for k, v in d.items()}
+    assert list(score.fetch_region("1", 13, 18, ["phastCons100way"])) == \
+        [{"phastCons100way": 0.02},
+         {"phastCons100way": 0.02},
+         {"phastCons100way": 0.02},
+         {"phastCons100way": 0.03},
+         {"phastCons100way": 0.03}]
 
-    assert expand(score.fetch_region("1", 13, 18, ["phastCons100way"])) == \
-        {"phastCons100way": [0.02, 0.02, 0.02, 0.03, 0.03]}
+    assert list(score.fetch_region("1", 13, 18, ["phastCons5way"])) == \
+        [{"phastCons5way": None},
+         {"phastCons5way": None},
+         {"phastCons5way": None},
+         {"phastCons5way": 0},
+         {"phastCons5way": 0}]
 
-    assert expand(score.fetch_region("1", 13, 18, ["phastCons5way"])) == \
-        {"phastCons5way": [None, None, None, 0, 0]}
-
-    assert expand(score.fetch_region("2", 13, 18, ["phastCons5way"])) == \
-        {"phastCons5way": [3, 3, 3, 3, 3, 3]}
+    scores = ["phastCons5way", "phastCons100way"]
+    assert list(score.fetch_region("2", 13, 18, scores)) == \
+        [{"phastCons5way": 3, "phastCons100way": 0.01},
+         {"phastCons5way": 3, "phastCons100way": 0.01},
+         {"phastCons5way": 3, "phastCons100way": 0.01},
+         {"phastCons5way": 3, "phastCons100way": 0.01},
+         {"phastCons5way": 3, "phastCons100way": 0.01},
+         {"phastCons5way": 3, "phastCons100way": 0.01}]

--- a/dae/dae/genomic_resources/tests/test_position_score.py
+++ b/dae/dae/genomic_resources/tests/test_position_score.py
@@ -1,9 +1,14 @@
 from typing import cast
 from dae.genomic_resources import GenomicResource
 from dae.genomic_resources.genomic_scores import \
-    open_position_score_from_resource
+    PositionScore,\
+    open_position_score_from_resource,\
+    open_score_from_resource
+from dae.genomic_resources.repository_factory import \
+    build_genomic_resource_repository
 from dae.genomic_resources.test_tools import build_a_test_resource
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME
+import yaml
 
 
 def test_the_simplest_position_score():
@@ -149,3 +154,72 @@ def test_position_score_over_http(genomic_resource_fixture_http_repo):
     result = score.fetch_scores("1", 10918)
     assert result
     assert result['phastCons100way'] == 0.253
+
+
+def test_build_score_from_resource_with_pos_resource():
+    definition = yaml.safe_load('''
+        id: mm
+        type: embeded
+        content:
+            pos_res:
+                genomic_resource.yaml: |
+                    type: position_score
+                    table:
+                            filename: data.mem
+                    scores:
+                    - id: score
+                      type: float
+                      name: s1
+                data.mem: |
+                        chrom  pos_begin  s1
+                        chr1   23         0.01
+    ''')
+    repo = build_genomic_resource_repository(definition)
+    assert repo is not None
+    gr = repo.get_resource('pos_res')
+    assert gr is not None
+
+    score = open_score_from_resource(gr)
+    assert isinstance(score, PositionScore)
+
+
+def test_fetch_region():
+    res: GenomicResource = build_a_test_resource({
+        GR_CONF_FILE_NAME: '''
+            type: position_score
+            table:
+                filename: data.mem
+            scores:
+              - id: phastCons100way
+                type: float
+                desc: "The phastCons computed over the tree of 100 \
+                       verterbarte species"
+                name: s1
+              - id: phastCons5way
+                type: int
+                position_aggregator: max
+                na_values: "-1"
+                desc: "The phastCons computed over the tree of 5 \
+                       verterbarte species"
+                name: s2''',
+        "data.mem": '''
+            chrom  pos_begin  pos_end  s1    s2
+            1      10         15       0.02  -1
+            1      17         19       0.03  0
+            1      22         25       0.46  EMPTY
+            2      5          80       0.01  3
+            '''
+    })
+    score = open_position_score_from_resource(res)
+
+    def expand(d):
+        return {k: list(v) for k, v in d.items()}
+
+    assert expand(score.fetch_region("1", 13, 18, ["phastCons100way"])) == \
+        {"phastCons100way": [0.02, 0.02, 0.02, 0.03, 0.03]}
+
+    assert expand(score.fetch_region("1", 13, 18, ["phastCons5way"])) == \
+        {"phastCons5way": [None, None, None, 0, 0]}
+
+    assert expand(score.fetch_region("2", 13, 18, ["phastCons5way"])) == \
+        {"phastCons5way": [3, 3, 3, 3, 3, 3]}

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -1,3 +1,4 @@
+import os
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME, GenomicResource
 from dae.genomic_resources.score_statistics import Histogram, HistogramBuilder
 from dae.genomic_resources.test_tools import build_a_test_resource
@@ -76,8 +77,8 @@ position_score_test_config = {
 
 def test_histogram_builder_position_resource():
     res: GenomicResource = build_a_test_resource(position_score_test_config)
-    hbuilder = HistogramBuilder()
-    hists = hbuilder.build(res)
+    hbuilder = HistogramBuilder(res)
+    hists = hbuilder.build()
     assert len(hists) == 2
 
     phastCons100way_hist = hists["phastCons100way"]
@@ -121,8 +122,8 @@ def test_histogram_builder_no_explicit_min_max():
             2      10         11       1.0
             '''
     })
-    hbuilder = HistogramBuilder()
-    hists = hbuilder.build(res)
+    hbuilder = HistogramBuilder(res)
+    hists = hbuilder.build()
     assert len(hists) == 1
 
     assert hists["phastCons100way"].x_min == 0
@@ -130,6 +131,10 @@ def test_histogram_builder_no_explicit_min_max():
 
 def test_histogram_builder_save(tmpdir):
     res: GenomicResource = build_a_test_resource(position_score_test_config)
-    hbuilder = HistogramBuilder()
-    hists = hbuilder.build(res)
+    hbuilder = HistogramBuilder(res)
+    hists = hbuilder.build()
     hbuilder.save(hists, tmpdir)
+
+    files = os.listdir(tmpdir)
+    print(files)
+    assert len(files) == 4  # 2 histograms and 2 metadatas

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -97,6 +97,37 @@ def test_histogram_builder_position_resource():
     assert phastCons5way_hist.bars.sum() == (76 + 2 + 3)
 
 
+def test_histogram_builder_no_explicit_min_max():
+    res: GenomicResource = build_a_test_resource({
+        GR_CONF_FILE_NAME: '''
+            type: position_score
+            table:
+                filename: data.mem
+            scores:
+                - id: phastCons100way
+                  type: float
+                  desc: "The phastCons computed over the tree of 100 \
+                        verterbarte species"
+                  name: s1
+            histograms:
+                - score: phastCons100way
+                  bins: 100''',
+        "data.mem": '''
+            chrom  pos_begin  pos_end  s1
+            1      10         15       0.0
+            1      17         19       0.03
+            1      22         25       0.46
+            2      5          80       0.01
+            2      10         11       1.0
+            '''
+    })
+    hbuilder = HistogramBuilder()
+    hists = hbuilder.build(res)
+    assert len(hists) == 1
+
+    assert hists["phastCons100way"].x_min == 0
+    assert hists["phastCons100way"].x_max == 1
+
 def test_histogram_builder_save(tmpdir):
     res: GenomicResource = build_a_test_resource(position_score_test_config)
     hbuilder = HistogramBuilder()

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def test_histogram_simple_input():
-    hist = Histogram(11, 0, 10, "linear", "linear")
+    hist = Histogram(10, 0, 10, "linear", "linear")
     assert (hist.bins == np.arange(0, 11)).all()
 
     hist.add_value(0)
@@ -41,11 +41,11 @@ def test_histogram_builder_simple_input():
                 name: s2
             histograms:
               - score: phastCons100way
-                bins: 101
+                bins: 100
                 min: 0
                 max: 1
               - score: phastCons5way
-                bins: 5
+                bins: 4
                 min: 0
                 max: 4''',
         "data.mem": '''

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -37,6 +37,21 @@ def test_histogram_log_scale():
     assert (hist.bars == np.array([2, 1, 1, 1])).all()
 
 
+def test_histogram_merge():
+    hist1 = Histogram(10, 0, 10, "linear", "linear")
+    hist2 = Histogram(10, 0, 10, "linear", "linear")
+
+    hist1.add_value(3)
+    hist1.add_value(7.5)
+    hist1.add_value(9)
+    hist1.add_value(10)
+    hist2.add_value(5)
+    hist2.add_value(7)
+
+    hist = Histogram.merge(hist1, hist2)
+    assert (hist.bars == np.array([0, 0, 0, 1, 0, 1, 0, 2, 0, 2])).all()
+
+
 position_score_test_config = {
     GR_CONF_FILE_NAME: '''
         type: position_score
@@ -232,6 +247,7 @@ def test_histogram_builder_no_explicit_min_max():
 
     assert hists["phastCons100way"].x_min == 0
     assert hists["phastCons100way"].x_max == 1
+
 
 def test_histogram_builder_save(tmpdir):
     res: GenomicResource = build_a_test_resource(position_score_test_config)

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -1,0 +1,78 @@
+from dae.genomic_resources.repository import GR_CONF_FILE_NAME, GenomicResource
+from dae.genomic_resources.score_statistics import Histogram, HistogramBuilder
+from dae.genomic_resources.test_tools import build_a_test_resource
+import numpy as np
+
+
+def test_histogram_simple_input():
+    hist = Histogram(11, 0, 10, "linear", "linear")
+    assert (hist.bins == np.arange(0, 11)).all()
+
+    hist.add_value(0)
+    assert (hist.bars == np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+
+    for i in range(1, 11):
+        hist.add_value(i)
+    assert (hist.bars == np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 2])).all()
+
+    hist.add_value(12)
+    hist.add_value(-1)
+    assert (hist.bars == np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 2])).all()
+
+
+def test_histogram_builder_simple_input():
+    res: GenomicResource = build_a_test_resource({
+        GR_CONF_FILE_NAME: '''
+            type: position_score
+            table:
+                filename: data.mem
+            scores:
+              - id: phastCons100way
+                type: float
+                desc: "The phastCons computed over the tree of 100 \
+                       verterbarte species"
+                name: s1
+              - id: phastCons5way
+                type: int
+                position_aggregator: max
+                na_values: "-1"
+                desc: "The phastCons computed over the tree of 5 \
+                       verterbarte species"
+                name: s2
+            histograms:
+              - score: phastCons100way
+                bins: 101
+                min: 0
+                max: 1
+              - score: phastCons5way
+                bins: 5
+                min: 0
+                max: 4''',
+        "data.mem": '''
+            chrom  pos_begin  pos_end  s1    s2
+            1      10         15       0.02  -1
+            1      17         19       0.03  0
+            1      22         25       0.46  EMPTY
+            2      5          80       0.01  3
+            2      10         11       0.02  3
+            '''
+    })
+    hbuilder = HistogramBuilder()
+    hists = hbuilder.build(res)
+    assert len(hists) == 2
+
+    phastCons100way_hist = hists["phastCons100way"]
+    assert len(phastCons100way_hist.bars) == 100
+    assert phastCons100way_hist.bars[0] == 0
+    assert phastCons100way_hist.bars[1] == 76  # region [5-80]
+    assert phastCons100way_hist.bars[2] == 8  # region [10-15] and [10-11]
+    assert phastCons100way_hist.bars[3] == 3  # region [17-19]
+    assert phastCons100way_hist.bars[4] == 0
+    assert phastCons100way_hist.bars[46] == 4  # region [22-24]
+    assert phastCons100way_hist.bars.sum() == (76 + 8 + 3 + 4)
+
+    phastCons5way_hist = hists["phastCons5way"]
+    assert len(phastCons5way_hist.bars) == 4
+    assert phastCons5way_hist.bars[0] == 3  # region [17-19]
+    assert phastCons5way_hist.bars[3] == 76 + 2  # region [5-80] and [10-11]
+    assert phastCons5way_hist.bars.sum() == (76 + 2 + 3)

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -20,6 +20,22 @@ def test_histogram_simple_input():
     assert (hist.bars == np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 2])).all()
 
 
+def test_histogram_log_scale():
+    hist = Histogram(4, 0, 1000, "log", "linear", x_min_log=1)
+    assert (hist.bins == np.array([0, 1, 10, 100, 1000])).all()
+
+    hist.add_value(0)
+    assert (hist.bars == np.array([1, 0, 0, 0])).all()
+
+    for i in [0.5, 2, 10, 200]:
+        hist.add_value(i)
+    assert (hist.bars == np.array([2, 1, 1, 1])).all()
+
+    hist.add_value(2000)
+    hist.add_value(-1)
+    assert (hist.bars == np.array([2, 1, 1, 1])).all()
+
+
 position_score_test_config = {
     GR_CONF_FILE_NAME: '''
         type: position_score

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -239,6 +239,8 @@ def test_histogram_builder_no_explicit_min_max():
             1      22         25       0.46
             2      5          80       0.01
             2      10         11       1.0
+            3      5          17       1.0
+            3      18         20       0.01
             '''
     })
     hbuilder = HistogramBuilder(res)


### PR DESCRIPTION
Add a new command `histogram` to `grr_manage`. The command takes as arguments a genomic resource repo and a resource in that repo. It generates histograms for that resource. The histograms are described in the resource `genomic_resource.yaml` file. The output histogram is written in a directory `histograms` under the resource path.

The histogram calculation is done in parallel. The parallelism is based on the contigs - for each config a separate job. The number of jobs to be executed in parallel can be controlled through the `--jobs` command line parameter. The default behavior is to start as many jobs as processors on the machine.