### PR TITLE
Import tools features

### DIFF
--- a/dae/dae/docs/import_tools.rst
+++ b/dae/dae/docs/import_tools.rst
@@ -85,9 +85,9 @@ Import Tools configuration format
         (OR)
         embedded-annotation
 
-    (optional by default default storage of gpf instance)
+    (optional by default use the default storage of the gpf instance)
     destination:
-        gpf_storage_id: "id in gpf_instance"
+        storage_id: "id in gpf_instance"
         (OR)
         storage_type: impala_schema_1
             hdfs:

--- a/dae/dae/impala_storage/schema2/schema2_import_storage.py
+++ b/dae/dae/impala_storage/schema2/schema2_import_storage.py
@@ -135,25 +135,28 @@ class Schema2ImportStorage(ImportStorage):
 
     def generate_import_task_graph(self, project) -> TaskGraph:
         graph = TaskGraph()
-        pedigree_task = graph.create_task("ped task", self._do_write_pedigree,
-                                          [project], [])
+        pedigree_task = graph.create_task(
+            "Generating Pedigree", self._do_write_pedigree, [project], []
+        )
 
         bucket_tasks = []
         for bucket in project.get_import_variants_buckets():
-            task = graph.create_task(f"Task {bucket}", self._do_write_variant,
-                                     [project, bucket], [])
+            task = graph.create_task(
+                "Converting Variants", self._do_write_variant,
+                [project, bucket], []
+            )
             bucket_tasks.append(task)
 
         if project.has_destination():
             hdfs_task = graph.create_task(
-                "hdfs copy", self._do_load_in_hdfs,
+                "Copying to HDFS", self._do_load_in_hdfs,
                 [project], [pedigree_task] + bucket_tasks)
 
             impala_task = graph.create_task(
-                "impala import", self._do_load_in_impala,
+                "Importing into Impala", self._do_load_in_impala,
                 [project, hdfs_task], [hdfs_task])
             graph.create_task(
-                "study config", self._do_study_config,
+                "Creating a study config", self._do_study_config,
                 [project], [impala_task])
 
         return graph

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -286,7 +286,9 @@ class ImportProject():
             genotype_storage_db = gpf_instance.genotype_storage_db
             storage_id = self.import_config.get("destination", {})\
                 .get("storage_id", None)
-            return genotype_storage_db.get_genotype_storage(storage_id)
+            if storage_id is not None:
+                return genotype_storage_db.get_genotype_storage(storage_id)
+            return genotype_storage_db.get_default_genotype_storage()
         # explicit storage config
         registry = GenotypeStorageRegistry()
         # FIXME: switch to using new storage configuration

--- a/dae/dae/import_tools/tests/resources/vcf_prefix/with_prefix.vcf
+++ b/dae/dae/import_tools/tests/resources/vcf_prefix/with_prefix.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=EFF,Number=1,Type=String,Description="Effect">
+##INFO=<ID=INH,Number=1,Type=String,Description="Inheritance">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	m1	d1	c1	c2
+chr1	10	.	C	T,A	.	.	EFF=SYN!MIS;INH=MIX	GT	0/0	0/1	0/1	0/2
+chr1	11	.	C	T,A	.	.	EFF=SYN!MIS;INH=UKN	GT	./.	./.	./.	./.
+chr1	12	.	G	A,T	.	.	EFF=SYN!MIS;INH=MIX	GT	0/0	0/0	./.	0/0
+chr1	13	.	C	T,A	.	.	EFF=SYN!MIS;INH=DEN	GT	0/0	0/0	0/1	0/0
+chr1	14	.	A	G,T	.	.	EFF=SYN!MIS;INH=OMI	GT	1/1	0/0	0/1	0/0
+chr1	15	.	G	A,T	.	.	EFF=SYN!MIS;INH=MIX	GT	1/0	0/0	0/.	0/2
+chr1	16	.	T	C,A	.	.	EFF=SYN!MIS;INH=OMI	GT	1/1	2/2	1/1	2/2

--- a/dae/dae/import_tools/tests/resources/vcf_prefix/without_prefix.vcf
+++ b/dae/dae/import_tools/tests/resources/vcf_prefix/without_prefix.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=EFF,Number=1,Type=String,Description="Effect">
+##INFO=<ID=INH,Number=1,Type=String,Description="Inheritance">
+##contig=<ID=1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	m1	d1	c1	c2
+1	10	.	C	T,A	.	.	EFF=SYN!MIS;INH=MIX	GT	0/0	0/1	0/1	0/2
+1	11	.	C	T,A	.	.	EFF=SYN!MIS;INH=UKN	GT	./.	./.	./.	./.
+1	12	.	G	A,T	.	.	EFF=SYN!MIS;INH=MIX	GT	0/0	0/0	./.	0/0
+1	13	.	C	T,A	.	.	EFF=SYN!MIS;INH=DEN	GT	0/0	0/0	0/1	0/0
+1	14	.	A	G,T	.	.	EFF=SYN!MIS;INH=OMI	GT	1/1	0/0	0/1	0/0
+1	15	.	G	A,T	.	.	EFF=SYN!MIS;INH=MIX	GT	1/0	0/0	0/.	0/2
+1	16	.	T	C,A	.	.	EFF=SYN!MIS;INH=OMI	GT	1/1	2/2	1/1	2/2

--- a/dae/dae/import_tools/tests/test_import_configs.py
+++ b/dae/dae/import_tools/tests/test_import_configs.py
@@ -226,7 +226,8 @@ def test_get_genotype_storage_no_explicit_config():
     assert genotype_storage is not None
     assert (
         genotype_storage.storage_id
-        == project.get_gpf_instance().genotype_storage_db.default_storage_id
+        == project.get_gpf_instance().genotype_storage_db
+        .get_default_genotype_storage().storage_id
     )
 
 

--- a/dae/dae/import_tools/tests/test_import_configs.py
+++ b/dae/dae/import_tools/tests/test_import_configs.py
@@ -228,3 +228,39 @@ def test_get_genotype_storage_no_explicit_config():
         genotype_storage.storage_id
         == project.get_gpf_instance().genotype_storage_db.default_storage_id
     )
+
+
+def test_add_chrom_prefix_already_present(resources_dir):
+    config = {
+        "id": "test_import",
+        "input": {
+            "pedigree": {
+                "file": f"{resources_dir}/vcf_import/multivcf.ped",
+            },
+            "vcf": {
+                "files": [f"{resources_dir}/vcf_prefix/with_prefix.vcf"],
+                "add_chrom_prefix": "chr",
+            }
+        }
+    }
+    project = import_tools.ImportProject.build_from_config(config)
+    with pytest.raises(ValueError):
+        project._get_variant_loader("vcf")
+
+
+def test_del_chrom_prefix_already_deleted(resources_dir):
+    config = {
+        "id": "test_import",
+        "input": {
+            "pedigree": {
+                "file": f"{resources_dir}/vcf_import/multivcf.ped",
+            },
+            "vcf": {
+                "files": [f"{resources_dir}/vcf_prefix/without_prefix.vcf"],
+                "del_chrom_prefix": "chr",
+            }
+        }
+    }
+    project = import_tools.ImportProject.build_from_config(config)
+    with pytest.raises(ValueError):
+        project._get_variant_loader("vcf")

--- a/dae/dae/import_tools/tests/test_import_configs.py
+++ b/dae/dae/import_tools/tests/test_import_configs.py
@@ -214,3 +214,17 @@ def test_project_input_dir(input_dir):
     )
     project = import_tools.ImportProject.build_from_config(config, "/dir")
     assert project.input_dir == os.path.join("/dir", input_dir)
+
+
+def test_get_genotype_storage_no_explicit_config():
+    config = dict(
+        id="test_import",
+        input={},
+    )
+    project = import_tools.ImportProject.build_from_config(config)
+    genotype_storage = project.get_genotype_storage()
+    assert genotype_storage is not None
+    assert (
+        genotype_storage.storage_id
+        == project.get_gpf_instance().genotype_storage_db.default_storage_id
+    )

--- a/dae/dae/import_tools/tests/test_task_graph.py
+++ b/dae/dae/import_tools/tests/test_task_graph.py
@@ -23,60 +23,45 @@ def executor(threaded_client, request):
     return SequentialExecutor()
 
 
-class Worker:
-    # NOTE these tests should not run in parallel
-    EXEC_ORDER: list[str] = []
-
-    @classmethod
-    def do_work(cls, name, timeout):
-        if timeout != 0:
-            time.sleep(timeout)
-        cls.EXEC_ORDER.append(name)
-
-    @classmethod
-    def assign_to_execution_order(cls, list_obj):
-        cls.EXEC_ORDER.extend(list_obj)
+def do_work(timeout):
+    if timeout != 0:
+        time.sleep(timeout)
 
 
-@pytest.fixture
-def worker():
-    Worker.EXEC_ORDER = []
-    return Worker()
-
-
-def test_dependancy_chain(executor, worker):
+def test_dependancy_chain(executor):
     graph = TaskGraph()
-    task_1 = graph.create_task("Task 1", worker.do_work, ["task_1", 0.01], [])
-    graph.create_task("Task 1", worker.do_work, ["task_2", 0], [task_1])
+    task_1 = graph.create_task("Task 1", do_work, [0.01], [])
+    graph.create_task("Task 2", do_work, [0], [task_1])
 
-    executor.execute(graph)
+    tasks_in_finish_order = list(executor.execute(graph))
+    names_in_finish_order = [task.name for task in tasks_in_finish_order]
+    assert names_in_finish_order == ["Task 1", "Task 2"]
 
-    assert worker.EXEC_ORDER == ["task_1", "task_2"]
 
-
-def test_multiple_dependancies(executor, worker):
+def test_multiple_dependancies(executor):
     graph = TaskGraph()
 
     tasks = []
     for i in range(10):
-        task = graph.create_task(
-            f"Task {i}", worker.do_work, [f"task_{i}", 0], []
-        )
+        task = graph.create_task(f"Task {i}", do_work, [0], [])
         tasks.append(task)
 
     for i in range(100, 105):
-        graph.create_task(f"Task {i}", worker.do_work, [f"task_{i}", 0], tasks)
+        graph.create_task(f"Task {i}", do_work, [0], tasks)
 
-    executor.execute(graph)
+    tasks_in_finish_order = list(executor.execute(graph))
+    names_in_finish_order = [task.name for task in tasks_in_finish_order]
 
-    assert len(worker.EXEC_ORDER) == 15
-    assert set(worker.EXEC_ORDER[:10]) == set(f"task_{i}" for i in range(10))
-    assert set(worker.EXEC_ORDER[10:]) == set(
-        f"task_{i}" for i in range(100, 105)
+    assert len(names_in_finish_order) == 15
+    assert set(names_in_finish_order[:10]) == set(
+        f"Task {i}" for i in range(10)
+    )
+    assert set(names_in_finish_order[10:]) == set(
+        f"Task {i}" for i in range(100, 105)
     )
 
 
-def test_implicit_dependancies(executor, worker):
+def test_implicit_dependancies(executor):
     graph = TaskGraph()
 
     def add_to_list(what, where):
@@ -87,8 +72,37 @@ def test_implicit_dependancies(executor, worker):
     for i in range(1, 8):
         last_task = graph.create_task(f"{i}", add_to_list, [i, last_task], [])
 
-    graph.create_task("8", worker.assign_to_execution_order, [last_task], [])
+    graph.create_task("8", add_to_list, [8, last_task], [])
 
-    executor.execute(graph)
+    tasks_in_finish_order = list(executor.execute(graph))
+    names_in_finish_order = [task.name for task in tasks_in_finish_order]
 
-    assert worker.EXEC_ORDER == list(range(8))
+    assert names_in_finish_order == [f"{i}" for i in range(9)]
+
+
+def test_active_tasks(executor):
+    def noop():
+        pass
+
+    graph = TaskGraph()
+    first_task = graph.create_task("First", noop, [], [])
+    second_layer_tasks = [
+        graph.create_task("Second", noop, [], [first_task])
+        for _ in range(10)
+    ]
+    third_task = graph.create_task("Third", noop, [], second_layer_tasks)
+    final_task = graph.create_task("Fourth", noop, [], [third_task])
+
+    tasks_as_complete = executor.execute(graph)
+    assert executor.get_active_tasks() == [first_task]
+    assert next(tasks_as_complete) is first_task
+
+    for _ in range(10):
+        assert set(executor.get_active_tasks()).issubset(second_layer_tasks)
+        assert next(tasks_as_complete) in second_layer_tasks
+    assert executor.get_active_tasks() == [third_task]
+
+    assert next(tasks_as_complete) is third_task
+    assert executor.get_active_tasks() == [final_task]
+    assert next(tasks_as_complete) is final_task
+    assert len(executor.get_active_tasks()) == 0

--- a/dae/dae/variants_loaders/cnv/flexible_cnv_loader.py
+++ b/dae/dae/variants_loaders/cnv/flexible_cnv_loader.py
@@ -5,11 +5,9 @@ from typing import Callable, List, Optional, Dict, Any, Tuple, \
 
 import numpy as np
 
-from dae.utils.regions import Region
 from dae.utils.variant_utils import get_interval_locus_ploidy
 
 from dae.variants_loaders.raw.flexible_variant_loader import \
-    adjust_chrom_prefix, \
     flexible_variant_loader
 
 from dae.variants.core import Allele
@@ -318,7 +316,6 @@ def flexible_cnv_loader(
         filepath_or_buffer: Union[str, Path, TextIO],
         families: FamiliesData,
         genome: ReferenceGenome,
-        regions: List[Region],
         cnv_chrom: Optional[str] = None,
         cnv_start: Optional[str] = None,
         cnv_end: Optional[str] = None,
@@ -330,8 +327,6 @@ def flexible_cnv_loader(
         cnv_plus_values: Optional[List[str]] = None,
         cnv_minus_values: Optional[List[str]] = None,
         cnv_sep: str = "\t",
-        add_chrom_prefix: Optional[str] = None,
-        del_chrom_prefix: Optional[str] = None,
         **_kwargs) -> Generator[Dict[str, Any], None, None]:
     """Load variants from CNVs input and transform them into DataFrames.
 
@@ -368,19 +363,10 @@ def flexible_cnv_loader(
             cnv_plus_values,
             cnv_minus_values)
 
-        transformers.append(adjust_chrom_prefix(
-            add_chrom_prefix, del_chrom_prefix))
-
-        def regions_filter(rec):
-            if len(regions) == 0:
-                return True
-            chrom = rec["chrom"]
-            pos = rec["pos"]
-            return any(r.isin(chrom, pos) for r in regions)
-
         variant_generator = flexible_variant_loader(
             infile, header, line_splitter, transformers,
-            filters=[regions_filter])
+            filters=[]
+        )
 
         for record in variant_generator:
             yield record

--- a/dae/dae/variants_loaders/cnv/tests/test_cnv_transformers_and_flexible_loader.py
+++ b/dae/dae/variants_loaders/cnv/tests/test_cnv_transformers_and_flexible_loader.py
@@ -3,7 +3,6 @@ import io
 import textwrap
 import pytest
 
-from dae.utils.regions import Region
 from dae.utils.variant_utils import mat2str
 from dae.variants.core import Allele
 
@@ -270,24 +269,3 @@ def test_cnv_loader_simple(families, cnv_dae, gpf_instance_2013):
         regions=[])
     result = list(generator)
     assert len(result) == 4
-
-
-@pytest.mark.parametrize(
-    "regions,expected", [
-        ([], 4),
-        (["1"], 2),
-        (["X"], 2),
-        (["1", "X"], 4),
-        (["3"], 0),
-    ]
-)
-def test_cnv_loader_with_regions(
-        families, cnv_dae, gpf_instance_2013, regions, expected):
-
-    regions_list = [Region.from_str(r) for r in regions]
-
-    generator = flexible_cnv_loader(
-        cnv_dae, families, gpf_instance_2013.reference_genome,
-        regions=regions_list)
-    result = list(generator)
-    assert len(result) == expected

--- a/dae/dae/variants_loaders/cnv/tests/test_flexible_cnv_loader.py
+++ b/dae/dae/variants_loaders/cnv/tests/test_flexible_cnv_loader.py
@@ -225,6 +225,6 @@ def test_flexible_cnv_variants_bad_configs(header, params, families, genome):
                 content,
                 families,
                 genome,
-                [],
+                regions=[],
                 **params)
         )

--- a/dae/dae/variants_loaders/raw/loader.py
+++ b/dae/dae/variants_loaders/raw/loader.py
@@ -815,16 +815,17 @@ class VariantsGenotypesLoader(VariantsLoader):
         return genotype, genetic_model
 
     def _add_chrom_prefix(self, chrom):
+        # there is an important invariant between this and _del_chrom_prefix
+        # we don't know if this or _del_chrom_prefix will be executed first so
+        # _add_chrom_prefix should undo _del_chrom_prefix
+        # _del_chrom_prefix should undo _add_chrom_prefix
         assert self._chrom_prefix is not None
-        if chrom is not None and not chrom.startswith(self._chrom_prefix):
-            return f"{self._chrom_prefix}{chrom}"
-        return chrom
+        return f"{self._chrom_prefix}{chrom}"
 
     def _del_chrom_prefix(self, chrom):
         assert self._chrom_prefix is not None
-        if chrom is not None and chrom.startswith(self._chrom_prefix):
-            return chrom[len(self._chrom_prefix):]
-        return chrom
+        assert chrom.startswith(self._chrom_prefix)
+        return chrom[len(self._chrom_prefix):]
 
     def full_variants_iterator(
         self,


### PR DESCRIPTION
## Background

This PR is basically polishing of the import-tools functionality.

## Aim

The changes are: 
 * Log the current stage when running import-tools
 * Minor fixes to the documentation.
 * Error with a nice message if `add_chrom_prefix` (or `del_chrom_prefix`) is set for an set of variants that already have prefix added or removed. This makes working with import-tools a less error prone activity.