### PR TITLE
Add CLI tool to export AGP data into a file

### DIFF
--- a/dae/dae/autism_gene_profile/exporter.py
+++ b/dae/dae/autism_gene_profile/exporter.py
@@ -1,0 +1,73 @@
+import sys
+import argparse
+import logging
+
+from dae.utils.verbosity_configuration import VerbosityConfiguration
+from dae.__version__ import VERSION, RELEASE
+from dae.gpf_instance import GPFInstance
+
+
+logger = logging.getLogger("agp_exporter")
+
+
+def cli_export(argv=None, gpf_instance=None):
+    """CLI for exporting AGP data."""
+    if argv is None:
+        argv = sys.argv[1:]
+
+    desc = "Tool for export of Autism Gene Profiles"
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument(
+        "--version", action="store_true", default=False,
+        help="Prints GPF version and exists.")
+    VerbosityConfiguration.set_argumnets(parser)
+    parser.add_argument(
+        "--gpf", "-G", type=str, default=None,
+        help="Path to GPF instance configuration file.")
+    parser.add_argument(
+        "--output", "-o", type=str, default=None,
+        help="Output file name to store exported data.")
+
+    args = parser.parse_args(argv)
+
+    if args.version:
+        print(f"GPF version: {VERSION} ({RELEASE})")
+        sys.exit(0)
+
+    VerbosityConfiguration.set(args)
+    if gpf_instance is None:
+        gpf_instance = GPFInstance.build(args.gpf)
+    logger.info(
+        "working with GPF instance from %s", gpf_instance.dae_dir)
+
+    if not gpf_instance.get_agp_configuration():
+        logger.warning("missing AGP configuration; no AGP to export")
+        return 1
+
+    if args.output is None:
+        outfile = sys.stdout
+    else:
+        # pylint: disable=consider-using-with
+        outfile = open(args.output, "wt", encoding="utf8")
+
+    try:
+        rows = list(gpf_instance.query_agp_statistics(1))
+        header = "\t".join(rows[0].keys())
+        outfile.write(header)
+        outfile.write("\n")
+
+        page = 1
+        while True:
+            rows = list(gpf_instance.query_agp_statistics(page))
+            if len(rows) == 0:
+                break
+
+            for row in rows:
+                line = "\t".join(map(str, row.values()))
+                outfile.write(line)
+                outfile.write("\n")
+            logger.debug("page %s exported", page)
+            page += 1
+    finally:
+        if args.output is not None:
+            outfile.close()

--- a/dae/dae/autism_gene_profile/tests/test_agp_export.py
+++ b/dae/dae/autism_gene_profile/tests/test_agp_export.py
@@ -1,0 +1,44 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import pytest
+
+from dae.autism_gene_profile.exporter import cli_export
+from dae.autism_gene_profile.db import AutismGeneProfileDB
+
+
+@pytest.fixture
+def two_rows_agp(
+        temp_dbfile, agp_config, sample_agp, agp_gpf_instance, mocker):
+    agpdb = AutismGeneProfileDB(agp_config, temp_dbfile, clear=True)
+    agpdb.insert_agp(sample_agp)
+
+    sample_agp.gene_symbol = "CHD7"
+    sample_scores = sample_agp.genomic_scores
+    sample_scores["protection_scores"]["SFARI_gene_score"] = -11
+    agpdb.insert_agp(sample_agp)
+
+    mocker.patch.object(
+        agp_gpf_instance,
+        "_autism_gene_profile_db",
+        agpdb)
+
+    return agp_gpf_instance
+
+
+def test_agp_export_no_output(two_rows_agp, capsys):
+
+    cli_export([], two_rows_agp)
+    out, _err = capsys.readouterr()
+
+    lines = list(filter(len, out.split("\n")))
+    assert len(lines) == 3
+
+
+def test_agp_export(two_rows_agp, tmp_path):
+
+    outfile = str(tmp_path / "agp_export.tsv")
+    cli_export(["-o", outfile], two_rows_agp)
+
+    assert (tmp_path / "agp_export.tsv").exists()
+    content = (tmp_path / "agp_export.tsv").read_text()
+    lines = list(filter(len, content.split("\n")))
+    assert len(lines) == 3

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -72,6 +72,8 @@ setuptools.setup(
     annotate_columns=dae.annotation.annotate_columns:cli
     annotate_vcf=dae.annotation.annotate_vcf:cli
 
+    agp_exporter=dae.autism_gene_profile.exporter:cli_export
+
     dae2parquet.py=dae.tools.dae2parquet:main
     vcf2parquet.py=dae.tools.vcf2parquet:main
     vcf2schema2.py=dae.backends.schema2.vcf2schema2:main

--- a/dae_conftests/dae_conftests/dae_conftests.py
+++ b/dae_conftests/dae_conftests/dae_conftests.py
@@ -1099,7 +1099,7 @@ def agp_gpf_instance(
     return fixtures_gpf_instance
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def sample_agp():
     gene_sets = ["main_CHD8 target genes"]
     genomic_scores = {


### PR DESCRIPTION
Closes #256.

## Background

Recently I received a request to export the AGP data from the HG38 production instance into a tab-separated values file. I would like to have a CLI tool that can do that.

## Aim

Add a CLI tool agp_export that does the job.

## Implementation

The tool added uses the GPF instance `query_agp_statistics` method to collect and store all the data into a file.