### PR TITLE
`GenotypeStorageRegistry.get_genotype_storage(None)` should return the default genotype storage

### DIFF
--- a/dae/dae/genotype_storage/genotype_storage_registry.py
+++ b/dae/dae/genotype_storage/genotype_storage_registry.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Dict
+from typing import Dict
 
 from dae.genotype_storage import get_genotype_storage_factory
 from dae.genotype_storage.genotype_storage import GenotypeStorage
@@ -52,11 +52,13 @@ class GenotypeStorageRegistry:
         self.register_genotype_storage(genotype_storage)
         self._default_genotype_storage = genotype_storage
 
-    def get_default_genotype_storage(self) -> Optional[GenotypeStorage]:
+    def get_default_genotype_storage(self) -> GenotypeStorage:
         """Return the default genotype storage if one is defined.
 
         Otherwise, return None.
         """
+        if self._default_genotype_storage is None:
+            raise ValueError("default genotype storage not set")
         return self._default_genotype_storage
 
     def get_genotype_storage(self, storage_id) -> GenotypeStorage:
@@ -65,6 +67,8 @@ class GenotypeStorageRegistry:
         If the method can not find storage with the specified ID, it will raise
         ValueError exception.
         """
+        if storage_id is None:
+            return self.get_default_genotype_storage()
         if storage_id not in self._genotype_storages:
             raise ValueError(f"unknown storage id {storage_id}")
         return self._genotype_storages[storage_id]

--- a/dae/dae/genotype_storage/tests/test_default_genotype_storage.py
+++ b/dae/dae/genotype_storage/tests/test_default_genotype_storage.py
@@ -1,0 +1,72 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import textwrap
+
+import pytest
+
+from dae.testing import setup_gpf_instance, setup_genome, \
+    setup_empty_gene_models, setup_directories
+
+
+@pytest.fixture
+def gpf_instance(tmp_path_factory):
+    root_path = tmp_path_factory.mktemp("default_storage_test")
+
+    genome = setup_genome(
+        root_path / "alla_gpf" / "genome" / "allChr.fa",
+        f"""
+        >chrA
+        {100 * "A"}
+        """
+    )
+    empty_gene_models = setup_empty_gene_models(
+        root_path / "alla_gpf" / "empty_gene_models" / "empty_genes.txt")
+
+    setup_directories(root_path / "gpf_instance", {
+        "gpf_instance.yaml": textwrap.dedent("""
+        genotype_storage:
+            default: alabala
+            storages:
+            - id: alabala
+              storage_type: inmemory
+              dir: "%(wd)s/alabala_storage"
+        """)
+    })
+
+    gpf = setup_gpf_instance(
+        root_path / "gpf_instance",
+        reference_genome=genome,
+        gene_models=empty_gene_models,
+    )
+    return gpf
+
+
+def test_default_genotype_storage(gpf_instance):
+    # Given
+    gpf = gpf_instance
+    # When
+    storage = gpf.genotype_storages.get_default_genotype_storage()
+
+    # Then
+    assert storage == gpf.genotype_storages.get_genotype_storage("alabala")
+
+
+def test_get_genotype_storage_with_none(gpf_instance):
+    # Given
+    gpf = gpf_instance
+
+    # When
+    storage = gpf.genotype_storages.get_genotype_storage(None)
+
+    # Then
+    assert storage == gpf.genotype_storages.get_genotype_storage("alabala")
+
+
+def test_missing_default_genotype_storage(gpf_instance, mocker):
+    # Given
+    gpf = gpf_instance
+    genotype_storages = gpf.genotype_storages
+    genotype_storages._default_genotype_storage = None
+
+    # When
+    with pytest.raises(ValueError, match="default genotype storage not set"):
+        genotype_storages.get_default_genotype_storage()


### PR DESCRIPTION
## Background

When `GenotypeStorageRegistry.get_genotype_storage()` is called with storage id `None`, it throws `ValueError` exception. This makes creating studies in production environments difficult because we use this behavior.

## Aim

`GenotypeStorageRegistry.get_genotype_storage(None)` should return the default genotype storage instead.

## Implementation

Implementation of the `get_genotype_storage` method is changed to check for `storage_id is None` and to return default genotype storage in this case. The `get_default_genotype_storage` method is also changed to raise `ValueError` if default genotype storage is not set.

Closes #251 