### PR TITLE
Use Dask for histogram compute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ cache
 dae/dae/__build__.py
 wdae/wdae/__build__.py
 dae/TESTphastCons100way.bedGraph.gz.tbi
+dask-worker-space/

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -232,28 +232,23 @@ class HistogramBuilder:
                     res[scr_id][1] = max(v, res[scr_id][1])
         return res
 
-    # def build():
-    #     over all chromosomes:
-    #         run build_region in parallel
-    #     merge all histograms.
-
     def save(self, histograms, out_dir):
         histogram_desc = self.resource.get_config().get("histograms", [])
         configs = {hist['score']: hist for hist in histogram_desc}
 
-        os.makedirs(out_dir, exist_ok=True)
         for score, histogram in histograms.items():
             df = pd.DataFrame({'bars': histogram.bars,
                                'bins': histogram.bins[:-1]})
-            hist_name = f"{score}.csv"
-            df.to_csv(os.path.join(out_dir, hist_name), index=None)
+            hist_file = os.path.join(out_dir, f"{score}.csv")
+            with self.resource.open_raw_file(hist_file, "wt") as f:
+                df.to_csv(f, index=None)
 
             metadata = {
                 'resource': self.resource.get_id(),
                 'histogram_config': configs.get(score, {}),
             }
-            metadata_name = f"{score}.metadata.yaml"
-            with open(os.path.join(out_dir, metadata_name), "wt") as f:
+            metadata_file = os.path.join(out_dir, f"{score}.metadata.yaml")
+            with self.resource.open_raw_file(metadata_file, "wt") as f:
                 yaml.dump(metadata, f)
 
 

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -3,6 +3,7 @@ import os
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME, GenomicResource
 from dae.genomic_resources.score_statistics import Histogram, HistogramBuilder
 from dae.genomic_resources.test_tools import build_a_test_resource
+from dae.genomic_resources.dir_repository import GenomicResourceDirRepo
 import numpy as np
 
 
@@ -262,11 +263,15 @@ def test_histogram_builder_no_explicit_min_max(client):
 
 
 def test_histogram_builder_save(tmpdir, client):
-    res: GenomicResource = build_a_test_resource(position_score_test_config)
+    for fn, content in position_score_test_config.items():
+        with open(os.path.join(tmpdir, fn), 'wt') as f:
+            f.write(content)
+
+    res = GenomicResourceDirRepo("", tmpdir).get_resource("")
     hbuilder = HistogramBuilder(res)
     hists = hbuilder.build(client)
-    hbuilder.save(hists, tmpdir)
+    hbuilder.save(hists, "")
 
     files = os.listdir(tmpdir)
     print(files)
-    assert len(files) == 4  # 2 histograms and 2 metadatas
+    assert len(files) == 6  # 2 config, 2 histograms and 2 metadatas

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME, GenomicResource
 from dae.genomic_resources.score_statistics import Histogram, HistogramBuilder
@@ -90,10 +91,19 @@ position_score_test_config = {
 }
 
 
-def test_histogram_builder_position_resource():
+@pytest.fixture(scope="module")
+def client():
+    from dask.distributed import Client
+
+    client = Client(n_workers=4, threads_per_worker=1)
+    yield client
+    client.close()
+
+
+def test_histogram_builder_position_resource(client):
     res: GenomicResource = build_a_test_resource(position_score_test_config)
     hbuilder = HistogramBuilder(res)
-    hists = hbuilder.build()
+    hists = hbuilder.build(client)
     assert len(hists) == 2
 
     phastCons100way_hist = hists["phastCons100way"]
@@ -113,7 +123,7 @@ def test_histogram_builder_position_resource():
     assert phastCons5way_hist.bars.sum() == (76 + 2 + 3)
 
 
-def test_histogram_builder_allele_resource():
+def test_histogram_builder_allele_resource(client):
     res: GenomicResource = build_a_test_resource({
         GR_CONF_FILE_NAME: '''
             type: allele_score
@@ -143,7 +153,7 @@ def test_histogram_builder_allele_resource():
         '''
     })
     hbuilder = HistogramBuilder(res)
-    hists = hbuilder.build()
+    hists = hbuilder.build(client)
     assert len(hists) == 1
 
     freq_hist = hists["freq"]
@@ -156,7 +166,7 @@ def test_histogram_builder_allele_resource():
     assert freq_hist.bars.sum() == (1 + 3 + 2 + 2)
 
 
-def test_histogram_builder_np_resource():
+def test_histogram_builder_np_resource(client):
     res: GenomicResource = build_a_test_resource({
         GR_CONF_FILE_NAME: '''
             type: np_score
@@ -198,7 +208,7 @@ def test_histogram_builder_np_resource():
         '''
     })
     hbuilder = HistogramBuilder(res)
-    hists = hbuilder.build()
+    hists = hbuilder.build(client)
     assert len(hists) == 2
 
     cadd_raw_hist = hists["cadd_raw"]
@@ -217,7 +227,7 @@ def test_histogram_builder_np_resource():
     assert cadd_test_hist.bars.sum() == (4 + 6 + 22)
 
 
-def test_histogram_builder_no_explicit_min_max():
+def test_histogram_builder_no_explicit_min_max(client):
     res: GenomicResource = build_a_test_resource({
         GR_CONF_FILE_NAME: '''
             type: position_score
@@ -244,17 +254,17 @@ def test_histogram_builder_no_explicit_min_max():
             '''
     })
     hbuilder = HistogramBuilder(res)
-    hists = hbuilder.build()
+    hists = hbuilder.build(client)
     assert len(hists) == 1
 
     assert hists["phastCons100way"].x_min == 0
     assert hists["phastCons100way"].x_max == 1
 
 
-def test_histogram_builder_save(tmpdir):
+def test_histogram_builder_save(tmpdir, client):
     res: GenomicResource = build_a_test_resource(position_score_test_config)
     hbuilder = HistogramBuilder(res)
-    hists = hbuilder.build()
+    hists = hbuilder.build(client)
     hbuilder.save(hists, tmpdir)
 
     files = os.listdir(tmpdir)

--- a/dae/dae/genomic_resources/tests/test_url_repo_s3.py
+++ b/dae/dae/genomic_resources/tests/test_url_repo_s3.py
@@ -18,3 +18,11 @@ def test_s3_url_vs_dir_results(genomic_resource_fixture_dir_repo,
     file_content = dir_repo.get_resource("hg19/CADD")\
         .get_file_content("CADD.bedgraph.gz.tbi")
     assert s3_content == file_content
+
+
+def test_writing_to_s3_repo(genomic_resource_fixture_s3_repo):
+    resource = genomic_resource_fixture_s3_repo.get_resource("hg19/CADD")
+    with resource.open_raw_file("test-file", "wt") as file:
+        file.write("Test")
+    s3_filesystem = genomic_resource_fixture_s3_repo.filesystem
+    assert s3_filesystem.exists("test-bucket/hg19/CADD/test-file")

--- a/dae/dae/genomic_resources/url_repository.py
+++ b/dae/dae/genomic_resources/url_repository.py
@@ -61,8 +61,6 @@ class GenomicResourceURLRepo(GenomicResourceRealRepo):
                       seekable=False):
 
         mode = mode if mode else "rb"
-        if 'w' in mode:
-            raise Exception("Can't handle writable files yet!")
 
         file_url = self.get_file_url(genomic_resource, filename)
         logger.debug(f"opening url resource: {file_url}")
@@ -70,14 +68,14 @@ class GenomicResourceURLRepo(GenomicResourceRealRepo):
         if self.scheme in ["http", "https"] and not seekable:
             binary_stream = urlopen(file_url)
         else:
-            binary_stream = self.filesystem.open(file_url)
+            bin_mode = mode.replace('t', 'b')
+            binary_stream = self.filesystem.open(file_url, bin_mode)
 
         if filename.endswith(".gz") and uncompress:
             return gzip.open(binary_stream, mode)
 
         if 't' in mode:
             return io.TextIOWrapper(binary_stream, encoding=GR_ENCODING)
-
         return binary_stream
 
     def open_tabix_file(self, genomic_resource,  filename,

--- a/environment.yml
+++ b/environment.yml
@@ -44,5 +44,5 @@ dependencies:
   - jinja2=3.0.1
   - snakemake-minimal=6.12.1
   - ijson=3.1.4
-  - dask-core=2021.10.0
-  - distributed=2021.10.0
+  - dask=2022.1.0
+  - dask-kubernetes=2022.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -44,3 +44,5 @@ dependencies:
   - jinja2=3.0.1
   - snakemake-minimal=6.12.1
   - ijson=3.1.4
+  - dask-core=2021.10.0
+  - distributed=2021.10.0


### PR DESCRIPTION
Dask is used instead of a `ProcessPoolExecutor` to run tasks in parallel. Dask allows us to run the computation not just locally but over a kubernetes cluster. A few options have been added to the `cli` to support this functionality.