### PR TITLE
Add DISABLE_PERMISSIONS flag for dataset permissions

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -7,6 +7,7 @@ from .models import Dataset
 from utils.datasets import find_dataset_id_in_request
 from dae.studies.study import GenotypeData
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.utils.encoding import force_str
 
@@ -102,13 +103,12 @@ def get_wdae_children(dataset, leaves=False):
 
 
 def _user_has_permission_strict(user, dataset):
-    "Checks if a user has access strictly to the given datasets"
-
+    """Check if a user has access strictly to the given datasets."""
     dataset = get_wdae_dataset(dataset)
     if dataset is None:
         return False
 
-    if user.is_superuser or user.is_staff:
+    if user.is_superuser or user.is_staff or settings.DISABLE_PERMISSIONS:
         return True
 
     if not user.is_active:
@@ -119,7 +119,7 @@ def _user_has_permission_strict(user, dataset):
         return True
 
     dataset_groups = get_dataset_groups(dataset)
-    if 'any_user' in dataset_groups:
+    if "any_user" in dataset_groups:
         return True
 
     return bool(user_groups & dataset_groups)

--- a/wdae/wdae/datasets_api/tests/test_permissions.py
+++ b/wdae/wdae/datasets_api/tests/test_permissions.py
@@ -3,6 +3,7 @@ import pytest
 from box import Box
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 
 from dae.studies.study import GenotypeDataGroup
 from studies.study_wrapper import StudyWrapper
@@ -294,3 +295,11 @@ def test_get_allowed_dataset_from_parent(db, user, dataset_wrapper):
 
     allowed_datasets = _get_allowed_datasets_for_user(user, "Dataset1")
     assert "Dataset1" in allowed_datasets
+
+
+@override_settings(DISABLE_PERMISSIONS=True)
+def test_disable_permissions_flag_allows_all(db, na_user, dataset_wrapper):
+    data_ids = {*dataset_wrapper.get_studies_ids(),
+                *dataset_wrapper.get_studies_ids(leaves=False)}
+    for data_id in data_ids:
+        assert user_has_permission(na_user, data_id)

--- a/wdae/wdae/wdae/default_settings.py
+++ b/wdae/wdae/wdae/default_settings.py
@@ -10,6 +10,8 @@ STUDIES_EAGER_LOADING = False
 
 OPEN_REGISTRATION = True
 
+DISABLE_PERMISSIONS = False
+
 SITE_URL = "localhost"
 
 BASE_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
## Background
We need a way to disable dataset permissions checking. 

## Aim
Have an easy, toggle-able way of disabling/enabling permissions checking for datasets.

## Implementation
A `DISABLE_PERMISSIONS` Django setting that, when enabled, gives access to any user for any dataset.

Closes #270.