### PR TITLE
Fix pedigrees download

### DIFF
--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -391,46 +391,6 @@ class GPFInstance:
                 configs.append(config.common_report)
         return configs
 
-    def get_common_report_families_data(self, common_report_id):
-        """Return common report families data."""
-        genotype_data = GPFInstance.get_genotype_data(self, common_report_id)
-        if not genotype_data:
-            return None
-
-        data = []
-        data.append(
-            [
-                "familyId",
-                "personId",
-                "dadId",
-                "momId",
-                "sex",
-                "status",
-                "role",
-                "genotype_data_study",
-            ]
-        )
-
-        families = list(genotype_data.families.values())
-        families.sort(key=lambda f: f.family_id)
-        for fam in families:
-            for person in fam.members_in_order:
-
-                row = [
-                    person.family_id,
-                    person.person_id,
-                    person.dad_id if person.dad_id else "0",
-                    person.mom_id if person.mom_id else "0",
-                    person.sex,
-                    person.status,
-                    person.role,
-                    genotype_data.name,
-                ]
-
-                data.append(row)
-
-        return map(join_line, data)
-
     # Gene sets
     def get_gene_sets_collections(self):
         return self.gene_sets_db.collections_descriptions

--- a/dae/dae/pedigrees/family.py
+++ b/dae/dae/pedigrees/family.py
@@ -345,24 +345,6 @@ class Family:
         columns.extend(sorted(extension_columns))
         return columns
 
-    def to_rows(self, sep="\t", columns=None):
-        if columns is None:
-            columns = self.get_columns()
-        rows = []
-        for member in self.full_members:
-            record = copy.deepcopy(member._attributes)
-            record["mom_id"] = member.mom_id if member.mom_id else "0"
-            record["dad_id"] = member.dad_id if member.dad_id else "0"
-            record["generated"] = member.generated \
-                if member.generated else False
-            record["not_sequenced"] = member.not_sequenced \
-                if member.not_sequenced else False
-            row = []
-            for col in columns:
-                row.append(str(record[col]))
-            rows.append(f"{sep.join(row)}\n")
-        return rows
-
     def add_members(self, persons: List[Person]) -> None:
         assert all(isinstance(p, Person) for p in persons)
         assert all(p.family_id == self.family_id for p in persons)
@@ -694,14 +676,6 @@ class FamiliesData(Mapping[str, Family]):
             self._ped_df = ped_df
 
         return self._ped_df
-
-    def to_rows(self, sep="\t", columns=None) -> List[str]:
-        if columns is None:
-            columns = list(self.values())[0].get_columns()
-        rows = [f"{sep.join(columns)}\n"]
-        for family in self.values():
-            rows.extend(family.to_rows(sep=sep, columns=columns))
-        return rows
 
     def copy(self) -> FamiliesData:
         """Build a copy of a families data object."""

--- a/dae/dae/pedigrees/serializer.py
+++ b/dae/dae/pedigrees/serializer.py
@@ -1,0 +1,42 @@
+import copy
+from typing import List
+from dae.pedigrees.family import FamiliesData, Family
+
+
+class FamiliesTsvSerializer:
+    """Class for serializing families into TSV format."""
+
+    def __init__(self, families: FamiliesData):
+        self._families = families
+
+    def serialize(self, sep="\t", columns=None) -> List[str]:
+        """Serialize families to list of lines with a header."""
+        if columns is None:
+            columns = list(self._families.values())[0].get_columns()
+        rows = [f"{sep.join(columns)}\n"]
+        for family in self._families.values():
+            rows.extend(
+                self._serialize_family(family, sep=sep, columns=columns)
+            )
+        return rows
+
+    @staticmethod
+    def _serialize_family(family: Family, sep="\t", columns=None) -> List[str]:
+        """Serialize family to a list of lines per member."""
+        if columns is None:
+            columns = family.get_columns()
+        rows = []
+        for member in family.full_members:
+            # pylint: disable=protected-access
+            record = copy.deepcopy(member._attributes)
+            record["mom_id"] = member.mom_id if member.mom_id else "0"
+            record["dad_id"] = member.dad_id if member.dad_id else "0"
+            record["generated"] = member.generated \
+                if member.generated else False
+            record["not_sequenced"] = member.not_sequenced \
+                if member.not_sequenced else False
+            row = []
+            for col in columns:
+                row.append(str(record[col]))
+            rows.append(f"{sep.join(row)}\n")
+        return rows

--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -87,7 +87,7 @@ def test_families_tags_download(admin_client):
 
     res = list(response.streaming_content)
     print(b"".join(res).decode())
-    assert len(res) == 31
+    assert len(res) == 24
 
 
 def test_families_tags_download_succeeds_on_empty_tags(admin_client):
@@ -132,30 +132,7 @@ def test_families_data_download(admin_client):
     streaming_content = list(response.streaming_content)
     assert streaming_content
 
-    assert len(streaming_content) == 31
-
-    header = streaming_content[0].decode("utf8")
-    assert header[-1] == "\n"
-    header = header[:-1].split("\t")
-    assert len(header) == 8
-
-    assert header == [
-        "familyId",
-        "personId",
-        "dadId",
-        "momId",
-        "sex",
-        "status",
-        "role",
-        "genotype_data_study",
-    ]
-
-    first_person = streaming_content[1].decode("utf8")
-    assert first_person[-1] == "\n"
-    first_person = first_person[:-1].split("\t")
-    assert len(first_person) == 8
-
-    assert first_person[-1] == "Study1"
+    assert len(streaming_content) == 34
 
 
 @pytest.mark.xfail(reason="this test is flipping; should be investigated")

--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -68,14 +68,15 @@ def test_family_counters_download(admin_client):
 
     res = list(response.streaming_content)
     print(b"".join(res).decode())
-    assert len(res) == 863
+
+    assert len(res) == 13
     # assert data == ["f2", "f4"]
 
 
 def test_families_tags_download(admin_client):
     url = (
-        "/api/v3/common_reports/families_data/download?"
-        "study_id=Study1&tags=tag_nuclear_family,tag_trio_family"
+        "/api/v3/common_reports/families_data/Study1?"
+        "tags=tag_nuclear_family,tag_trio_family"
     )
     response = admin_client.get(
         url, content_type="application/json"
@@ -86,25 +87,12 @@ def test_families_tags_download(admin_client):
 
     res = list(response.streaming_content)
     print(b"".join(res).decode())
-    assert len(res) == 7279
+    assert len(res) == 31
 
 
 def test_families_tags_download_succeeds_on_empty_tags(admin_client):
-    url = (
-        "/api/v3/common_reports/families_data/download?"
-        "study_id=Study1&tags="
-    )
-    response = admin_client.get(
-        url, content_type="application/json"
-    )
+    url = "/api/v3/common_reports/families_data/Study1?tags="
 
-    assert response
-    assert response.status_code == status.HTTP_200_OK
-
-    url = (
-        "/api/v3/common_reports/families_data/download?"
-        "study_id=Study1"
-    )
     response = admin_client.get(
         url, content_type="application/json"
     )

--- a/wdae/wdae/common_reports_api/urls.py
+++ b/wdae/wdae/common_reports_api/urls.py
@@ -29,10 +29,6 @@ urlpatterns = [
         name="family_counter_list",
     ),
     re_path(
-        r"^/families_data/download$",
-        views.FamiliesDataTagDownload.as_view(),
-    ),
-    re_path(
         r"^/families_data/(?P<dataset_id>.+)$",
         views.FamiliesDataDownloadView.as_view(),
     ),

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -101,10 +101,8 @@ class FamilyCounterDownloadView(QueryBaseView):
             for family_id in counter_families
         })
 
-        ped_df = counter_families_data.ped_df
-
         response = StreamingHttpResponse(
-            ped_df.to_csv(index=False, sep="\t"),
+            counter_families_data.to_rows(),
             content_type="text/tab-separated-values"
         )
         response["Content-Disposition"] = "attachment; filename=families.ped"
@@ -113,15 +111,14 @@ class FamilyCounterDownloadView(QueryBaseView):
         return response
 
 
-class FamiliesDataTagDownload(QueryBaseView):
-    def get(self, request):
-        study_id = request.GET.get("study_id")
+class FamiliesDataDownloadView(QueryBaseView):
+    def get(self, request, dataset_id):
         tags = request.GET.get("tags")
 
-        if study_id is None:
+        if dataset_id is None or dataset_id == "":
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        study = self.gpf_instance.get_genotype_data(study_id)
+        study = self.gpf_instance.get_genotype_data(dataset_id)
 
         if study is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
@@ -151,7 +148,7 @@ class FamiliesDataTagDownload(QueryBaseView):
             result = FamiliesData.from_families(result)
 
         response = StreamingHttpResponse(
-            result.ped_df.to_csv(index=False, sep="\t"),
+            result.to_rows(),
             content_type="text/tab-separated-values"
         )
         response["Content-Disposition"] = "attachment; filename=families.ped"

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -160,26 +160,3 @@ class FamiliesDataDownloadView(QueryBaseView):
         response["Expires"] = "0"
 
         return response
-
-
-class FamiliesDataDownloadView(QueryBaseView):
-    def get(self, request, dataset_id):
-        if not user_has_permission(
-            request.user, dataset_id
-        ):
-            return Response(status=status.HTTP_403_FORBIDDEN)
-
-        families_data = self.gpf_instance.get_common_report_families_data(
-            dataset_id
-        )
-        if not families_data:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        response = StreamingHttpResponse(
-            families_data, content_type="text/tsv"
-        )
-
-        response["Content-Disposition"] = "attachment; filename=families.ped"
-        response["Expires"] = "0"
-
-        return response

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -9,6 +9,7 @@ from query_base.query_base import QueryBaseView
 
 from dae.pedigrees.family import FamiliesData
 from dae.pedigrees.family_tag_builder import check_tag
+from dae.pedigrees.serializer import FamiliesTsvSerializer
 
 
 class VariantReportsView(QueryBaseView):
@@ -101,8 +102,10 @@ class FamilyCounterDownloadView(QueryBaseView):
             for family_id in counter_families
         })
 
+        serializer = FamiliesTsvSerializer(counter_families_data)
+
         response = StreamingHttpResponse(
-            counter_families_data.to_rows(),
+            serializer.serialize(),
             content_type="text/tab-separated-values"
         )
         response["Content-Disposition"] = "attachment; filename=families.ped"
@@ -115,7 +118,7 @@ class FamiliesDataDownloadView(QueryBaseView):
     def get(self, request, dataset_id):
         tags = request.GET.get("tags")
 
-        if dataset_id is None or dataset_id == "":
+        if not dataset_id:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         study = self.gpf_instance.get_genotype_data(dataset_id)
@@ -147,8 +150,10 @@ class FamiliesDataDownloadView(QueryBaseView):
 
             result = FamiliesData.from_families(result)
 
+        serializer = FamiliesTsvSerializer(result)
+
         response = StreamingHttpResponse(
-            result.to_rows(),
+            serializer.serialize(),
             content_type="text/tab-separated-values"
         )
         response["Content-Disposition"] = "attachment; filename=families.ped"

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -239,7 +239,7 @@ class DatasetPermissionsView(QueryBaseView):
     def get(self, request):
         dataset_search = request.GET.get("search")
         page = request.GET.get("page", 1)
-        query  = Dataset.objects
+        query = Dataset.objects
         if dataset_search is not None and dataset_search != "":
             query = query.filter(dataset_id__icontains=dataset_search)
 
@@ -260,7 +260,9 @@ class DatasetPermissionsView(QueryBaseView):
             user_model = get_user_model()
             users_list = []
             for group in groups:
-                users = user_model.objects.filter(groups__name=group.name).all()
+                users = user_model.objects.filter(
+                    groups__name=group.name
+                ).all()
                 users_list += [
                     {"name": user.name, "email": user.email}
                     for user in users


### PR DESCRIPTION
## Background

We added the functionality to download a filtered list of pedigrees by tags. The initial implementation was slow for some reason and this had to be fixed.

## Aim

To fix the slow download of pedigrees when filtering by tags.

## Implementation

The bug was due to pandas Dataframe.to_csv method returning the result as an entire string, which was later passed on to a streaming response. This resulted in a lot of overhead because every single character was being streamed individually.
I decided to change the method from using dataframes, as it could also lead to a slower download when working with larger pedigrees.
There were also 2 download routes, of which one supported tags and had a complete response with all fields, and one which just returned all pedigrees but with more limited data. The code from the latter has been cleaned up and they have been merged into one to avoid route repetition.

Closes #258 
