### PR TITLE
Fix initialisation of genomic scores db from annotation pipeline.

### DIFF
--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -170,11 +170,9 @@ class GPFInstance:
                     continue
 
                 for field_name in schema.public_fields:
-                    field = schema[field_name]
-                    score_name = field.source.attribute_config["source"]
-                    scores.append((resource_id, score_name))
+                    scores.append((resource_id, field_name))
 
-        if self.dae_config.genomic_scores_db is not None:
+        elif self.dae_config.genomic_scores_db is not None:
             for score_def in self.dae_config.genomic_scores_db:
                 scores.append((score_def["resource"], score_def["score"]))
 
@@ -484,7 +482,6 @@ class GPFInstance:
     def get_annotation_pipeline(self):
         """Return the annotation pipeline configured in the GPF instance."""
         if self._annotation_pipeline is None:
-
             if self.dae_config.annotation is None:
                 self._annotation_pipeline = build_annotation_pipeline(
                     [], grr_repository=self.grr)

--- a/dae/dae/testing/setup_helpers.py
+++ b/dae/dae/testing/setup_helpers.py
@@ -132,7 +132,8 @@ def setup_gpf_instance(
         reference_genome=None, gene_models=None,
         grr=None):
     """Set up a GPF instance using prebuild genome, gene models, etc."""
-    setup_directories(out_path, {"gpf_instance.yaml": ""})
+    if not (out_path / "gpf_instance.yaml").exists():
+        setup_directories(out_path, {"gpf_instance.yaml": ""})
     # pylint: disable=import-outside-toplevel
     from dae.gpf_instance import GPFInstance
     return GPFInstance(


### PR DESCRIPTION
Closes #243.

## Background

When a GPFInstance has an annotation configuration the initialization of genomic scores DB throws an exception.

## Aim

Fix the initialization of genomic scores DB from the annotation pipeline.

## Implementation

A test to check initialization from an annotation pipeline is added, and the initialization of genomic scores DB is fixed.