### PR TITLE
Various fixes to download routes in API

### DIFF
--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -70,19 +70,12 @@ class QueryVariantsView(QueryBaseView):
 
 
 class DownloadSummaryVariantsView(QueryBaseView):
-
     DOWNLOAD_LIMIT = 10000
-
-    def _parse_query_params(self, data):
-        res = {str(k): str(v) for k, v in list(data.items())}
-        assert "queryData" in res
-        query = json.loads(res["queryData"])
-        return query
 
     @expand_gene_set
     @request_logging(LOGGER)
     def post(self, request):
-        data = self._parse_query_params(request.data)
+        data = request.data
         dataset_id = data.pop("datasetId", None)
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/wdae/wdae/genotype_browser/tests/test_effect_types_download.py
+++ b/wdae/wdae/genotype_browser/tests/test_effect_types_download.py
@@ -4,14 +4,11 @@ import json
 from rest_framework import status  # type: ignore
 
 
-def test_effect_details_download(
-        admin_client, datasets):
+def test_effect_details_download(admin_client, datasets):
     data = {
-        "queryData": json.dumps({
-            "datasetId": "iossifov_2014",
-            "effectTypes": ["missense"],
-            "download": True,
-        })
+        "datasetId": "iossifov_2014",
+        "effectTypes": ["missense"],
+        "download": True,
     }
     response = admin_client.post(
         "/api/v3/genotype_browser/query",

--- a/wdae/wdae/genotype_browser/tests/test_query_api.py
+++ b/wdae/wdae/genotype_browser/tests/test_query_api.py
@@ -40,26 +40,21 @@ def test_simple_query(db, admin_client, preview_sources):
 def test_simple_query_download_anonymous(
         db, anonymous_client, download_sources):
     data = {
-        "queryData": json.dumps({
-            **EXAMPLE_REQUEST_F1,
-            "download": True,
-            "sources": download_sources
-        })
+        **EXAMPLE_REQUEST_F1,
+        "download": True,
+        "sources": download_sources
     }
-
     response = anonymous_client.post(
         QUERY_VARIANTS_URL, json.dumps(data), content_type=JSON_CONTENT_TYPE
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_simple_query_download(db, admin_client, download_sources):
     data = {
-        "queryData": json.dumps({
-            **EXAMPLE_REQUEST_F1,
-            "download": True,
-            "sources": download_sources
-        })
+        **EXAMPLE_REQUEST_F1,
+        "download": True,
+        "sources": download_sources
     }
 
     response = admin_client.post(
@@ -122,11 +117,9 @@ def test_simple_query_summary_variants_download(
     db, admin_client, summary_download_sources
 ):
     data = {
-        "queryData": json.dumps({
-            **EXAMPLE_REQUEST_F1,
-            "download": True,
-            "sources": summary_download_sources
-        })
+        **EXAMPLE_REQUEST_F1,
+        "download": True,
+        "sources": summary_download_sources
     }
 
     response = admin_client.post(
@@ -268,11 +261,9 @@ def test_mixed_dataset_rights_download(
     db, user, user_client, download_sources
 ):
     data = {
-        "queryData": json.dumps({
-            "datasetId": "composite_dataset_ds",
-            "sources": list(download_sources),
-            "download": True,
-        })
+        "datasetId": "composite_dataset_ds",
+        "sources": list(download_sources),
+        "download": True,
     }
 
     add_group_perm_to_dataset("new_custom_group", "inheritance_trio")

--- a/wdae/wdae/genotype_browser/views.py
+++ b/wdae/wdae/genotype_browser/views.py
@@ -1,5 +1,4 @@
 """Genotype browser routes for browsing and listing variants in studies."""
-import json
 import logging
 import itertools
 
@@ -30,13 +29,6 @@ class GenotypeBrowserQueryView(QueryBaseView):
     """Genotype browser queries view."""
 
     MAX_SHOWN_VARIANTS = 1000
-
-    @staticmethod
-    def _parse_query_params(data):
-        res = {str(k): str(v) for k, v in list(data.items())}
-        assert "queryData" in res
-        query = json.loads(res["queryData"])
-        return query
 
     @expand_gene_set
     @request_logging(LOGGER)
@@ -113,15 +105,13 @@ class GenotypeBrowserQueryView(QueryBaseView):
         data = request.data
         user = request.user
 
-        if "queryData" in data:
-            data = self._parse_query_params(data)
-        dataset_id = data.pop("datasetId", None)
-
-        if not user_has_permission(request.user, dataset_id):
-            return Response(status=status.HTTP_403_FORBIDDEN)
+        dataset_id = data.get("datasetId", None)
 
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
+        if not user_has_permission(request.user, dataset_id):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
         if "genomicScores" in data:
             scores = data["genomicScores"]
             for score in scores:

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -19,9 +19,6 @@ class PhenoBrowserBaseView(QueryBaseView):
 
 
 class PhenoConfigView(PhenoBrowserBaseView):
-    def __init__(self):
-        super(PhenoConfigView, self).__init__()
-
     def get(self, request):
         logger.debug(f"pheno_config: {self.pheno_config}")
 
@@ -39,9 +36,6 @@ class PhenoConfigView(PhenoBrowserBaseView):
 
 
 class PhenoInstrumentsView(QueryBaseView):
-    def __init__(self):
-        super(PhenoInstrumentsView, self).__init__()
-
     def get(self, request):
         if "dataset_id" not in request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -60,9 +54,6 @@ class PhenoInstrumentsView(QueryBaseView):
 
 
 class PhenoMeasuresInfoView(PhenoBrowserBaseView):
-    def __init__(self):
-        super(PhenoMeasuresInfoView, self).__init__()
-
     def get(self, request):
         if "dataset_id" not in request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -104,9 +95,6 @@ class PhenoMeasureDescriptionView(PhenoBrowserBaseView):
 
 
 class PhenoMeasuresView(PhenoBrowserBaseView):
-    def __init__(self):
-        super(PhenoMeasuresView, self).__init__()
-
     def get(self, request):
         if "dataset_id" not in request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Background

Multiple download functionalities on the frontend were broken after the merge of the OAuth branch. These download functionalities were implemented because they used HTML form elements to initiate the download. Headers cannot be set on HTML forms, making it impossible to attach an authorization token. Additionally, they'd send a stringified JSON as the request body, which would have to be parsed before being used. This step is no longer needed as a proper JSON request is being sent.

## Aim

Adjust API to changes in the frontend.

## Implementation

Removed a few _parse_query_params functions that are now obsolete. Added explicit check for permissions on pheno tool download.