### PR TITLE
Import tools multi file configs i.e. support for embedded annotations and external input

### DIFF
--- a/dae/dae/configuration/schemas/import_config.py
+++ b/dae/dae/configuration/schemas/import_config.py
@@ -37,35 +37,42 @@ _loader_processing_schema = {
     ],
 }
 
+embedded_input_schema = {
+    "vcf": {
+        "type": "dict",
+        "schema": {},
+    },
+    "denovo": {
+        "type": "dict",
+        "schema": {},
+    },
+    "cnv": {
+        "type": "dict",
+        "schema": {},
+    },
+    "dae": {
+        "type": "dict",
+        "schema": {},
+    },
+    "pedigree": {
+        "type": "dict",
+        "schema": {
+            "file": {"type": "string", "required": True},
+        },
+    },
+    "input_dir": {"type": "string"}
+}
+
 import_config_schema = {
     "id": {"type": "string"},
     "input": {
         "type": "dict",
-        "schema": {
-            "vcf": {
-                "type": "dict",
-                "schema": {},
+        "anyof_schema": [
+            {
+                "file": {"type": "string"}
             },
-            "denovo": {
-                "type": "dict",
-                "schema": {},
-            },
-            "cnv": {
-                "type": "dict",
-                "schema": {},
-            },
-            "dae": {
-                "type": "dict",
-                "schema": {},
-            },
-            "pedigree": {
-                "type": "dict",
-                "schema": {
-                    "file": {"type": "string", "required": True},
-                },
-            },
-            "input_dir": {"type": "string"}
-        },
+            embedded_input_schema
+        ],
     },
     "processing_config": {
         "type": "dict",
@@ -134,23 +141,23 @@ import_config_schema = {
 def _fill_with_loader_arguments():
     _set_loader_args(
         VcfLoader,
-        import_config_schema["input"]["schema"]["vcf"]["schema"],
+        import_config_schema["input"]["anyof_schema"][1]["vcf"]["schema"],
         "vcf_")
     _set_loader_args(
         DenovoLoader,
-        import_config_schema["input"]["schema"]["denovo"]["schema"],
+        import_config_schema["input"]["anyof_schema"][1]["denovo"]["schema"],
         "denovo_")
     _set_loader_args(
         CNVLoader,
-        import_config_schema["input"]["schema"]["cnv"]["schema"],
+        import_config_schema["input"]["anyof_schema"][1]["cnv"]["schema"],
         "cnv_")
     _set_loader_args(
         DaeTransmittedLoader,
-        import_config_schema["input"]["schema"]["dae"]["schema"],
+        import_config_schema["input"]["anyof_schema"][1]["dae"]["schema"],
         "dae_")
     _copy_loader_args(
         FamiliesLoader,
-        import_config_schema["input"]["schema"]["pedigree"]["schema"],
+        import_config_schema["input"]["anyof_schema"][1]["pedigree"]["schema"],
         "ped_")
 
 

--- a/dae/dae/configuration/schemas/import_config.py
+++ b/dae/dae/configuration/schemas/import_config.py
@@ -94,6 +94,19 @@ import_config_schema = {
             "cnv": {"anyof_type": ["integer", "string"]},
         },
     },
+    "annotation": {
+        "anyof": [
+            {
+                "type": "dict",
+                "schema": {
+                    "file": {"type": "string"}
+                }
+            }, {
+                "type": "list",
+                "allow_unknown": True,
+            }
+        ]
+    },
     "destination": {
         "type": "dict",
         "anyof_schema": [

--- a/dae/dae/docs/import_tools.rst
+++ b/dae/dae/docs/import_tools.rst
@@ -39,25 +39,26 @@ Import Tools configuration format
         file: "external file defining input"
         (OR)
         input_dir:
-    
+
         pedigree:
             file: %(input_dir)s/SFARI_SPARK_WES_2.ped
 
-    vcf:
-        files:
-            - wes2_15995_exome.gatk.vcf.gz
-        denovo_mode: ignore
-        omission_mode: ignore
-        add_chrom_prefix: chr
-    denovo:
-        files:
-            - wes2_merged_cohFreq_Cut17_final_v1_ALL_042921_GPF.tsv.txt
-        persion_id: spid
-        chrom: chrom
-        pos: pos
-        ref: ref
-        alt: alt
-        add_chrom_prefix: chr
+        vcf:
+            files:
+                - wes2_15995_exome.gatk.vcf.gz
+            denovo_mode: ignore
+            omission_mode: ignore
+            add_chrom_prefix: chr
+
+        denovo:
+            files:
+                - wes2_merged_cohFreq_Cut17_final_v1_ALL_042921_GPF.tsv.txt
+            persion_id: spid
+            chrom: chrom
+            pos: pos
+            ref: ref
+            alt: alt
+            add_chrom_prefix: chr
 
     processing_config:
         vcf: single_bucket

--- a/dae/dae/impala_storage/schema1/impala_genotype_storage.py
+++ b/dae/dae/impala_storage/schema1/impala_genotype_storage.py
@@ -74,19 +74,10 @@ class ImpalaGenotypeStorage(GenotypeStorage):
     def __init__(self, storage_config: Dict[str, Any]):
         super().__init__(storage_config)
 
-        impala_hosts = self.storage_config["impala"]["hosts"]
-        impala_port = self.storage_config["impala"]["port"]
-        pool_size = self.storage_config["impala"]["pool_size"]
-
-        self._impala_helpers = ImpalaHelpers(
-            impala_hosts=impala_hosts, impala_port=impala_port,
-            pool_size=pool_size)
+        self._impala_helpers = None
 
         self._hdfs_helpers = None
         self._rsync_helpers = None
-        if self.storage_config.get("rsync"):
-            self._rsync_helpers = RsyncHelpers(
-                self.storage_config["rsync"]["location"])
 
     @classmethod
     def validate_and_normalize_config(cls, config: Dict) -> Dict:
@@ -119,7 +110,16 @@ class ImpalaGenotypeStorage(GenotypeStorage):
 
     @property
     def impala_helpers(self):
-        assert self._impala_helpers is not None
+        """Return an impala helper object."""
+        if self._impala_helpers is None:
+            impala_hosts = self.storage_config["impala"]["hosts"]
+            impala_port = self.storage_config["impala"]["port"]
+            pool_size = self.storage_config["impala"]["pool_size"]
+
+            self._impala_helpers = ImpalaHelpers(
+                impala_hosts=impala_hosts, impala_port=impala_port,
+                pool_size=pool_size)
+
         return self._impala_helpers
 
     @property
@@ -137,6 +137,10 @@ class ImpalaGenotypeStorage(GenotypeStorage):
 
     @property
     def rsync_helpers(self):
+        if self._rsync_helpers is None and self.storage_config.get("rsync"):
+            self._rsync_helpers = RsyncHelpers(
+                self.storage_config["rsync"]["location"]
+            )
         return self._rsync_helpers
 
     @classmethod

--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -97,10 +97,8 @@ class ImpalaSchema1ImportStorage(ImportStorage):
             logger.error("missing or non-impala genotype storage")
             return
 
-        study_id = project.study_id
-
         hdfs_variants_dir = \
-            genotype_storage.default_variants_hdfs_dirname(study_id)
+            genotype_storage.default_variants_hdfs_dirname(project.study_id)
 
         hdfs_pedigree_file = \
             genotype_storage.default_pedigree_hdfs_filename(project.study_id)

--- a/dae/dae/impala_storage/schema2/schema2_genotype_storage.py
+++ b/dae/dae/impala_storage/schema2/schema2_genotype_storage.py
@@ -31,14 +31,7 @@ class Schema2GenotypeStorage(GenotypeStorage):
     def __init__(self, storage_config: Dict[str, Any]):
         super().__init__(storage_config)
         self._hdfs_helpers = None
-
-        impala_hosts = self.storage_config["impala"]["hosts"]
-        impala_port = self.storage_config["impala"]["port"]
-        pool_size = self.storage_config["impala"]["pool_size"]
-
-        self._impala_helpers = ImpalaHelpers(
-            impala_hosts=impala_hosts, impala_port=impala_port,
-            pool_size=pool_size)
+        self._impala_helpers = None
 
     @classmethod
     def get_storage_type(cls) -> str:
@@ -232,7 +225,16 @@ class Schema2GenotypeStorage(GenotypeStorage):
 
     @property
     def impala_helpers(self):
-        assert self._impala_helpers is not None
+        """Return the impala helper object."""
+        if self._impala_helpers is None:
+            impala_hosts = self.storage_config["impala"]["hosts"]
+            impala_port = self.storage_config["impala"]["port"]
+            pool_size = self.storage_config["impala"]["pool_size"]
+
+            self._impala_helpers = ImpalaHelpers(
+                impala_hosts=impala_hosts, impala_port=impala_port,
+                pool_size=pool_size)
+
         return self._impala_helpers
 
     @staticmethod

--- a/dae/dae/impala_storage/tests/test_storage_is_serializable.py
+++ b/dae/dae/impala_storage/tests/test_storage_is_serializable.py
@@ -1,0 +1,31 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import cloudpickle  # type: ignore
+import pytest
+from dae.impala_storage.schema1.impala_genotype_storage import \
+    ImpalaGenotypeStorage
+from dae.impala_storage.schema2.schema2_genotype_storage import \
+    Schema2GenotypeStorage
+
+
+@pytest.mark.parametrize("storage_cls, storage_type", [
+    (ImpalaGenotypeStorage, "impala"),
+    (Schema2GenotypeStorage, "impala2"),
+])
+def test_genotype_storage_is_cpickle_serializable(storage_cls, storage_type):
+    storage = storage_cls({
+        "id": "storage",
+        "storage_type": storage_type,
+        "impala": {
+            "db": "db_name",
+            "hosts": ["localhost"],
+            "port": 21050,
+            "pool_size": 3,
+        },
+        "hdfs": {
+            "base_dir": "/studies",
+            "host": "localhost",
+            "port": 8020,
+            "replication": 1,
+        }
+    })
+    _ = cloudpickle.dumps(storage)

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -243,7 +243,7 @@ class ImportProject():
             if instance_dir is None:
                 config_filename = None
             else:
-                config_filename = os.path.join(
+                config_filename = fs_utils.join(
                     instance_dir, "gpf_instance.yaml")
             self._gpf_instance = \
                 GPFInstance.build(config_filename)
@@ -271,7 +271,7 @@ class ImportProject():
     @property
     def input_dir(self):
         """Return the path relative to which input files are specified."""
-        return os.path.join(
+        return fs_utils.join(
             self._base_input_dir,
             self.import_config["input"].get("input_dir", "")
         )
@@ -535,7 +535,7 @@ class ImportConfigNormalizer:
 
         sub_config = config[section_key]
         while "file" in sub_config:
-            external_fn = os.path.join(base_input_dir, sub_config["file"])
+            external_fn = fs_utils.join(base_input_dir, sub_config["file"])
             sub_config = GPFConfigParser.parse_and_interpolate_file(
                 external_fn
             )

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -55,7 +55,8 @@ class ImportProject():
     """
 
     # pylint: disable=too-many-public-methods
-    def __init__(self, import_config, base_input_dir, gpf_instance=None):
+    def __init__(self, import_config, base_input_dir, base_config_dir=None,
+                 gpf_instance=None):
         """Create a new project from the provided config.
 
         It is best not to call this ctor directly but to use one of the
@@ -68,6 +69,7 @@ class ImportProject():
             assert len_files == 1, "Support for multiple denovo files is NYI"
 
         self._base_input_dir = base_input_dir
+        self._base_config_dir = base_config_dir or base_input_dir
         self._gpf_instance = gpf_instance
         self.stats: StatsCollection = StatsCollection()
 
@@ -82,10 +84,13 @@ class ImportProject():
         import_config = GPFConfigParser.validate_config(import_config,
                                                         import_config_schema)
         normalizer = ImportConfigNormalizer()
+        base_config_dir = base_input_dir
         import_config, base_input_dir = \
             normalizer.normalize(import_config, base_input_dir)
         return ImportProject(
-            import_config, base_input_dir, gpf_instance=gpf_instance)
+            import_config, base_input_dir, base_config_dir,
+            gpf_instance=gpf_instance
+        )
 
     @staticmethod
     def build_from_file(import_filename, gpf_instance=None):
@@ -479,7 +484,9 @@ class ImportProject():
         annotation_config = self.import_config["annotation"]
         if "file" in annotation_config:
             # pipeline in external file
-            annotation_config_file = annotation_config["file"]
+            annotation_config_file = fs_utils.join(
+                self._base_config_dir, annotation_config["file"]
+            )
             return construct_import_annotation_pipeline(
                 gpf_instance, annotation_configfile=annotation_config_file
             )

--- a/dae/dae/import_tools/tests/resources/external_input/files/input.yaml
+++ b/dae/dae/import_tools/tests/resources/external_input/files/input.yaml
@@ -1,0 +1,7 @@
+pedigree:
+  file: multivcf.ped
+
+vcf:
+  files:
+    - multivcf_[vc].vcf.gz
+  chromosomes: 1,2,3

--- a/dae/dae/import_tools/tests/resources/external_input/import_config.yaml
+++ b/dae/dae/import_tools/tests/resources/external_input/import_config.yaml
@@ -1,0 +1,13 @@
+id: test_import
+
+input:
+  file: files/input.yaml
+
+partition_description:
+  region_bin:
+    chromosomes: 1, 2, 3, 4
+    region_length: 100000000
+  family_bin:
+    family_bin_size: 10
+  frequency_bin:
+    rare_boundary: 5

--- a/dae/dae/import_tools/tests/test_import_configs.py
+++ b/dae/dae/import_tools/tests/test_import_configs.py
@@ -272,3 +272,19 @@ def test_input_in_external_file(resources_dir):
     project = import_tools.ImportProject.build_from_file(config_fn)
 
     assert project.input_dir == f"{resources_dir}/external_input/files/"
+
+
+def test_embedded_annotation_pipeline():
+    import_config = dict(
+        input={},
+        annotation=[
+            dict(np_score=dict(
+                resource_id="hg19/scores/CADD",
+            ))
+        ]
+    )
+    project = import_tools.ImportProject.build_from_config(import_config)
+    pipeline = project._build_annotation_pipeline(project.get_gpf_instance())
+    assert pipeline.config == [
+        {"resource_id": "hg19/scores/CADD", "annotator_type": "np_score"}
+    ]

--- a/dae/dae/import_tools/tests/test_import_configs.py
+++ b/dae/dae/import_tools/tests/test_import_configs.py
@@ -265,3 +265,10 @@ def test_del_chrom_prefix_already_deleted(resources_dir):
     project = import_tools.ImportProject.build_from_config(config)
     with pytest.raises(ValueError):
         project._get_variant_loader("vcf")
+
+
+def test_input_in_external_file(resources_dir):
+    config_fn = resources_dir / "external_input" / "import_config.yaml"
+    project = import_tools.ImportProject.build_from_file(config_fn)
+
+    assert project.input_dir == f"{resources_dir}/external_input/files/"

--- a/dae/dae/import_tools/tests/test_import_project.py
+++ b/dae/dae/import_tools/tests/test_import_project.py
@@ -1,0 +1,14 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import cloudpickle  # type: ignore
+from dae.import_tools.import_tools import ImportProject
+
+
+def test_import_project_is_cpickle_serializable():
+    import_config = dict(
+        input={},
+    )
+    project = ImportProject.build_from_config(import_config)
+    _ = cloudpickle.dumps(project)
+
+    _ = project.get_import_storage()
+    _ = cloudpickle.dumps(project)


### PR DESCRIPTION
## Background

Until now the entire import config had to be in a single file apart from the annotation config which had to be in a separate file.

## Aim

This PR provides support for embedding the annotation pipeline in the import config and extracting the input config into a separate file. This allow for the input (study files + a description) to be packed in a single folder separate from the configuration of the actual import process.
