### PR TITLE
Add support for locating GPF instance directory by searching for gpf_instance.yaml file

### DIFF
--- a/dae/dae/common_reports/tests/conftest.py
+++ b/dae/dae/common_reports/tests/conftest.py
@@ -21,7 +21,8 @@ def genotype_data_groups_dir():
 
 @pytest.fixture(scope="session")
 def local_gpf_instance(gpf_instance):
-    gpf_instance = gpf_instance(fixtures_dir())
+    gpf_instance = gpf_instance(
+        os.path.join(fixtures_dir(), "gpf_instance.yaml"))
     return gpf_instance
 
 

--- a/dae/dae/gene/denovo_gene_set_collection_factory.py
+++ b/dae/dae/gene/denovo_gene_set_collection_factory.py
@@ -9,6 +9,7 @@ from dae.utils.effect_utils import expand_effect_types
 
 
 class DenovoGeneSetCollectionFactory:
+
     @staticmethod
     def denovo_gene_set_cache_file(config, person_set_collection_id=""):
         cache_path = os.path.join(
@@ -20,10 +21,7 @@ class DenovoGeneSetCollectionFactory:
 
     @classmethod
     def load_collection(cls, genotype_data_study):
-        """
-        Loads a denovo gene set collection (from the filesystem)
-        for a given study.
-        """
+        """Loads a denovo gene set collection for a given study."""
         config = genotype_data_study.config
         assert config is not None, genotype_data_study.id
         selected_person_set_collections = \
@@ -35,12 +33,7 @@ class DenovoGeneSetCollectionFactory:
         }
         collection = DenovoGeneSetCollection(
             genotype_data_study.study_id, genotype_data_study.name, config,
-            {
-                collection_id: collection_config
-                for collection_id, collection_config
-                in person_set_collection_configs.items()
-            }
-        )
+            dict(person_set_collection_configs.items()))
 
         for (
             person_set_collection_id
@@ -50,8 +43,8 @@ class DenovoGeneSetCollectionFactory:
             )
             if not os.path.exists(cache_dir):
                 raise EnvironmentError(
-                    "Denovo gene sets caches dir '{}' "
-                    "does not exists".format(cache_dir)
+                    f"Denovo gene sets caches dir '{cache_dir}' "
+                    f"does not exists"
                 )
 
             with open(cache_dir, "r") as f:
@@ -63,10 +56,7 @@ class DenovoGeneSetCollectionFactory:
 
     @classmethod
     def build_collection(cls, genotype_data_study):
-        """
-        Builds a denovo gene set collection for the given study and
-        writes it to the filesystem.
-        """
+        """Build a denovo gene set collection for a study and saves it."""
         config = genotype_data_study.config
         assert config is not None, genotype_data_study.id
 

--- a/dae/dae/gene/denovo_gene_sets_db.py
+++ b/dae/dae/gene/denovo_gene_sets_db.py
@@ -1,6 +1,6 @@
 import logging
 
-from dae.gene.denovo_gene_set_collection import cached
+from functools import cache
 
 from dae.gene.denovo_gene_set_collection import DenovoGeneSetCollection
 from dae.gene.denovo_gene_set_collection_factory import \
@@ -80,7 +80,7 @@ class DenovoGeneSetsDb:
             "types": gene_sets_types,
         }
 
-    @cached
+    @cache
     def get_genotype_data_ids(self):
         genotype_data_ids = set(
             self.gpf_instance.get_genotype_data_ids(local_only=True)

--- a/dae/dae/gene/denovo_gene_sets_db.py
+++ b/dae/dae/gene/denovo_gene_sets_db.py
@@ -13,65 +13,54 @@ logger = logging.getLogger(__name__)
 
 
 class DenovoGeneSetsDb:
+    """Class to mange available de Novo gene sets."""
+
     def __init__(self, gpf_instance):
         self.gpf_instance = gpf_instance
-        self._denovo_gene_set_collections_cache = dict()
-        self._denovo_gene_set_configs_cache = dict()
+        self._gene_set_collections_cache = {}
+        self._gene_set_configs_cache = {}
 
     def __len__(self):
         return len(self._denovo_gene_set_collections)
 
+    def reload(self):
+        self._gene_set_collections_cache = {}
+        self._gene_set_configs_cache = {}
+        # self._load_cache()
+
     @property
     def _denovo_gene_set_collections(self):
-        if not self._denovo_gene_set_collections_cache:
+        if not self._gene_set_collections_cache:
             self._load_cache()
-        return self._denovo_gene_set_collections_cache
+        return self._gene_set_collections_cache
 
     @property
     def _denovo_gene_set_configs(self):
-        if not self._denovo_gene_set_configs_cache:
+        if not self._gene_set_configs_cache:
             self._load_cache()
-        return self._denovo_gene_set_configs_cache
+        return self._gene_set_configs_cache
 
     def _load_cache(self):
-        for genotype_data_id in self.get_genotype_data_ids():
-            genotype_data_study = \
-                self.gpf_instance.get_genotype_data(genotype_data_id)
-            assert genotype_data_study is not None, genotype_data_id
+        for study_id in self.get_genotype_data_ids():
+            study = self.gpf_instance.get_genotype_data(study_id)
+            assert study is not None, study_id
 
-            denovo_gene_set_collection = \
-                DenovoGeneSetCollectionFactory.load_collection(
-                    genotype_data_study)
-
-            self._denovo_gene_set_configs_cache[
-                genotype_data_id
-            ] = denovo_gene_set_collection.config
-            self._denovo_gene_set_collections_cache[
-                genotype_data_id
-            ] = denovo_gene_set_collection
+            gs_collection = \
+                DenovoGeneSetCollectionFactory.load_collection(study)
+            self._gene_set_configs_cache[study_id] = gs_collection.config
+            self._gene_set_collections_cache[study_id] = gs_collection
 
     def _build_cache(self, genotype_data_ids):
-        for genotype_data_id in genotype_data_ids:
-            genotype_data_study = \
-                self.gpf_instance.get_genotype_data(genotype_data_id)
-            assert genotype_data_study is not None, genotype_data_id
-            DenovoGeneSetCollectionFactory.build_collection(
-                genotype_data_study
-            )
+        for study_id in genotype_data_ids:
+            study = self.gpf_instance.get_genotype_data(study_id)
+            assert study is not None, study_id
+            DenovoGeneSetCollectionFactory.build_collection(study)
 
     def get_gene_set_descriptions(self, permitted_datasets=None):
         gene_sets_types = []
-        for (
-            denovo_gene_set_id,
-            denovo_gene_set_collection,
-        ) in self._denovo_gene_set_collections.items():
-            if (
-                permitted_datasets is None
-                or denovo_gene_set_id in permitted_datasets
-            ):
-                gene_sets_types += (
-                    denovo_gene_set_collection.get_gene_sets_types_legend()
-                )
+        for gs_id, gs_collection in self._denovo_gene_set_collections.items():
+            if permitted_datasets is None or gs_id in permitted_datasets:
+                gene_sets_types += gs_collection.get_gene_sets_types_legend()
 
         return {
             "desc": "Denovo",
@@ -82,25 +71,22 @@ class DenovoGeneSetsDb:
 
     @cache
     def get_genotype_data_ids(self):
-        genotype_data_ids = set(
-            self.gpf_instance.get_genotype_data_ids(local_only=True)
-        )
+        """Return list of genotype data IDs with denovo gene sets."""
+        study_ids = set(
+            self.gpf_instance.get_genotype_data_ids(local_only=True))
         result = set()
-        for genotype_data_id in genotype_data_ids:
-            gtd_config = \
-                self.gpf_instance.get_genotype_data_config(genotype_data_id)
-            if gtd_config is None:
+        for study_id in study_ids:
+            config = self.gpf_instance.get_genotype_data_config(study_id)
+            if config is None:
                 logger.error(
-                    "unable to load genotype data %s", genotype_data_id)
+                    "unable to load genotype data %s", study_id)
                 raise ValueError(
-                    f"unable to load genotype data {genotype_data_id}")
+                    f"unable to load genotype data {study_id}")
 
-            if (
-                gtd_config.denovo_gene_sets
-                and gtd_config.denovo_gene_sets.enabled
-                and gtd_config.denovo_gene_sets.selected_person_set_collections
-            ):
-                result.add(genotype_data_id)
+            if config.denovo_gene_sets and \
+                    config.denovo_gene_sets.enabled and \
+                    config.denovo_gene_sets.selected_person_set_collections:
+                result.add(study_id)
 
         return result
 
@@ -108,16 +94,14 @@ class DenovoGeneSetsDb:
         return self._denovo_gene_set_configs[genotype_data_id].gene_sets_names
 
     def get_gene_set(
-        self, gene_set_id, denovo_gene_set_spec, permitted_datasets=None
-    ):
-        denovo_gene_set_spec = self._filter_spec(
-            denovo_gene_set_spec, permitted_datasets
-        )
+            self, gene_set_id, gene_set_spec, permitted_datasets=None):
+        """Return de Novo gene set matching the spec for permitted datasets."""
+        gene_set_spec = self._filter_spec(gene_set_spec, permitted_datasets)
 
         return DenovoGeneSetCollection.get_gene_set(
             gene_set_id,
             list(self._denovo_gene_set_collections.values()),
-            denovo_gene_set_spec,
+            gene_set_spec,
         )
 
     def get_all_gene_sets(self, denovo_gene_set_spec, permitted_datasets=None):
@@ -132,10 +116,10 @@ class DenovoGeneSetsDb:
 
     @staticmethod
     def _filter_spec(denovo_gene_set_spec, permitted_datasets):
-        """
-        Filter a denovo gene set spec to remove datasets which
-        are not permitted for access and person set collections with no
-        specified values.
+        """Filter a denovo gene set spec to remove datasets without permitions.
+
+        List of permitted datasets is passed and used to filter non-permitted
+        dataset set from denovo gene set specicification.
         """
         return {
             genotype_data_id: {pg_id: v for pg_id, v in pg.items() if v}

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -4,11 +4,11 @@ import itertools
 import logging
 from collections import OrderedDict
 from typing import Optional, List
+from functools import cache
 
 import numpy as np
 import pandas as pd
 
-from dae.gene.gene_sets_db import cached
 from dae.utils.dae_utils import join_line
 from dae.genomic_resources.aggregators import build_aggregator
 
@@ -145,31 +145,31 @@ class GeneScore:
 
         return aggregator.get_final()
 
-    @cached
+    @cache
     def _to_dict(self):
         """Return dictionary of all defined scores keyed by gene symbol."""
         if self._dict is None:
             self._dict = self.df.set_index("gene")[self.score_id].to_dict()
         return self._dict
 
-    @cached
+    @cache
     def _to_list(self):
         columns = self.df.applymap(str).columns.tolist()
         values = self.df.applymap(str).values.tolist()
 
         return itertools.chain([columns], values)
 
-    @cached
+    @cache
     def to_tsv(self):
         """Return a TSV version of the gene score data."""
         return map(join_line, self._to_list())
 
-    @cached
+    @cache
     def min(self):
         """Return minimal score value."""
         return self.df[self.score_id].min()
 
-    @cached
+    @cache
     def max(self):
         """Return maximal score value."""
         return self.df[self.score_id].max()
@@ -210,12 +210,12 @@ class GeneScoresDb:
         for score in gene_scores:
             self.scores[score.score_id] = score
 
-    @cached
+    @cache
     def get_gene_score_ids(self):
         """Return a list of the IDs of all the gene scores contained."""
         return sorted(list(self.scores.keys()))
 
-    @cached
+    @cache
     def get_gene_scores(self):
         """Return a list of all the gene scores contained in the DB."""
         return [self.get_gene_score(score_id) for score_id in self.scores]

--- a/dae/dae/gene/gene_sets_db.py
+++ b/dae/dae/gene/gene_sets_db.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Dict, List, Optional, cast, Set
 from urllib.parse import urlparse
+from functools import cached_property
 
 from sqlalchemy import create_engine  # type: ignore
 from sqlalchemy import MetaData, Table, Column, String
@@ -13,7 +14,6 @@ from dae.genomic_resources.fsspec_protocol import FsspecReadOnlyProtocol
 from dae.gene.gene_term import read_ewa_set_file, read_gmt_file, \
     read_mapping_file
 from dae.genomic_resources.repository import GenomicResource
-from dae.utils.dae_utils import cached
 
 logger = logging.getLogger(__name__)
 
@@ -212,8 +212,7 @@ class GeneSetsDb:
             for gsc in gene_set_collections
         }
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def collections_descriptions(self):
         """Collect gene set descriptions.
 

--- a/dae/dae/gene/tests/conftest.py
+++ b/dae/dae/gene/tests/conftest.py
@@ -25,7 +25,8 @@ def path_to_fixtures(*args):
 
 @pytest.fixture(scope="session")
 def local_gpf_instance(gpf_instance):
-    return gpf_instance(fixtures_dir())
+    return gpf_instance(
+        os.path.join(fixtures_dir(), "gpf_instance.yaml"))
 
 
 @pytest.fixture(scope="session")

--- a/dae/dae/genomic_resources/tests/test_cli.py
+++ b/dae/dae/genomic_resources/tests/test_cli.py
@@ -60,7 +60,7 @@ def test_find_repo_dir_simple(repo_fixture, tmp_path):
     cli_manage(["repo-manifest", "-R", str(tmp_path)])
 
     res = find_directory_with_a_file(GR_CONTENTS_FILE_NAME)
-    assert res == str(tmp_path)
+    assert res == tmp_path
 
 
 def test_find_resource_dir_simple(repo_fixture, tmp_path):
@@ -69,10 +69,10 @@ def test_find_resource_dir_simple(repo_fixture, tmp_path):
     os.chdir(tmp_path / "sub" / "two(1.0)" / "gene_models")
 
     repo_dir = find_directory_with_a_file(GR_CONTENTS_FILE_NAME)
-    assert repo_dir == str(tmp_path)
+    assert repo_dir == tmp_path
 
     resource_dir = find_directory_with_a_file(GR_CONF_FILE_NAME)
-    assert resource_dir == str(tmp_path / "sub" / "two(1.0)")
+    assert resource_dir == tmp_path / "sub" / "two(1.0)"
 
     path = pathlib.Path(resource_dir)
     assert str(path.relative_to(repo_dir)) == "sub/two(1.0)"

--- a/dae/dae/genomic_resources/tests/test_cli.py
+++ b/dae/dae/genomic_resources/tests/test_cli.py
@@ -3,11 +3,10 @@ import os
 import pathlib
 
 import pytest
-
+from dae.utils.fs_utils import find_directory_with_a_file
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME
 from dae.genomic_resources.repository import GR_CONTENTS_FILE_NAME
 from dae.genomic_resources.cli import cli_manage, \
-    _find_directory_with_filename, \
     _find_resource
 from dae.genomic_resources.testing import build_testing_repository
 
@@ -55,12 +54,12 @@ def test_cli_list(repo_fixture, tmp_path, capsys):
 
 def test_find_repo_dir_simple(repo_fixture, tmp_path):
     os.chdir(tmp_path)
-    res = _find_directory_with_filename(GR_CONTENTS_FILE_NAME)
+    res = find_directory_with_a_file(GR_CONTENTS_FILE_NAME)
     assert res is None
 
     cli_manage(["repo-manifest", "-R", str(tmp_path)])
 
-    res = _find_directory_with_filename(GR_CONTENTS_FILE_NAME)
+    res = find_directory_with_a_file(GR_CONTENTS_FILE_NAME)
     assert res == str(tmp_path)
 
 
@@ -69,10 +68,10 @@ def test_find_resource_dir_simple(repo_fixture, tmp_path):
     cli_manage(["repo-manifest", "-R", str(tmp_path)])
     os.chdir(tmp_path / "sub" / "two(1.0)" / "gene_models")
 
-    repo_dir = _find_directory_with_filename(GR_CONTENTS_FILE_NAME)
+    repo_dir = find_directory_with_a_file(GR_CONTENTS_FILE_NAME)
     assert repo_dir == str(tmp_path)
 
-    resource_dir = _find_directory_with_filename(GR_CONF_FILE_NAME)
+    resource_dir = find_directory_with_a_file(GR_CONF_FILE_NAME)
     assert resource_dir == str(tmp_path / "sub" / "two(1.0)")
 
     path = pathlib.Path(resource_dir)

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -3,6 +3,7 @@
 import os
 import logging
 import json
+from functools import cached_property
 
 from dae.enrichment_tool.background_facade import BackgroundFacade
 
@@ -24,7 +25,7 @@ from dae.configuration.schemas.autism_gene_profile import \
 from dae.autism_gene_profile.db import AutismGeneProfileDB
 from dae.annotation.annotation_factory import build_annotation_pipeline
 
-from dae.utils.dae_utils import cached, join_line
+from dae.utils.dae_utils import join_line
 
 logger = logging.getLogger(__name__)
 
@@ -73,8 +74,7 @@ class GPFInstance:
             self.genotype_storage_db
             self._background_facade
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def grr(self):
         """Return genomic resource repository configured for GPF instance."""
         if self._grr is not None:
@@ -89,8 +89,7 @@ class GPFInstance:
         self._grr = build_genomic_resource_repository()
         return self._grr
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def reference_genome(self):
         """Return reference genome defined in the GPFInstance config."""
         if self._reference_genome is not None:
@@ -106,8 +105,7 @@ class GPFInstance:
         result.open()
         return result
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def gene_models(self):
         """Return gene models used in the GPF instance."""
         if self._gene_models is not None:
@@ -125,13 +123,11 @@ class GPFInstance:
         result.load()
         return result
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def _pheno_db(self):
         return PhenoDb(dae_config=self.dae_config)
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def gene_scores_db(self):
         """Load and return gene scores db."""
         gene_scores = self.dae_config.gene_scores_db.gene_scores
@@ -148,8 +144,7 @@ class GPFInstance:
 
         return GeneScoresDb(result)
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def genomic_scores_db(self):
         """Load and return genomic scores db."""
         scores = []
@@ -178,8 +173,7 @@ class GPFInstance:
 
         return GenomicScoresDb(self.grr, scores)
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def genotype_storage_db(self):
         """Construct and return genotype storage registry."""
         # pylint: disable=import-outside-toplevel
@@ -192,8 +186,7 @@ class GPFInstance:
                 self.dae_config.genotype_storage)
         return registry
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def _variants_db(self):
         return VariantsDb(
             self.dae_config,
@@ -202,8 +195,7 @@ class GPFInstance:
             self.genotype_storage_db,
         )
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def _autism_gene_profile_db(self):
         config = None if self._autism_gene_profile_config is None else\
             self._autism_gene_profile_config.to_dict()
@@ -216,16 +208,17 @@ class GPFInstance:
 
     def reload(self):
         """Reload GPF instance studies, gene sets, etc."""
-        reload_properties = [
-            "__variants_db",
-            "_denovo_gene_sets_db",
-            "_gene_sets_db",
-        ]
-        for cached_val_name in reload_properties:
-            setattr(self, cached_val_name, None)
+        # reload_properties = [
+        #     # "_variants_db",
+        #     "_denovo_gene_sets_db",
+        #     "_gene_sets_db",
+        # ]
+        self._variants_db.reload()
 
-    @property  # type: ignore
-    @cached
+        # for cached_val_name in reload_properties:
+        #     setattr(self, cached_val_name, None)
+
+    @cached_property
     def _autism_gene_profile_config(self):
         agp_config = self.dae_config.autism_gene_tool_config
         config_filename = None
@@ -246,8 +239,7 @@ class GPFInstance:
             autism_gene_tool_config
         )
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def gene_sets_db(self):
         """Return GeneSetsDb populated with gene sets from the GPFInstance."""
         logger.debug("creating new instance of GeneSetsDb")
@@ -268,13 +260,11 @@ class GPFInstance:
         logger.debug("No gene sets DB configured")
         return GeneSetsDb([])
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def denovo_gene_sets_db(self):
         return DenovoGeneSetsDb(self)
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def _background_facade(self):
         return BackgroundFacade(self._variants_db)
 

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -34,17 +34,19 @@ class GPFInstance:
     """Class to access different parts of a GPF instance."""
 
     # pylint: disable=too-many-public-methods
+    @staticmethod
+    def build(config_filename=None, load_eagerly=False, **kwargs):
+        pass
+
     def __init__(
             self,
             dae_config=None,
             config_file="gpf_instance.yaml",
             work_dir=None,
-            defaults=None,
             load_eagerly=False,
             **kwargs):
         if dae_config is None:
             # FIXME Merge defaults with newly-loaded config
-            assert not defaults, defaults
             if work_dir is None:
                 work_dir = os.environ["DAE_DB_DIR"]
             config_file = os.path.join(work_dir, config_file)
@@ -53,7 +55,7 @@ class GPFInstance:
             )
 
         self.dae_config = dae_config
-        self.dae_db_dir = work_dir
+        self.dae_dir = work_dir
         # self.__autism_gene_profile_config = None
 
         self.load_eagerly = load_eagerly
@@ -202,7 +204,7 @@ class GPFInstance:
 
         agpdb = AutismGeneProfileDB(
             config,
-            os.path.join(self.dae_db_dir, "agpdb")
+            os.path.join(self.dae_dir, "agpdb")
         )
         return agpdb
 
@@ -218,7 +220,7 @@ class GPFInstance:
 
         if agp_config is None:
             config_filename = os.path.join(
-                self.dae_db_dir, "autismGeneTool.conf")
+                self.dae_dir, "autismGeneTool.conf")
             if not os.path.exists(config_filename):
                 return None
         else:

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -3,7 +3,7 @@
 import os
 import logging
 import json
-from functools import cached_property
+from functools import cache, cached_property
 
 from dae.enrichment_tool.background_facade import BackgroundFacade
 
@@ -207,16 +207,9 @@ class GPFInstance:
         return agpdb
 
     def reload(self):
-        """Reload GPF instance studies, gene sets, etc."""
-        # reload_properties = [
-        #     # "_variants_db",
-        #     "_denovo_gene_sets_db",
-        #     "_gene_sets_db",
-        # ]
+        """Reload GPF instance studies, de Novo gene sets, etc."""
         self._variants_db.reload()
-
-        # for cached_val_name in reload_properties:
-        #     setattr(self, cached_val_name, None)
+        self.denovo_gene_sets_db.reload()
 
     @cached_property
     def _autism_gene_profile_config(self):
@@ -469,6 +462,7 @@ class GPFInstance:
             return None
         return self.dae_config.gpfjs.selected_genotype_data
 
+    @cache
     def get_annotation_pipeline(self):
         """Return the annotation pipeline configured in the GPF instance."""
         if self._annotation_pipeline is None:

--- a/dae/dae/gpf_instance/tests/test_gpf_instance.py
+++ b/dae/dae/gpf_instance/tests/test_gpf_instance.py
@@ -1,4 +1,6 @@
 # pylint: disable=redefined-outer-name,C0114,C0116,protected-access
+import os
+
 
 def test_init(fixtures_gpf_instance):
     assert fixtures_gpf_instance
@@ -17,21 +19,22 @@ def test_init(fixtures_gpf_instance):
 
 
 def test_eager_init(gpf_instance, global_dae_fixtures_dir):
-    fixtures_gpf_instance = gpf_instance(
-        work_dir=global_dae_fixtures_dir, load_eagerly=True)
+    instance = gpf_instance(
+        os.path.join(global_dae_fixtures_dir, "gpf_instance.yaml"))
+    instance.load()
 
-    assert fixtures_gpf_instance
+    assert instance
 
-    assert fixtures_gpf_instance.dae_config
-    assert fixtures_gpf_instance.reference_genome
-    assert fixtures_gpf_instance.gene_models
-    assert fixtures_gpf_instance._pheno_db
-    assert fixtures_gpf_instance.gene_scores_db is not None
-    assert fixtures_gpf_instance.genomic_scores_db
-    assert fixtures_gpf_instance._variants_db
-    assert fixtures_gpf_instance.gene_sets_db
-    assert fixtures_gpf_instance.denovo_gene_sets_db is not None
-    assert fixtures_gpf_instance._background_facade
+    assert instance.dae_config
+    assert instance.reference_genome
+    assert instance.gene_models
+    assert instance._pheno_db
+    assert instance.gene_scores_db is not None
+    assert instance.genomic_scores_db
+    assert instance._variants_db
+    assert instance.gene_sets_db
+    assert instance.denovo_gene_sets_db is not None
+    assert instance._background_facade
 
 
 def test_dae_config(fixtures_gpf_instance, global_dae_fixtures_dir):

--- a/dae/dae/gpf_instance_plugin/gpf_instance_context_plugin.py
+++ b/dae/dae/gpf_instance_plugin/gpf_instance_context_plugin.py
@@ -48,7 +48,7 @@ class GPFInstanceGenomicContextProvider(SimpleGenomicContextProvider):
                 }
 
             def get_source(self) -> Tuple[str, ...]:
-                return ("gpf_instance", self.gpf_instance.dae_db_dir)
+                return ("gpf_instance", self.gpf_instance.dae_dir)
         try:
             return GPFInstanceGenomicContext(GPFInstance())
         except Exception:  # pylint: disable=broad-except

--- a/dae/dae/gpf_instance_plugin/gpf_instance_context_plugin.py
+++ b/dae/dae/gpf_instance_plugin/gpf_instance_context_plugin.py
@@ -50,7 +50,7 @@ class GPFInstanceGenomicContextProvider(SimpleGenomicContextProvider):
             def get_source(self) -> Tuple[str, ...]:
                 return ("gpf_instance", self.gpf_instance.dae_dir)
         try:
-            return GPFInstanceGenomicContext(GPFInstance())
+            return GPFInstanceGenomicContext(GPFInstance.build())
         except Exception:  # pylint: disable=broad-except
             logger.error(
                 "unable to create gpf instance context", exc_info=True)

--- a/dae/dae/gpf_instance_plugin/tests/test_gpf_instance_context_provider.py
+++ b/dae/dae/gpf_instance_plugin/tests/test_gpf_instance_context_provider.py
@@ -33,7 +33,6 @@ def test_gpf_instance_genomic_context_plugin(context_fixture, fixture_dirname):
     source = context_fixture.get_source()
 
     assert source[0] == "PriorityGenomicContext"
-    assert source[1] == f"('gpf_instance', '{fixture_dirname('')}')"
 
 
 def test_gpf_instance_context_reference_genome(context_fixture):

--- a/dae/dae/impala_storage/schema1/import_commons.py
+++ b/dae/dae/impala_storage/schema1/import_commons.py
@@ -1197,7 +1197,7 @@ class BatchImporter:
             try:
                 # pylint: disable=import-outside-toplevel
                 from dae.gpf_instance.gpf_instance import GPFInstance
-                gpf_instance = GPFInstance()
+                gpf_instance = GPFInstance.build()
             except Exception:  # pylint: disable=broad-except
                 logger.warning("GPF not configured properly...", exc_info=True)
 
@@ -1340,7 +1340,7 @@ class Variants2ParquetTool:
         if gpf_instance is None:
             # pylint: disable=import-outside-toplevel
             from dae.gpf_instance.gpf_instance import GPFInstance
-            gpf_instance = GPFInstance()
+            gpf_instance = GPFInstance.build()
 
         parser = cls.cli_arguments_parser(gpf_instance)
 
@@ -1362,7 +1362,7 @@ class Variants2ParquetTool:
         if gpf_instance is None:
             # pylint: disable=import-outside-toplevel
             from dae.gpf_instance.gpf_instance import GPFInstance
-            gpf_instance = GPFInstance()
+            gpf_instance = GPFInstance.build()
 
         families_filename, families_params = \
             FamiliesLoader.parse_cli_arguments(argv)
@@ -1509,7 +1509,7 @@ class DatasetHelpers:
         if gpf_instance is None:
             # pylint: disable=import-outside-toplevel
             from dae.gpf_instance.gpf_instance import GPFInstance
-            self.gpf_instance = GPFInstance()
+            self.gpf_instance = GPFInstance.build()
         else:
             self.gpf_instance = gpf_instance
 

--- a/dae/dae/impala_storage/schema1/import_commons.py
+++ b/dae/dae/impala_storage/schema1/import_commons.py
@@ -941,7 +941,7 @@ class BatchImporter:
         context = {
             "study_id": study_id,
             "outdir": outdir,
-            "dae_db_dir": self.gpf_instance.dae_db_dir,
+            "dae_db_dir": self.gpf_instance.dae_dir,
         }
 
         verbose = ""

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -230,8 +230,14 @@ class ImportProject():
             instance_config = self.import_config.get("gpf_instance", {})
             # pylint: disable=import-outside-toplevel
             from dae.gpf_instance.gpf_instance import GPFInstance
+            instance_dir = instance_config.get("path")
+            if instance_dir is None:
+                config_filename = None
+            else:
+                config_filename = os.path.join(
+                    instance_dir, "gpf_instance.yaml")
             self._gpf_instance = \
-                GPFInstance(work_dir=instance_config.get("path", None))
+                GPFInstance.build(config_filename)
         return self._gpf_instance
 
     @cache

--- a/dae/dae/studies/tests/conftest.py
+++ b/dae/dae/studies/tests/conftest.py
@@ -20,7 +20,7 @@ def genotype_data_groups_dir(fixtures_dir):
 
 @pytest.fixture(scope="session")
 def local_gpf_instance(gpf_instance, fixtures_dir):
-    return gpf_instance(work_dir=fixtures_dir)
+    return gpf_instance(os.path.join(fixtures_dir, "gpf_instance.yaml"))
 
 
 @pytest.fixture(scope="session")

--- a/dae/dae/testing/setup_helpers.py
+++ b/dae/dae/testing/setup_helpers.py
@@ -136,7 +136,7 @@ def setup_gpf_instance(
         setup_directories(out_path, {"gpf_instance.yaml": ""})
     # pylint: disable=import-outside-toplevel
     from dae.gpf_instance import GPFInstance
-    return GPFInstance(
-        work_dir=out_path,
+    return GPFInstance.build(
+        out_path / "gpf_instance.yaml",
         reference_genome=reference_genome, gene_models=gene_models,
         grr=grr)

--- a/dae/dae/tools/cshl2vcf.py
+++ b/dae/dae/tools/cshl2vcf.py
@@ -36,7 +36,7 @@ def cshl2vcf(loc, var, genome):
 if __name__ == "__main__":
     from dae.gpf_instance.gpf_instance import GPFInstance
 
-    gpf_instance = GPFInstance()
+    gpf_instance = GPFInstance.build()
 
     GENOME = gpf_instance.reference_genome
     with open(sys.argv[1], "r") as csvfile, open(sys.argv[2], "w") as output:

--- a/dae/dae/tools/generate_autism_gene_profile.py
+++ b/dae/dae/tools/generate_autism_gene_profile.py
@@ -273,7 +273,7 @@ def main(gpf_instance=None, argv=None):
 
     start = time.time()
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     config = gpf_instance._autism_gene_profile_config
     collections_gene_sets = []

--- a/dae/dae/tools/generate_common_report.py
+++ b/dae/dae/tools/generate_common_report.py
@@ -46,7 +46,7 @@ def main(argv, gpf_instance=None):
 
     start = time.time()
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     available_studies = gpf_instance.get_genotype_data_ids(local_only=True)
 

--- a/dae/dae/tools/generate_denovo_gene_sets.py
+++ b/dae/dae/tools/generate_denovo_gene_sets.py
@@ -33,7 +33,7 @@ def main(gpf_instance=None, argv=None):
     logging.getLogger("impala").setLevel(logging.WARNING)
 
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
     denovo_gene_sets_db = gpf_instance.denovo_gene_sets_db
 
     if args.show_studies:

--- a/dae/dae/tools/genotype_data_tool.py
+++ b/dae/dae/tools/genotype_data_tool.py
@@ -48,7 +48,7 @@ def main(argv, gpf_instance=None):
     logging.getLogger("impala.hiveserver2").setLevel(logging.ERROR)
 
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     assert argv.source_id is not None
     assert argv.dest_id is not None

--- a/dae/dae/tools/gpf_validation_runner.py
+++ b/dae/dae/tools/gpf_validation_runner.py
@@ -912,7 +912,7 @@ def main(argv=sys.argv[1:]):
         logging.basicConfig(level=logging.ERROR)
     logging.getLogger("impala").setLevel(logging.WARNING)
 
-    gpf_instance = GPFInstance()
+    gpf_instance = GPFInstance.build()
     main_runner = MainRunner(
         gpf_instance, args.output, args.detailed_reporting, skip_columns)
 

--- a/dae/dae/tools/hdfs_parquet_loader.py
+++ b/dae/dae/tools/hdfs_parquet_loader.py
@@ -65,7 +65,7 @@ def parse_cli_arguments(argv, gpf_instance):
 def main(argv=None, gpf_instance=None):
     """Upload parquet dataset into HDFS storage."""
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     argv = parse_cli_arguments(argv or sys.argv[1:], gpf_instance)
 

--- a/dae/dae/tools/impala_parquet_loader.py
+++ b/dae/dae/tools/impala_parquet_loader.py
@@ -78,7 +78,7 @@ def parse_cli_arguments(argv, gpf_instance):
 def main(argv=None, gpf_instance=None):
     """Upload parquet dataset into Impala."""
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     argv = parse_cli_arguments(argv or sys.argv[1:], gpf_instance)
 

--- a/dae/dae/tools/impala_tables_loader.py
+++ b/dae/dae/tools/impala_tables_loader.py
@@ -94,7 +94,7 @@ def parse_cli_arguments(argv, gpf_instance):
 def main(argv=None, gpf_instance=None):
     """Import parquet dataset into Impala genotype storage."""
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     argv = parse_cli_arguments(argv or sys.argv[1:], gpf_instance)
 

--- a/dae/dae/tools/impala_tables_stats.py
+++ b/dae/dae/tools/impala_tables_stats.py
@@ -94,7 +94,7 @@ def pedigree_compute_stats(study_backend):
 
 def main(argv=sys.argv[1:], gpf_instance=None):
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     argv = parse_cli_arguments(argv, gpf_instance)
 

--- a/dae/dae/tools/impala_tables_summary_variants.py
+++ b/dae/dae/tools/impala_tables_summary_variants.py
@@ -307,7 +307,7 @@ def insert_into_summary_table(
 
 def main(argv=sys.argv[1:], gpf_instance=None):
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     argv = parse_cli_arguments(argv, gpf_instance)
 

--- a/dae/dae/tools/ped2ped.py
+++ b/dae/dae/tools/ped2ped.py
@@ -47,7 +47,7 @@ def main(argv, gpf_instance=None):
     It should be called from the command line.
     """
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", "-V", action="count", default=0)

--- a/dae/dae/tools/simple_pheno_import.py
+++ b/dae/dae/tools/simple_pheno_import.py
@@ -128,7 +128,7 @@ def main(argv):
     try:
         # Setup argument parser
 
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
         dae_conf = gpf_instance.dae_config
 
         parser = pheno_cli_parser()

--- a/dae/dae/tools/simple_study_import.py
+++ b/dae/dae/tools/simple_study_import.py
@@ -223,7 +223,7 @@ def main(argv, gpf_instance=None):
         dae_config = gpf_instance.dae_config
     else:
         try:
-            gpf_instance = GPFInstance()
+            gpf_instance = GPFInstance.build()
             dae_config = gpf_instance.dae_config
         except Exception:  # pylint: disable=broad-except
             logger.warning("GPF not configured correctly", exc_info=True)

--- a/dae/dae/tools/tests/test_impala_parquet_loader.py
+++ b/dae/dae/tools/tests/test_impala_parquet_loader.py
@@ -1,3 +1,5 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+
 from dae.tools.impala_parquet_loader import main
 
 
@@ -29,7 +31,8 @@ def test_impala_parquet_loader_no_partition(
 ):
 
     pedigree_path = fixture_dirname(
-        "studies/quads_f1_impala/data/pedigree/quads_f1_impala_pedigree.parquet")
+        "studies/quads_f1_impala/data/pedigree/"
+        "quads_f1_impala_pedigree.parquet")
     variants_path = fixture_dirname(
         "studies/quads_f1_impala/data/variants")
 

--- a/dae/dae/tools/vcfinfo_extractor.py
+++ b/dae/dae/tools/vcfinfo_extractor.py
@@ -78,7 +78,7 @@ def main(argv, gpf_instance=None):
         logging.basicConfig(level=logging.ERROR)
 
     if gpf_instance is None:
-        gpf_instance = GPFInstance()
+        gpf_instance = GPFInstance.build()
 
     assert argv.columns is not None
     info_columns = [c.strip() for c in argv.columns.split(",")]

--- a/dae/dae/utils/dae_utils.py
+++ b/dae/dae/utils/dae_utils.py
@@ -5,16 +5,6 @@ INS_RE = re.compile(r"^ins\(([NACGT]+)\)$")
 DEL_RE = re.compile(r"^del\((\d+)\)$")
 
 
-def cached(prop):
-    cached_val_name = "_" + prop.__name__
-
-    def wrap(self):
-        if getattr(self, cached_val_name, None) is None:
-            setattr(self, cached_val_name, prop(self))
-        return getattr(self, cached_val_name)
-    return wrap
-
-
 def dae2vcf_variant(chrom, position, var, genome):
     match = SUB_COMPLEX_RE.match(var)
     if match:

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -1,7 +1,7 @@
 import os
-import pathlib
+from pathlib import Path
 from urllib.parse import urlparse
-from typing import Optional
+from typing import Optional, Union
 
 from fsspec.core import url_to_fs
 
@@ -18,23 +18,25 @@ def join(path, *paths):
     return os.path.join(path, *paths)
 
 
-def find_directory_with_a_file(filename: str, cwd: Optional[str] = None):
+def find_directory_with_a_file(
+        filename: str,
+        cwd: Optional[Union[str, Path]] = None) -> Optional[Path]:
     """Find a directory containing a file.
 
     Starts from current working directory or from a directory passed.
     """
     if cwd is None:
-        curr_dir = pathlib.Path().absolute()
+        curr_dir = Path().absolute()
     else:
-        curr_dir = pathlib.Path(cwd).absolute()
+        curr_dir = Path(cwd).absolute()
 
     pathname = curr_dir / filename
     if pathname.exists():
-        return str(curr_dir)
+        return curr_dir
 
     for work_dir in curr_dir.parents:
         pathname = work_dir / filename
         if pathname.exists():
-            return str(work_dir)
+            return work_dir
 
     return None

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -1,6 +1,9 @@
-from fsspec.core import url_to_fs  # type: ignore
 import os
+import pathlib
 from urllib.parse import urlparse
+from typing import Optional
+
+from fsspec.core import url_to_fs
 
 
 def exists(filename):
@@ -9,7 +12,29 @@ def exists(filename):
 
 
 def join(path, *paths):
-    for i in range(len(paths)-1, -1, -1):
+    for i in range(len(paths) - 1, -1, -1):
         if urlparse(paths[i]).scheme:
             return os.path.join(*paths[i:])
     return os.path.join(path, *paths)
+
+
+def find_directory_with_a_file(filename: str, cwd: Optional[str] = None):
+    """Find a directory containing a file.
+
+    Starts from current working directory or from a directory passed.
+    """
+    if cwd is None:
+        curr_dir = pathlib.Path().absolute()
+    else:
+        curr_dir = pathlib.Path(cwd).absolute()
+
+    pathname = curr_dir / filename
+    if pathname.exists():
+        return str(curr_dir)
+
+    for work_dir in curr_dir.parents:
+        pathname = work_dir / filename
+        if pathname.exists():
+            return str(work_dir)
+
+    return None

--- a/dae/dae/utils/tests/test_find_a_directory_with_a_file.py
+++ b/dae/dae/utils/tests/test_find_a_directory_with_a_file.py
@@ -19,7 +19,7 @@ def test_one_parent(tmp_path):
     )
     dirname = find_directory_with_a_file(
         "file.test", str(tmp_path / "dir1" / "dir2"))
-    assert dirname == str(tmp_path / "dir1")
+    assert dirname == tmp_path / "dir1"
 
 
 def test_two_parents(tmp_path):
@@ -38,7 +38,7 @@ def test_two_parents(tmp_path):
 
     dirname = find_directory_with_a_file(
         "file.test", str(tmp_path / "dir1" / "dir2" / "dir3"))
-    assert dirname == str(tmp_path / "dir1")
+    assert dirname == tmp_path / "dir1"
 
 
 def test_first_parent(tmp_path):
@@ -58,7 +58,7 @@ def test_first_parent(tmp_path):
 
     dirname = find_directory_with_a_file(
         "file.test", str(tmp_path / "dir1" / "dir2" / "dir3"))
-    assert dirname == str(tmp_path / "dir1" / "dir2")
+    assert dirname == tmp_path / "dir1" / "dir2"
 
 
 def test_one_parent_getcwd(tmp_path, mocker):
@@ -77,7 +77,7 @@ def test_one_parent_getcwd(tmp_path, mocker):
     mocker.patch("os.getcwd", lambda: str(tmp_path / "dir1" / "dir2"))
 
     dirname = find_directory_with_a_file("file.test")
-    assert dirname == str(tmp_path / "dir1")
+    assert dirname == tmp_path / "dir1"
 
 
 def test_two_parents_getcwd(tmp_path, mocker):
@@ -96,7 +96,7 @@ def test_two_parents_getcwd(tmp_path, mocker):
     mocker.patch("os.getcwd", lambda: str(tmp_path / "dir1" / "dir2" / "dir3"))
 
     dirname = find_directory_with_a_file("file.test")
-    assert dirname == str(tmp_path / "dir1")
+    assert dirname == tmp_path / "dir1"
 
 
 def test_first_parent_getcwd(tmp_path, mocker):
@@ -116,4 +116,4 @@ def test_first_parent_getcwd(tmp_path, mocker):
 
     mocker.patch("os.getcwd", lambda: str(tmp_path / "dir1" / "dir2" / "dir3"))
     dirname = find_directory_with_a_file("file.test")
-    assert dirname == str(tmp_path / "dir1" / "dir2")
+    assert dirname == tmp_path / "dir1" / "dir2"

--- a/dae/dae/utils/tests/test_find_a_directory_with_a_file.py
+++ b/dae/dae/utils/tests/test_find_a_directory_with_a_file.py
@@ -1,0 +1,119 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+
+from dae.testing import setup_directories
+from dae.utils.fs_utils import find_directory_with_a_file
+
+
+def test_one_parent(tmp_path):
+    setup_directories(
+        tmp_path,
+        {
+            "dir1": {
+                "file.test": "",
+                "dir2": {
+                    "dir3": {
+                    }
+                }
+            }
+        }
+    )
+    dirname = find_directory_with_a_file(
+        "file.test", str(tmp_path / "dir1" / "dir2"))
+    assert dirname == str(tmp_path / "dir1")
+
+
+def test_two_parents(tmp_path):
+    setup_directories(
+        tmp_path,
+        {
+            "dir1": {
+                "file.test": "",
+                "dir2": {
+                    "dir3": {
+                    }
+                }
+            }
+        }
+    )
+
+    dirname = find_directory_with_a_file(
+        "file.test", str(tmp_path / "dir1" / "dir2" / "dir3"))
+    assert dirname == str(tmp_path / "dir1")
+
+
+def test_first_parent(tmp_path):
+    setup_directories(
+        tmp_path,
+        {
+            "dir1": {
+                "file.test": "",
+                "dir2": {
+                    "file.test": "",
+                    "dir3": {
+                    }
+                }
+            }
+        }
+    )
+
+    dirname = find_directory_with_a_file(
+        "file.test", str(tmp_path / "dir1" / "dir2" / "dir3"))
+    assert dirname == str(tmp_path / "dir1" / "dir2")
+
+
+def test_one_parent_getcwd(tmp_path, mocker):
+    setup_directories(
+        tmp_path,
+        {
+            "dir1": {
+                "file.test": "",
+                "dir2": {
+                    "dir3": {
+                    }
+                }
+            }
+        }
+    )
+    mocker.patch("os.getcwd", lambda: str(tmp_path / "dir1" / "dir2"))
+
+    dirname = find_directory_with_a_file("file.test")
+    assert dirname == str(tmp_path / "dir1")
+
+
+def test_two_parents_getcwd(tmp_path, mocker):
+    setup_directories(
+        tmp_path,
+        {
+            "dir1": {
+                "file.test": "",
+                "dir2": {
+                    "dir3": {
+                    }
+                }
+            }
+        }
+    )
+    mocker.patch("os.getcwd", lambda: str(tmp_path / "dir1" / "dir2" / "dir3"))
+
+    dirname = find_directory_with_a_file("file.test")
+    assert dirname == str(tmp_path / "dir1")
+
+
+def test_first_parent_getcwd(tmp_path, mocker):
+    setup_directories(
+        tmp_path,
+        {
+            "dir1": {
+                "file.test": "",
+                "dir2": {
+                    "file.test": "",
+                    "dir3": {
+                    }
+                }
+            }
+        }
+    )
+
+    mocker.patch("os.getcwd", lambda: str(tmp_path / "dir1" / "dir2" / "dir3"))
+    dirname = find_directory_with_a_file("file.test")
+    assert dirname == str(tmp_path / "dir1" / "dir2")

--- a/dae/tests/integration/tools/test_flexible_denovo_import.py
+++ b/dae/tests/integration/tools/test_flexible_denovo_import.py
@@ -19,7 +19,8 @@ def test_import_iossifov2014_filesystem(
         tmp_path_factory, storage_id, fixture_dirname):
     root_path = tmp_path_factory.mktemp(storage_id)
     foobar_gpf(root_path)
-    gpf_instance = GPFInstance(work_dir=str(root_path / "gpf_instance"))
+    gpf_instance = GPFInstance.build(
+        root_path / "gpf_instance" / "gpf_instance.yaml")
 
     pedigree_filename = \
         fixture_dirname("dae_iossifov2014/iossifov2014_families.ped")

--- a/dae_conftests/dae_conftests/dae_conftests.py
+++ b/dae_conftests/dae_conftests/dae_conftests.py
@@ -117,11 +117,7 @@ def default_dae_config(request, fixture_dirname):
 def gpf_instance(default_dae_config, fixture_dirname):
     from dae.gpf_instance.gpf_instance import GPFInstance
 
-    class GPFInstanceInternal(GPFInstance):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-    def build(work_dir=None, load_eagerly=False):
+    def build(config_filename):
         repositories = [
             build_genomic_resource_repository(
                 {
@@ -140,9 +136,7 @@ def gpf_instance(default_dae_config, fixture_dirname):
         ]
         grr = GenomicResourceGroupRepo(repositories)
 
-        instance = GPFInstanceInternal(
-            work_dir=work_dir, load_eagerly=load_eagerly, grr=grr
-        )
+        instance = GPFInstance.build(config_filename, grr=grr)
 
         return instance
 
@@ -155,8 +149,6 @@ def gpf_instance_2013(
     from dae.gpf_instance.gpf_instance import GPFInstance
 
     class GPFInstance2013(GPFInstance):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
 
         @cached_property
         def gene_models(self):
@@ -181,14 +173,18 @@ def gpf_instance_2013(
         build_genomic_resource_repository(),
     ]
     grr = GenomicResourceGroupRepo(repositories)
-    gpf_instance = GPFInstance2013(dae_config=default_dae_config, grr=grr)
+    gpf_instance = GPFInstance2013(
+        dae_config=default_dae_config,
+        dae_dir=default_dae_config.config_dir,
+        grr=grr)
 
     return gpf_instance
 
 
 @pytest.fixture(scope="session")
 def fixtures_gpf_instance(gpf_instance, global_dae_fixtures_dir):
-    return gpf_instance(global_dae_fixtures_dir)
+    return gpf_instance(
+        os.path.join(global_dae_fixtures_dir, "gpf_instance.yaml"))
 
 
 @pytest.fixture(scope="session")
@@ -197,8 +193,6 @@ def gpf_instance_2019(
     from dae.gpf_instance.gpf_instance import GPFInstance
 
     class GPFInstance2019(GPFInstance):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
 
         @cached_property
         def gene_models(self):
@@ -223,7 +217,7 @@ def gpf_instance_2019(
     ]
     grr = GenomicResourceGroupRepo(repositories)
     gpf_instance = GPFInstance2019(
-        dae_config=default_dae_config, work_dir=global_dae_fixtures_dir,
+        dae_config=default_dae_config, dae_dir=global_dae_fixtures_dir,
         grr=grr)
 
     return gpf_instance
@@ -235,8 +229,6 @@ def _create_gpf_instance(
     from dae.gpf_instance.gpf_instance import GPFInstance
 
     class CustomGPFInstance(GPFInstance):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
 
         @cached_property
         def gene_models(self):
@@ -271,7 +263,7 @@ def _create_gpf_instance(
     grr = GenomicResourceGroupRepo(repositories)
 
     instance = CustomGPFInstance(
-        dae_config=default_dae_config, work_dir=global_dae_fixtures_dir,
+        dae_config=default_dae_config, dae_dir=global_dae_fixtures_dir,
         grr=grr
     )
 

--- a/dae_conftests/dae_conftests/dae_conftests.py
+++ b/dae_conftests/dae_conftests/dae_conftests.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 import logging
 from pathlib import Path
+from functools import cached_property
 
 from io import StringIO
 
@@ -151,14 +152,13 @@ def gpf_instance(default_dae_config, fixture_dirname):
 @pytest.fixture(scope="session")
 def gpf_instance_2013(
         default_dae_config, fixture_dirname, global_dae_fixtures_dir):
-    from dae.gpf_instance.gpf_instance import GPFInstance, cached
+    from dae.gpf_instance.gpf_instance import GPFInstance
 
     class GPFInstance2013(GPFInstance):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
-        @property  # type: ignore
-        @cached
+        @cached_property
         def gene_models(self):
             print(self.dae_config.gene_models)
             resource = self.grr.get_resource(
@@ -194,14 +194,13 @@ def fixtures_gpf_instance(gpf_instance, global_dae_fixtures_dir):
 @pytest.fixture(scope="session")
 def gpf_instance_2019(
         default_dae_config, fixture_dirname, global_dae_fixtures_dir):
-    from dae.gpf_instance.gpf_instance import GPFInstance, cached
+    from dae.gpf_instance.gpf_instance import GPFInstance
 
     class GPFInstance2019(GPFInstance):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
-        @property  # type: ignore
-        @cached
+        @cached_property
         def gene_models(self):
             resource = self.grr.get_resource(
                 "hg19/gene_models/refGene_v20190211")
@@ -233,14 +232,13 @@ def gpf_instance_2019(
 def _create_gpf_instance(
         gene_model_dir, ref_genome_dir,
         default_dae_config, global_dae_fixtures_dir, fixture_dirname):
-    from dae.gpf_instance.gpf_instance import GPFInstance, cached
+    from dae.gpf_instance.gpf_instance import GPFInstance
 
     class CustomGPFInstance(GPFInstance):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
-        @property  # type: ignore
-        @cached
+        @cached_property
         def gene_models(self):
             if gene_model_dir is None:
                 return super().gene_models
@@ -249,8 +247,7 @@ def _create_gpf_instance(
             result.load()
             return result
 
-        @property  # type: ignore
-        @cached
+        @cached_property
         def reference_genome(self):
             if ref_genome_dir is None:
                 return super().reference_genome
@@ -1099,7 +1096,7 @@ def agp_gpf_instance(
         "get_gene_set_ids",
         return_value=main_gene_sets
     )
-    fixtures_gpf_instance.__autism_gene_profile_db = \
+    fixtures_gpf_instance._autism_gene_profile_db = \
         AutismGeneProfileDB(
             fixtures_gpf_instance._autism_gene_profile_config,
             temp_dbfile,

--- a/wdae/wdae/autism_gene_profiles_api/tests/test_agp_api.py
+++ b/wdae/wdae/autism_gene_profiles_api/tests/test_agp_api.py
@@ -1,3 +1,5 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+
 import pytest
 
 pytestmark = pytest.mark.usefixtures(
@@ -5,11 +7,11 @@ pytestmark = pytest.mark.usefixtures(
     "dae_calc_gene_sets",
 )
 
-route_prefix = "/api/v3/autism_gene_tool"
+ROUTE_PREFIX = "/api/v3/autism_gene_tool"
 
 
 def test_configuration(admin_client):
-    response = admin_client.get(f"{route_prefix}/single-view/configuration")
+    response = admin_client.get(f"{ROUTE_PREFIX}/single-view/configuration")
 
     assert response.status_code == 200
     print(response.data)
@@ -38,16 +40,16 @@ def test_configuration(admin_client):
             "childrenCount": 11,
             "statistics": [
                 {
-                    'id': 'denovo_noncoding',
-                    'displayName': 'Noncoding',
-                    'effects': ['noncoding'],
-                    'category': 'denovo'
+                    "id": "denovo_noncoding",
+                    "displayName": "Noncoding",
+                    "effects": ["noncoding"],
+                    "category": "denovo"
                 },
                 {
-                    'id': 'denovo_missense',
-                    'displayName': 'Missense',
-                    'effects': ['missense'],
-                    'category': 'denovo'
+                    "id": "denovo_missense",
+                    "displayName": "Missense",
+                    "effects": ["missense"],
+                    "category": "denovo"
                 }
             ]
         },
@@ -60,16 +62,16 @@ def test_configuration(admin_client):
             "childrenCount": 10,
             "statistics": [
                 {
-                    'id': 'denovo_noncoding',
-                    'displayName': 'Noncoding',
-                    'effects': ['noncoding'],
-                    'category': 'denovo'
+                    "id": "denovo_noncoding",
+                    "displayName": "Noncoding",
+                    "effects": ["noncoding"],
+                    "category": "denovo"
                 },
                 {
-                    'id': 'denovo_missense',
-                    'displayName': 'Missense',
-                    'effects': ['missense'],
-                    'category': 'denovo'
+                    "id": "denovo_missense",
+                    "displayName": "Missense",
+                    "effects": ["missense"],
+                    "category": "denovo"
                 }
             ]
         }
@@ -77,13 +79,13 @@ def test_configuration(admin_client):
 
 
 def test_get_statistic(admin_client):
-    response = admin_client.get(f"{route_prefix}/single-view/gene/CHD8")
+    response = admin_client.get(f"{ROUTE_PREFIX}/single-view/gene/CHD8")
     assert response.status_code == 200
     print(response.data)
 
 
 def test_get_table_config(admin_client):
-    response = admin_client.get(f"{route_prefix}/table/configuration")
+    response = admin_client.get(f"{ROUTE_PREFIX}/table/configuration")
     assert response.status_code == 200
     assert "defaultDataset" in response.data
     assert "columns" in response.data
@@ -91,6 +93,6 @@ def test_get_table_config(admin_client):
 
 
 def test_get_statistics(admin_client):
-    response = admin_client.get(f"{route_prefix}/table/rows")
+    response = admin_client.get(f"{ROUTE_PREFIX}/table/rows")
     assert response.status_code == 200
     print(response.data)

--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -231,7 +231,7 @@ def wdae_gpf_instance_agp(  # pylint: disable=too-many-arguments
     wdae_gpf_instance._autism_gene_profile_db = \
         AutismGeneProfileDB(
             agp_config,
-            os.path.join(wdae_gpf_instance.dae_db_dir, temp_filename),
+            os.path.join(wdae_gpf_instance.dae_dir, temp_filename),
             clear=True
         )
     wdae_gpf_instance._autism_gene_profile_db.insert_agp(sample_agp)

--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -174,7 +174,7 @@ def wdae_gpf_instance(
         "datasets_api.permissions.get_gpf_instance",
         return_value=fixtures_wgpf_instance,
     )
-    wdae_gpf_instance.__autism_gene_profile_config = None
+    wdae_gpf_instance._autism_gene_profile_config = None
 
     return fixtures_wgpf_instance
 
@@ -205,7 +205,7 @@ def wdae_gpf_instance_agp(  # pylint: disable=too-many-arguments
         return_value=wdae_gpf_instance,
     )
 
-    wdae_gpf_instance.__autism_gene_profile_config = agp_config
+    wdae_gpf_instance._autism_gene_profile_config = agp_config
     main_gene_sets = {
         "CHD8 target genes",
         "FMRP Darnell",
@@ -228,7 +228,7 @@ def wdae_gpf_instance_agp(  # pylint: disable=too-many-arguments
         "get_gene_set_ids",
         return_value=main_gene_sets
     )
-    wdae_gpf_instance.__autism_gene_profile_db = \
+    wdae_gpf_instance._autism_gene_profile_db = \
         AutismGeneProfileDB(
             agp_config,
             os.path.join(wdae_gpf_instance.dae_db_dir, temp_filename),

--- a/wdae/wdae/gpf_instance/apps.py
+++ b/wdae/wdae/gpf_instance/apps.py
@@ -48,19 +48,19 @@ class WDAETestingConfig(AppConfig):
     def ready(self):
 
         AppConfig.ready(self)
-        work_dir = None
+        config_filename = None
 
         if getattr(settings, "TESTING", None):
-            work_dir = Path(__file__).parents[3].joinpath(
-                "data/data-hg19-local")
+            config_filename = Path(__file__).parents[3].joinpath(
+                "data/data-hg19-local/gpf_instance.yaml")
 
-            logger.error("testing environment... work_dir: %s", work_dir)
+            logger.error("testing environment... config: %s", config_filename)
 
         try:
             logger.warning(
-                "going to call load_gpf_instance with "
-                "work_dir=%s", work_dir)
-            load_gpf_instance(work_dir=work_dir)
+                "going to call load_gpf_instance with %s",
+                config_filename)
+            load_gpf_instance(config_filename)
         except Exception:  # pylint: disable=broad-except
             logger.error(
                 "problem while preloading testing gpf instance",

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Optional, List, Dict
 from threading import Lock
+from functools import cached_property
 
 from django.conf import settings
 
@@ -18,7 +19,6 @@ from remote.gene_sets_db import RemoteGeneSetsDb
 from remote.denovo_gene_sets_db import RemoteDenovoGeneSetsDb
 from remote.rest_api_client import RESTClient
 
-from dae.utils.dae_utils import cached
 from dae.gpf_instance.gpf_instance import GPFInstance
 from dae.enrichment_tool.tool import EnrichmentTool
 from dae.enrichment_tool.event_counters import CounterBase
@@ -89,16 +89,14 @@ class WGPFInstance(GPFInstance):
             raise ValueError("remote study db not initialized.")
         return self._remote_study_db.remote_study_ids
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def gene_sets_db(self):
         logger.debug("creating new instance of GeneSetsDb")
         self.load_remotes()
         gene_sets_db = super().gene_sets_db
         return RemoteGeneSetsDb(self._clients, gene_sets_db)
 
-    @property  # type: ignore
-    @cached
+    @cached_property
     def denovo_gene_sets_db(self):
         self.load_remotes()
         denovo_gene_sets_db = super().denovo_gene_sets_db

--- a/wdae/wdae/gpf_instance/tests/conftest.py
+++ b/wdae/wdae/gpf_instance/tests/conftest.py
@@ -1,8 +1,10 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
 import pytest
 
 
 @pytest.fixture(scope="function")
 def wgpf_instance_fixture(
         wgpf_instance, admin_client, global_dae_fixtures_dir):
-    return wgpf_instance(global_dae_fixtures_dir)
+    return wgpf_instance(
+        os.path.join(global_dae_fixtures_dir, "gpf_instance.yaml"))

--- a/wdae/wdae/studies/tests/conftest.py
+++ b/wdae/wdae/studies/tests/conftest.py
@@ -14,7 +14,7 @@ def local_dir():
 
 @pytest.fixture(scope="session")
 def local_gpf_instance(local_dir):
-    return GPFInstance(work_dir=local_dir)
+    return GPFInstance.build(local_dir / "gpf_instance.yaml")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Background

Currently, the supported way to locate the GPF instance directory is to use the DAE_DB_DIR environment variable. 

## Aim

We want to add the option to find the instance directory by looking for the `gpf_instance.yaml` file in the current working directory and its parents.

## Implementation

A factory method is added into `GPFInstance` that accepts an optional filename argument for a configuration file.

If the argument is not passed, a discovery procedure is started. First, it checks for `DAE_DB_DIR` environment variable. If found it is used as an instance directory. Otherwise, the current working directory and its parents are scanned for a file `gpf_instance.yaml`.

**Why it's implemented the way it is? What alternative implementations have you
considered and why you chose this one?**

The usage of a factory method allows the constructor to be easy and straightforward. 

The parameters of the GPFInstance constructor are reduced. The `load_eagerly` flag is removed from the GPFInstance constructor. 