### PR TITLE
Management routes

### DIFF
--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -52,7 +52,7 @@ def fake_dataset(db):
 
 
 @pytest.fixture()
-def hundred_users(db):
+def hundred_users(db, user):
     user_model = get_user_model()
     users_data = []
     for i in range(100):

--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -1,6 +1,7 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
 import pytest
+from rest_framework import status  # type: ignore
 from dae.configuration.gpf_config_parser import FrozenBox
 
 pytestmark = pytest.mark.usefixtures(
@@ -217,3 +218,25 @@ def test_datasets_hierarchy(admin_client, wdae_gpf_instance):
         "name": "Dataset1",
         "access_rights": True,
     }
+
+
+def test_datasets_permissions(admin_client, wdae_gpf_instance):
+    response = admin_client.get("/api/v3/datasets/permissions")
+    assert len(response.data) == 25
+    assert set(response.data[0].keys()) == set([
+        "dataset_id",
+        "dataset_name",
+        "users",
+        "groups"
+    ])
+    response = admin_client.get("/api/v3/datasets/permissions?page=2")
+    assert len(response.data) == 18
+
+    response = admin_client.get("/api/v3/datasets/permissions?page=3")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_datasets_permissions_search(admin_client, wdae_gpf_instance):
+    response = admin_client.get("/api/v3/datasets/permissions?search=we2014")
+    assert len(response.data) == 1
+    assert response.data[0]["dataset_id"] == "iossifov_we2014_test"

--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -233,7 +233,7 @@ def test_datasets_permissions(admin_client, wdae_gpf_instance):
     assert len(response.data) == 18
 
     response = admin_client.get("/api/v3/datasets/permissions?page=3")
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
 def test_datasets_permissions_search(admin_client, wdae_gpf_instance):

--- a/wdae/wdae/datasets_api/urls.py
+++ b/wdae/wdae/datasets_api/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         name="dataset_hierarchy"
     ),
     re_path(
+        r"^/permissions/?$",
+        views.DatasetPermissionsView.as_view(),
+        name="management_details"
+    ),
+    re_path(
         r"^/(?P<dataset_id>.+)$",
         views.DatasetView.as_view(),
         name="dataset"

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -283,7 +283,7 @@ class DatasetPermissionsView(QueryBaseView):
             })
 
         if len(dataset_details) == 0:
-            return Response(status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
         return Response(dataset_details)
 

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -1,5 +1,7 @@
 import os
 
+from django.contrib.auth import get_user_model
+from django.conf import settings
 from rest_framework.response import Response  # type: ignore
 from rest_framework import status  # type: ignore
 
@@ -228,6 +230,62 @@ class DatasetDescriptionView(QueryBaseView):
         genotype_data.description = description
 
         return Response(status=status.HTTP_200_OK)
+
+
+class DatasetPermissionsView(QueryBaseView):
+
+    page_size = settings.REST_FRAMEWORK["PAGE_SIZE"]
+
+    def get(self, request):
+        dataset_search = request.GET.get("search")
+        page = request.GET.get("page", 1)
+        query  = Dataset.objects
+        if dataset_search is not None and dataset_search != "":
+            query = query.filter(dataset_id__icontains=dataset_search)
+
+        if page is None:
+            return Response(status.HTTP_400_BAD_REQUEST)
+        if isinstance(page, str):
+            page = int(page)
+
+        page_start = (page - 1) * self.page_size
+        page_end = page * self.page_size
+        datasets = query.all()[page_start:page_end]
+
+        dataset_details = []
+        for dataset in datasets:
+            groups = dataset.groups.all()
+            group_names = [group.name for group in groups]
+
+            user_model = get_user_model()
+            users_list = []
+            for group in groups:
+                users = user_model.objects.filter(groups__name=group.name).all()
+                users_list += [
+                    {"name": user.name, "email": user.email}
+                    for user in users
+                ]
+
+            dataset_gd = self.gpf_instance.get_genotype_data(
+                dataset.dataset_id
+            )
+
+            name = dataset_gd.name
+            if name is None:
+                name = ""
+
+            dataset_details.append({
+                "dataset_id": dataset_gd.study_id,
+                "dataset_name": name,
+                "users": users_list,
+                "groups": group_names
+
+            })
+
+        if len(dataset_details) == 0:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        return Response(dataset_details)
 
 
 class DatasetHierarchyView(QueryBaseView):

--- a/wdae/wdae/groups_api/tests/test_groups_rest.py
+++ b/wdae/wdae/groups_api/tests/test_groups_rest.py
@@ -378,4 +378,4 @@ def test_groups_search_pagination(admin_client, hundred_groups):
     assert len(response.data) == 25
     url = "/api/v3/groups?page=5&search=Group"
     response = admin_client.get(url)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/wdae/wdae/groups_api/tests/test_groups_rest.py
+++ b/wdae/wdae/groups_api/tests/test_groups_rest.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
 
 from django.contrib.auth.models import Group
@@ -329,3 +330,52 @@ def test_cant_revoke_default_permissions(user_client, dataset):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert dataset.groups.filter(pk=group.pk).exists()
+
+
+def test_groups_pagination(admin_client, hundred_groups):
+    url = "/api/v3/groups?page=1"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["name"] == "Group1"
+    assert response.data[24]["name"] == "Group30"
+    url = "/api/v3/groups?page=2"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["name"] == "Group31"
+    assert response.data[24]["name"] == "Group53"
+    url = "/api/v3/groups?page=3"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["name"] == "Group54"
+    assert response.data[24]["name"] == "Group76"
+    url = "/api/v3/groups?page=4"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["name"] == "Group77"
+    assert response.data[24]["name"] == "Group99"
+    url = "/api/v3/groups?page=5"
+    response = admin_client.get(url)
+    assert len(response.data) == 1
+    assert response.data[0]["name"] == "admin"
+
+def test_groups_search(admin_client, hundred_groups):
+    url = "/api/v3/groups?search=Group1"
+    response = admin_client.get(url)
+    assert len(response.data) == 12
+
+def test_groups_search_pagination(admin_client, hundred_groups):
+    url = "/api/v3/groups?page=1&search=Group"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    url = "/api/v3/groups?page=2&search=Group"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    url = "/api/v3/groups?page=3&search=Group"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    url = "/api/v3/groups?page=4&search=Group"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    url = "/api/v3/groups?page=5&search=Group"
+    response = admin_client.get(url)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/wdae/wdae/groups_api/views.py
+++ b/wdae/wdae/groups_api/views.py
@@ -1,5 +1,5 @@
 from django.db.models import Count, Q
-from rest_framework import viewsets, permissions, mixins, status
+from rest_framework import viewsets, permissions, mixins, status, filters
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 
@@ -16,7 +16,8 @@ class GroupsViewSet(
 ):
     serializer_class = GroupSerializer
     permission_classes = (permissions.IsAdminUser,)
-    pagination_class = None
+    filter_backends = (filters.SearchFilter,)
+    search_fields = ("name",)
 
     def get_serializer_class(self):
         serializer_class = self.serializer_class
@@ -34,7 +35,7 @@ class GroupsViewSet(
             users_count=Count("user"), datasets_count=Count("dataset")
         ).filter(
             Q(users_count__gt=0) | Q(datasets_count__gt=0)
-        )
+        ).order_by("name")
 
 
 @api_view(["POST"])

--- a/wdae/wdae/users_api/tests/test_users_api.py
+++ b/wdae/wdae/users_api/tests/test_users_api.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
 from pprint import pprint
 
@@ -84,3 +85,73 @@ def test_password_validation():
     assert not is_password_valid("qwerty123456")
 
     assert is_password_valid(generic_password)
+
+
+def test_users_pagination(admin_client, hundred_users):
+    url = "/api/v3/users?page=1"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["email"] == "admin@example.com"
+    assert response.data[24]["email"] == "user30@example.com"
+
+    url = "/api/v3/users?page=2"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["email"] == "user31@example.com"
+    assert response.data[24]["email"] == "user53@example.com"
+
+    url = "/api/v3/users?page=3"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["email"] == "user54@example.com"
+    assert response.data[24]["email"] == "user76@example.com"
+
+    url = "/api/v3/users?page=4"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    assert response.data[0]["email"] == "user77@example.com"
+    assert response.data[24]["email"] == "user99@example.com"
+
+    url = "/api/v3/users?page=5"
+    response = admin_client.get(url)
+    assert len(response.data) == 1
+    assert response.data[0]["email"] == "user9@example.com"
+
+    for idx, user in enumerate(response.data):
+        print(f"{idx}: {user['email']}")
+
+
+def test_users_search(admin_client, hundred_users):
+    url = "/api/v3/users?search=user9"
+    response = admin_client.get(url)
+    assert len(response.data) == 11
+
+
+def test_users_search_pagination(admin_client, hundred_users):
+    url = "/api/v3/users?page=1&search=user"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    for idx, user in enumerate(response.data):
+        print(f"{idx}: {user['email']}")
+
+    url = "/api/v3/users?page=2&search=user"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    for idx, user in enumerate(response.data):
+        print(f"{idx}: {user['email']}")
+
+    url = "/api/v3/users?page=3&search=user"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    for idx, user in enumerate(response.data):
+        print(f"{idx}: {user['email']}")
+
+    url = "/api/v3/users?page=4&search=user"
+    response = admin_client.get(url)
+    assert len(response.data) == 25
+    for idx, user in enumerate(response.data):
+        print(f"{idx}: {user['email']}")
+
+    url = "/api/v3/users?page=5&search=user"
+    response = admin_client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/wdae/wdae/users_api/tests/test_users_api.py
+++ b/wdae/wdae/users_api/tests/test_users_api.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
+import pytest
 from pprint import pprint
 
 from rest_framework import status  # type: ignore
@@ -87,39 +88,45 @@ def test_password_validation():
     assert is_password_valid(generic_password)
 
 
-def test_users_pagination(admin_client, hundred_users):
-    url = "/api/v3/users?page=1"
+@pytest.mark.parametrize(
+    "page,status_code,length,first_email,last_email",
+    [
+        (
+            1, status.HTTP_200_OK, 25, 
+            "admin@example.com", "user30@example.com"
+        ),
+        (
+            2, status.HTTP_200_OK, 25, 
+            "user31@example.com", "user53@example.com"
+        ),
+        (
+            3, status.HTTP_200_OK, 25, 
+            "user54@example.com", "user76@example.com"
+        ),
+        (
+            4, status.HTTP_200_OK, 25, 
+            "user77@example.com", "user99@example.com"
+        ),
+        (5, status.HTTP_200_OK, 2, "user9@example.com", "user@example.com"),
+        (6, status.HTTP_204_NO_CONTENT, None, None, None),
+    ]
+)
+def test_users_pagination(
+    admin_client, hundred_users, page, status_code,
+    length, first_email, last_email
+):
+    url = f"/api/v3/users?page={page}"
     response = admin_client.get(url)
-    assert len(response.data) == 25
-    assert response.data[0]["email"] == "admin@example.com"
-    assert response.data[24]["email"] == "user30@example.com"
+    assert response.status_code == status_code
 
-    url = "/api/v3/users?page=2"
-    response = admin_client.get(url)
-    assert len(response.data) == 25
-    assert response.data[0]["email"] == "user31@example.com"
-    assert response.data[24]["email"] == "user53@example.com"
+    if length is not None:
+        assert len(response.data) == length
 
-    url = "/api/v3/users?page=3"
-    response = admin_client.get(url)
-    assert len(response.data) == 25
-    assert response.data[0]["email"] == "user54@example.com"
-    assert response.data[24]["email"] == "user76@example.com"
+    if first_email is not None:
+        assert response.data[0]["email"] == first_email
 
-    url = "/api/v3/users?page=4"
-    response = admin_client.get(url)
-    assert len(response.data) == 25
-    assert response.data[0]["email"] == "user77@example.com"
-    assert response.data[24]["email"] == "user99@example.com"
-
-    url = "/api/v3/users?page=5"
-    response = admin_client.get(url)
-    assert len(response.data) == 2
-    assert response.data[0]["email"] == "user9@example.com"
-    assert response.data[1]["email"] == "user@example.com"
-    url = "/api/v3/users?page=6"
-    response = admin_client.get(url)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    if last_email is not None:
+        assert response.data[length - 1]["email"] == last_email
 
 
 def test_users_search(admin_client, hundred_users):
@@ -127,36 +134,24 @@ def test_users_search(admin_client, hundred_users):
     response = admin_client.get(url)
     assert len(response.data) == 11
 
-
-def test_users_search_pagination(admin_client, hundred_users):
-    url = "/api/v3/users?page=1&search=user"
+@pytest.mark.parametrize(
+    "page,status_code,length",
+    [
+        (1, status.HTTP_200_OK, 25),
+        (2, status.HTTP_200_OK, 25),
+        (3, status.HTTP_200_OK, 25),
+        (4, status.HTTP_200_OK, 25),
+        (5, status.HTTP_200_OK, 1),
+        (6, status.HTTP_204_NO_CONTENT, None),
+    ]
+)
+def test_users_search_pagination(
+    admin_client, hundred_users, page, status_code, length
+):
+    url = f"/api/v3/users?page={page}&search=user"
     response = admin_client.get(url)
-    assert len(response.data) == 25
-    for idx, user in enumerate(response.data):
-        print(f"{idx}: {user['email']}")
-
-    url = "/api/v3/users?page=2&search=user"
-    response = admin_client.get(url)
-    assert len(response.data) == 25
-    for idx, user in enumerate(response.data):
-        print(f"{idx}: {user['email']}")
-
-    url = "/api/v3/users?page=3&search=user"
-    response = admin_client.get(url)
-    assert len(response.data) == 25
-    for idx, user in enumerate(response.data):
-        print(f"{idx}: {user['email']}")
-
-    url = "/api/v3/users?page=4&search=user"
-    response = admin_client.get(url)
-    assert len(response.data) == 25
-    for idx, user in enumerate(response.data):
-        print(f"{idx}: {user['email']}")
-
-    url = "/api/v3/users?page=5&search=user"
-    response = admin_client.get(url)
-    assert len(response.data) == 1
-
-    url = "/api/v3/users?page=6&search=user"
-    response = admin_client.get(url)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status_code
+    if length is not None:
+        assert len(response.data) == length
+        for idx, user in enumerate(response.data):
+            print(f"{idx}: {user['email']}")

--- a/wdae/wdae/users_api/tests/test_users_api.py
+++ b/wdae/wdae/users_api/tests/test_users_api.py
@@ -92,19 +92,19 @@ def test_password_validation():
     "page,status_code,length,first_email,last_email",
     [
         (
-            1, status.HTTP_200_OK, 25, 
+            1, status.HTTP_200_OK, 25,
             "admin@example.com", "user30@example.com"
         ),
         (
-            2, status.HTTP_200_OK, 25, 
+            2, status.HTTP_200_OK, 25,
             "user31@example.com", "user53@example.com"
         ),
         (
-            3, status.HTTP_200_OK, 25, 
+            3, status.HTTP_200_OK, 25,
             "user54@example.com", "user76@example.com"
         ),
         (
-            4, status.HTTP_200_OK, 25, 
+            4, status.HTTP_200_OK, 25,
             "user77@example.com", "user99@example.com"
         ),
         (5, status.HTTP_200_OK, 2, "user9@example.com", "user@example.com"),
@@ -133,6 +133,7 @@ def test_users_search(admin_client, hundred_users):
     url = "/api/v3/users?search=user9"
     response = admin_client.get(url)
     assert len(response.data) == 11
+
 
 @pytest.mark.parametrize(
     "page,status_code,length",

--- a/wdae/wdae/users_api/tests/test_users_api.py
+++ b/wdae/wdae/users_api/tests/test_users_api.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
-import pytest
 from pprint import pprint
+import pytest
 
 from rest_framework import status  # type: ignore
 

--- a/wdae/wdae/users_api/tests/test_users_api.py
+++ b/wdae/wdae/users_api/tests/test_users_api.py
@@ -114,11 +114,12 @@ def test_users_pagination(admin_client, hundred_users):
 
     url = "/api/v3/users?page=5"
     response = admin_client.get(url)
-    assert len(response.data) == 1
+    assert len(response.data) == 2
     assert response.data[0]["email"] == "user9@example.com"
-
-    for idx, user in enumerate(response.data):
-        print(f"{idx}: {user['email']}")
+    assert response.data[1]["email"] == "user@example.com"
+    url = "/api/v3/users?page=6"
+    response = admin_client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_users_search(admin_client, hundred_users):
@@ -153,5 +154,9 @@ def test_users_search_pagination(admin_client, hundred_users):
         print(f"{idx}: {user['email']}")
 
     url = "/api/v3/users?page=5&search=user"
+    response = admin_client.get(url)
+    assert len(response.data) == 1
+
+    url = "/api/v3/users?page=6&search=user"
     response = admin_client.get(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -62,33 +62,32 @@ def iterator_to_json(users):
 
 class UserViewSet(viewsets.ModelViewSet):
     serializer_class = UserSerializer
-    queryset = get_user_model().objects.all()
+    queryset = get_user_model().objects.order_by("email").all()
     permission_classes = (permissions.IsAdminUser,)
-    pagination_class = None
     filter_backends = (filters.SearchFilter,)
-    search_fields = ("groups__name", "email", "name")
+    search_fields = ("email", "name", "groups__name")
 
     @request_logging(LOGGER)
-    def list(self, request):
-        return super(UserViewSet, self).list(request)
+    def list(self, request, *args, **kwargs):
+        return super().list(request)
 
     @request_logging(LOGGER)
-    def create(self, request):
-        return super(UserViewSet, self).create(request)
+    def create(self, request, *args, **kwargs):
+        return super().create(request)
 
     @request_logging(LOGGER)
-    def retrieve(self, request, pk=None):
-        return super(UserViewSet, self).retrieve(request, pk=pk)
+    def retrieve(self, request, *args, pk=None, **kwargs):
+        return super().retrieve(request, pk=pk)
 
     @request_logging(LOGGER)
-    def update(self, request, pk=None, *args, **kwargs):
+    def update(self, request, *args, pk=None, **kwargs):
         if (
             request.user.pk == int(pk)
             and request.user.is_staff
             and "admin" not in request.data["groups"]
         ):
             return Response(status=status.HTTP_400_BAD_REQUEST)
-        return super(UserViewSet, self).update(request, pk=pk, *args, **kwargs)
+        return super().update(request, pk=pk, *args, **kwargs)
 
     @request_logging(LOGGER)
     def partial_update(self, request, pk=None):
@@ -98,10 +97,10 @@ class UserViewSet(viewsets.ModelViewSet):
             and "admin" not in request.data["groups"]
         ):
             return Response(status=status.HTTP_400_BAD_REQUEST)
-        return super(UserViewSet, self).partial_update(request, pk=pk)
+        return super().partial_update(request, pk=pk)
 
     @request_logging(LOGGER)
-    def destroy(self, request, pk=None):
+    def destroy(self, request, *args, pk=None, **kwargs):
         if request.user.pk == int(pk):
             return Response(status=status.HTTP_400_BAD_REQUEST)
         return super().destroy(request, pk=pk)

--- a/wdae/wdae/utils/pagination.py
+++ b/wdae/wdae/utils/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework import pagination
+from rest_framework.response import Response  # type: ignore
+
+
+class WdaePageNumberPagination(pagination.PageNumberPagination):
+    def get_paginated_response(self, data):
+        return Response(data)

--- a/wdae/wdae/utils/pagination.py
+++ b/wdae/wdae/utils/pagination.py
@@ -1,7 +1,17 @@
-from rest_framework import pagination
+from rest_framework import pagination, status  # type: ignore
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response  # type: ignore
 
 
 class WdaePageNumberPagination(pagination.PageNumberPagination):
+    def paginate_queryset(self, queryset, request, view=None):
+        """Paginate and handle empty pages by returning 204."""
+        try:
+            return super().paginate_queryset(queryset, request, view=view)
+        except NotFound:
+            return []
+
     def get_paginated_response(self, data):
+        if len(data) == 0:
+            return Response(status=status.HTTP_204_NO_CONTENT)
         return Response(data)

--- a/wdae/wdae/wdae/default_settings.py
+++ b/wdae/wdae/wdae/default_settings.py
@@ -208,6 +208,10 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "utils.authentication.GPFOAuth2Authentication",
     ),
+    "DEFAULT_PAGINATION_CLASS": (
+        "utils.pagination.WdaePageNumberPagination"
+    ),
+    "PAGE_SIZE": 25
 }
 
 OAUTH2_PROVIDER = {


### PR DESCRIPTION
## Background

We are updating the frontend's management pages to be more responsive and stable. This requires a few changes in the API, as the old way of constructing the management pages required way too many queries.

## Aim

We are changing the existing users and groups API listing methods to include pagination for finer control over how many resources are loaded at once. We are also providing a new API route for dataset permissions.
Provide a short summary of the changes. Try to include answers to the **Why?** questions,
e.g. **Why are we introducing this change?**, **Why now?**, etc.

If your changes make UI changes, consider providing before and after screenshots.
You can also include a video demonstrating the old vs. the new UX.

## Implementation

The groups and users API had explicitly disabled pagination, which is now re-enabled and uses a custom pagination class.
The default page pagination class would return a response, which was way too detailed and it included things like URLs for the next and previous pages and total page count along with the body. Due to the nature of the frontend pagination mechanism, we only need to return the main body of the response and a 404 if the page is out of range. Testing fixtures for many users and groups have also been added with bulk_create
