### PR TITLE
Switch to using conda package for `django-oauth-toolkit.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Create a conda `gpf` environment with all of the conda package dependencies
 from `environment.yml` and `dev-environment.yml` files:
 
 ```bash
-conda env create --name gpf --file ./environment.yml
-conda env update --name gpf --file ./dev-environment.yml
+mamba env create --name gpf --file ./environment.yml
+mamba env update --name gpf --file ./dev-environment.yml
 ```
 
 To use this environment, you need to activate it using the following command:

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -37,6 +37,7 @@ dependencies:
   - types-requests=2.27.30
   - dask-jobqueue=0.7.3
   - bandit=1.7.4
+  - pip=22.3.1
   - pip:
     - sphinx-autorun==1.1.1
     - sphinx-copybutton==0.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -35,9 +35,10 @@ dependencies:
   - setuptools=65.0.1
   - sqlalchemy=1.4.40
   - sqlite=3.39.2
-  - django==4.1
+  - django=4.1.3
   - django-cors-headers=3.13.0
   - djangorestframework=3.13.1
+  - django-oauth-toolkit=2.2.0
   - openjdk=8.0.312
   - hadoop=3.1.2
   - deprecation=2.1.0
@@ -49,8 +50,3 @@ dependencies:
   - dask=2022.7.1
   - dask-kubernetes=2022.7.0
   - tqdm=4.64.0
-  - snakeobjects=3.1.1
-  - google-cloud-bigquery=3.2.0
-  - pip=21.3.1
-  - pip:
-    - django-oauth-toolkit==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python==3.10.4
+python==3.9.12
 importlib_metadata==4.11.3
 pysam==0.19.1
 samtools==1.15.1
@@ -22,9 +22,10 @@ python-box==6.0.2
 setuptools==65.0.1
 sqlalchemy==1.4.40
 sqlite==3.39.2
-django==4.1
+django==4.1.3
 django-cors-headers==3.13.0
 djangorestframework==3.13.1
+django-oauth-toolkit==2.2.0
 openjdk==8.0.312
 hadoop==3.1.2
 deprecation==2.1.0
@@ -36,8 +37,6 @@ ijson==3.1.4
 dask==2022.7.1
 dask-kubernetes==2022.7.0
 tqdm==4.64.0
-snakeobjects==3.1.1
-google-cloud-bigquery==3.2.0
 bump2version==1.0.1
 sphinx==4.5.0
 sphinx_rtd_theme==1.0.0
@@ -48,11 +47,11 @@ flake8==4.0.1
 flake8-quotes==3.3.1
 flake8-docstrings==1.6.0
 mypy==0.931
-pytest==7.1.2
-pytest-cov==3.0.0
-pytest-mock==3.7.0
+pytest==7.1.3
+pytest-cov==4.0.0
+pytest-mock==3.10.0
 pytest-django==4.5.2
-pytest-doctestplus==0.12.0
+pytest-doctestplus==0.12.1
 pylint==2.13.8
 werkzeug==2.1.2
 moto==3.1.16
@@ -66,6 +65,8 @@ types-python-dateutil==2.8.9
 types-requests==2.27.30
 dask-jobqueue==0.7.3
 bandit==1.7.4
-pip==21.3.1
+pip==22.3.1
 sphinx-autorun===1.1.1
+sphinx-copybutton===0.5.0
+sphinx-rtd-theme===1.0.0
 rangehttpserver===1.2.0


### PR DESCRIPTION
## Background

We use `django-oauth-toolkit,` which has no conda package, so for development, we use it as a `pip` dependency. This brokes the packaging of `gpf_wdae` because conda recipes could not use `pip` dependencies.

## Aim
We need to fix the conda packaging of `gpf_dae` and `gpf_wdae.`

## Implementation

To fix the conda packaging of `gpf_dae` and `gpf_wdae,` we built a conda package for `django-oauth-toolkit` and published it in the iossifovlab conda channel:
https://github.com/seqpipe/conda-recipies/tree/master/django-oauth-toolkit

Also, we cleaned up some dependencies and bumped the Django version.