### PR TITLE
Hash histograms and don't compute a histogram if it's already been computed

### DIFF
--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -81,7 +81,7 @@ def cli_manage(cli_args=None):
     parser_hist.add_argument('--kubernetes', default=False,
                              action='store_true',
                              help='Run computation in a kubernetes cluster')
-    parser_hist.add_argument('--envvars', nargs='*',
+    parser_hist.add_argument('--envvars', nargs='*', default=[],
                              help='Environment variables to pass to '
                              'kubernetes workers')
     parser_hist.add_argument('--container-image',

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -89,6 +89,9 @@ def cli_manage(cli_args=None):
     parser_hist.add_argument('--image-pull-secrets', nargs='*',
                              help='Secrets to use when pulling '
                              'the docker image')
+    parser_hist.add_argument('-f', '--force', default=False,
+                             action='store_true', help='Ignore histogram '
+                             'hashes and always precompute all histograms')
 
     args = parser.parse_args(cli_args)
 
@@ -133,7 +136,7 @@ def cli_manage(cli_args=None):
             cluster = LocalCluster(n_workers=n_jobs, threads_per_worker=1)
         with cluster:
             with Client(cluster) as client:
-                histograms = builder.build(client)
+                histograms = builder.build(client, force=args.force)
 
         hist_out_dir = 'histograms'
         print(f"Saving histograms in {hist_out_dir}")

--- a/dae/dae/genomic_resources/dir_repository.py
+++ b/dae/dae/genomic_resources/dir_repository.py
@@ -65,6 +65,12 @@ class GenomicResourceDirRepo(GenomicResourceRealRepo):
     def open_raw_file(self, genomic_resource: GenomicResource, filename: str,
                       mode=None, uncompress=False, _seekable=False):
         fullFilePath = self.get_file_path(genomic_resource, filename)
+        if 'w' in mode:
+            # Create the containing directory if it doesn't exists.
+            # This align DireRepo API with URL and fspec APIs
+            dirname = os.path.dirname(fullFilePath)
+            if dirname:
+                os.makedirs(dirname, exist_ok=True)
         if filename.endswith(".gz") and uncompress:
             return gzip.open(fullFilePath, "rb")
         else:

--- a/dae/dae/genomic_resources/dir_repository.py
+++ b/dae/dae/genomic_resources/dir_repository.py
@@ -58,6 +58,10 @@ class GenomicResourceDirRepo(GenomicResourceRealRepo):
         yield from find_genomic_resource_files_helper(
             content_dict, my_leaf_to_size_and_time)
 
+    def file_exists(self, genomic_resource, filename):
+        full_file_path = self.get_file_path(genomic_resource, filename)
+        return os.path.exists(full_file_path)
+
     def open_raw_file(self, genomic_resource: GenomicResource, filename: str,
                       mode=None, uncompress=False, _seekable=False):
         fullFilePath = self.get_file_path(genomic_resource, filename)

--- a/dae/dae/genomic_resources/embeded_repository.py
+++ b/dae/dae/genomic_resources/embeded_repository.py
@@ -21,6 +21,13 @@ class GenomicResourceEmbededRepo(GenomicResourceRealRepo):
         for grId, grVr in find_genomic_resources_helper(self.content):
             yield self.build_genomic_resource(grId, grVr)
 
+    def file_exists(self, genomic_resource, filename):
+        try:
+            self.get_file_content(genomic_resource, filename, uncompress=False)
+            return True
+        except Exception:
+            return False
+
     def get_file_content(self, genomic_resource: GenomicResource, filename,
                          uncompress=True):
         content = self._get_file_content_and_time(

--- a/dae/dae/genomic_resources/repository.py
+++ b/dae/dae/genomic_resources/repository.py
@@ -176,6 +176,12 @@ class GenomicResource:
         '''
         return self.repo.get_files(self)
 
+    def file_exists(self, filename):
+        '''
+        Returns whether filename exists in this resource
+        '''
+        return self.repo.file_exists(self, filename)
+
     def get_md5_sum(self, filename):
         with self.open_raw_file(filename, "rb") as infile:
             md5_hash = hashlib.md5()
@@ -318,6 +324,9 @@ class GenomicResourceRealRepo(GenomicResourceRepo):
 
     @abc.abstractmethod
     def get_files(self, genomicResource):
+        raise Exception("Should not be called!")
+
+    def file_exists(self, genomic_resource, filename):
         raise Exception("Should not be called!")
 
     @abc.abstractmethod

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -135,12 +135,16 @@ class HistogramBuilder:
     def __init__(self, resource) -> None:
         self.resource = resource
 
-    def build(self, client, path="histograms") -> dict[str, Histogram]:
+    def build(self, client, path="histograms",
+              force=False) -> dict[str, Histogram]:
+        histogram_desc = self.resource.get_config().get("histograms", [])
+        if force:
+            return self._do_build(client, histogram_desc)
+
         hists, metadata = _load_histograms(self.resource.repo,
                                            self.resource.get_id(), None, None,
                                            path)
         hashes = self._build_hashes()
-        histogram_desc = self.resource.get_config().get("histograms", [])
 
         configs_to_calculate = []
         result = {}

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -251,6 +251,9 @@ class HistogramBuilder:
             with self.resource.open_raw_file(metadata_file, "wt") as f:
                 yaml.dump(metadata, f)
 
+        # update manifest with newly written files
+        self.resource.update_manifest()
+
 
 def load_histograms(repo, resource_id, version_constraint=None,
                     genomic_repository_id=None, path="histograms"):

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -6,6 +6,7 @@ import yaml
 import pandas as pd
 from typing import Dict
 from copy import copy
+import matplotlib.pyplot as plt
 
 from dae.genomic_resources.genomic_scores import open_score_from_resource
 
@@ -315,6 +316,14 @@ class HistogramBuilder:
             metadata_file = os.path.join(out_dir, f"{score}.metadata.yaml")
             with self.resource.open_raw_file(metadata_file, "wt") as f:
                 yaml.dump(metadata, f)
+
+            plt.hist(histogram.bins[:-1], histogram.bins,
+                     weights=histogram.bars)
+            plt.grid(axis='y')
+            plt.grid(axis='x')
+            plot_file = os.path.join(out_dir, f"{score}.png")
+            with self.resource.open_raw_file(plot_file, "wb") as f:
+                plt.savefig(f)
 
         # update manifest with newly written files
         self.resource.update_manifest()

--- a/dae/dae/genomic_resources/score_statistics.py
+++ b/dae/dae/genomic_resources/score_statistics.py
@@ -266,11 +266,13 @@ class HistogramBuilder:
         config = self.resource.get_config()
         table_filename = config["table"]["filename"]
         manifest = self.resource.get_manifest()
-        table_hash = ''
+        table_hash = None
         for rec in manifest:
             if rec["name"] == table_filename:
                 table_hash = rec["md5"]
                 break
+        if table_hash is None:
+            return {}
 
         histogram_desc = config.get("histograms", [])
         hist_configs = {hist['score']: hist for hist in histogram_desc}
@@ -299,8 +301,9 @@ class HistogramBuilder:
             metadata = {
                 'resource': self.resource.get_id(),
                 'histogram_config': hist_config,
-                'md5': hist_hashes[score]
             }
+            if score in hist_hashes:
+                metadata['md5'] = hist_hashes[score]
             if 'min' not in hist_config:
                 metadata['calculated_min'] = histogram.x_min
             if 'max' not in hist_config:

--- a/dae/dae/genomic_resources/tests/test_dir_repository.py
+++ b/dae/dae/genomic_resources/tests/test_dir_repository.py
@@ -138,3 +138,21 @@ def test_dir_repository_resource_update_delete(tmp_path):
 
     dir_repo2.update_resource(gr1)
     assert gr1.get_manifest() == gr2.get_manifest()
+
+
+def test_dir_repository_file_exists(tmp_path):
+    src_repo = GenomicResourceEmbededRepo("src", content={
+        "one": {
+            GR_CONF_FILE_NAME: "",
+            "data.txt": "alabala",
+            "alabala.txt": "alabala",
+        },
+    })
+
+    repo = GenomicResourceDirRepo('dir', directory=tmp_path / "t1")
+    repo.store_all_resources(src_repo)
+    res = repo.get_resource("one")
+
+    assert repo.file_exists(res, GR_CONF_FILE_NAME)
+    assert not repo.file_exists(res, "missing_file")
+    assert res.file_exists("data.txt")

--- a/dae/dae/genomic_resources/tests/test_embedded_repository.py
+++ b/dae/dae/genomic_resources/tests/test_embedded_repository.py
@@ -1,0 +1,17 @@
+from dae.genomic_resources.embeded_repository import GenomicResourceEmbededRepo
+from dae.genomic_resources.repository import GR_CONF_FILE_NAME
+
+
+def test_embedded_repository_file_exists(tmp_path):
+    repo = GenomicResourceEmbededRepo("src", content={
+        "one": {
+            GR_CONF_FILE_NAME: "",
+            "data.txt": "alabala",
+            "alabala.txt": "alabala",
+        },
+    })
+
+    res = repo.get_resource("one")
+    assert repo.file_exists(res, GR_CONF_FILE_NAME)
+    assert not repo.file_exists(res, "missing_file")
+    assert res.file_exists("data.txt")

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -276,7 +276,8 @@ def test_histogram_builder_save(tmpdir, client):
     hbuilder.save(hists, "")
 
     files = os.listdir(tmpdir)
-    assert len(files) == 7  # 2 config, 2 histograms, 2 metadatas, 1 manifest
+    # 2 config, 2 histograms, 2 metadatas, 1 manifest, 2 png images
+    assert len(files) == 9
 
     # assert the manifest file is updated
     manifest = res.load_manifest()

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -318,3 +318,15 @@ def test_load_histograms(tmpdir, client):
     # assert nothing is cached
     files = os.listdir(cache_dir)
     assert len(files) == 0
+
+
+def test_histogram_builder_build_hashes():
+    res: GenomicResource = build_a_test_resource(position_score_test_config)
+    hbuilder = HistogramBuilder(res)
+    hashes = hbuilder._build_hashes()
+    assert len(hashes) == 2
+
+    hashes_again = hbuilder._build_hashes()
+    assert hashes["phastCons100way"] == hashes_again["phastCons100way"]
+    assert hashes["phastCons5way"] == hashes_again["phastCons5way"]
+    assert hashes["phastCons100way"] != hashes["phastCons5way"]

--- a/dae/dae/genomic_resources/tests/test_score_statistics.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics.py
@@ -275,8 +275,14 @@ def test_histogram_builder_save(tmpdir, client):
     hbuilder.save(hists, "")
 
     files = os.listdir(tmpdir)
-    print(files)
-    assert len(files) == 6  # 2 config, 2 histograms and 2 metadatas
+    assert len(files) == 7  # 2 config, 2 histograms, 2 metadatas, 1 manifest
+
+    # assert the manifest file is updated
+    manifest = res.load_manifest()
+    manifest_dict = {x['name']: x for x in manifest}
+    for score_id in ['phastCons5way', 'phastCons100way']:
+        assert f'{score_id}.csv' in manifest_dict
+        assert f'{score_id}.metadata.yaml' in manifest_dict
 
 
 def test_load_histograms(tmpdir, client):

--- a/dae/dae/genomic_resources/tests/test_url_repo_s3.py
+++ b/dae/dae/genomic_resources/tests/test_url_repo_s3.py
@@ -26,3 +26,12 @@ def test_writing_to_s3_repo(genomic_resource_fixture_s3_repo):
         file.write("Test")
     s3_filesystem = genomic_resource_fixture_s3_repo.filesystem
     assert s3_filesystem.exists("test-bucket/hg19/CADD/test-file")
+
+
+def test_url_repository_file_exists(genomic_resource_fixture_s3_repo):
+    repo = genomic_resource_fixture_s3_repo
+    res = repo.get_resource("hg19/CADD")
+
+    assert repo.file_exists(res, "CADD.bedgraph.gz.tbi")
+    assert not repo.file_exists(res, "missing_file")
+    assert res.file_exists("CADD.bedgraph.gz.tbi")

--- a/dae/dae/genomic_resources/url_repository.py
+++ b/dae/dae/genomic_resources/url_repository.py
@@ -51,6 +51,10 @@ class GenomicResourceURLRepo(GenomicResourceRealRepo):
         for mnfst in mnfst:
             yield mnfst['name'], int(mnfst['size']), mnfst['time']
 
+    def file_exists(self, genomic_resource, filename):
+        file_url = self.get_file_url(genomic_resource, filename)
+        return self.filesystem.exists(file_url)
+
     def get_file_url(self, genomic_resource, filename):
         return self.url + "/" + genomic_resource.get_genomic_resource_dir() + \
             "/" + filename


### PR DESCRIPTION
Each histogram now gets a hash that is computed based on the input file (used to calculate the histogram) and the config. The hash is stored as part of the histogram metadata. When running `grr_manage histogram` the stored hash is compared against a newly computed one. If hashes match than the histogram is simply loaded from disk and not recomputed.

This PR contains a few other improvements like for each histogram a png file is also saved.