### PR TITLE
Small bug fixes to make the `GPF getting started guide` working

### DIFF
--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-from collections import OrderedDict
 from typing import Optional, List
 from functools import cache
 
@@ -206,7 +205,7 @@ class GeneScoresDb:
 
     def __init__(self, gene_scores):
         super().__init__()
-        self.scores = OrderedDict()
+        self.scores = {}
         for score in gene_scores:
             self.scores[score.score_id] = score
 
@@ -222,8 +221,10 @@ class GeneScoresDb:
 
     def get_gene_score(self, score_id):
         """Return a given gene score."""
-        assert self[score_id].df is not None
-        return self[score_id]
+        if score_id not in self.scores:
+            return None
+        assert self.scores[score_id].df is not None
+        return self.scores[score_id]
 
     def __getitem__(self, score_id):
         if score_id not in self.scores:

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -160,7 +160,7 @@ class GPFInstance:
     def gene_scores_db(self):
         """Load and return gene scores db."""
         if self.dae_config.gene_scores_db is None:
-            return []
+            return GeneScoresDb([])
 
         gene_scores = self.dae_config.gene_scores_db.gene_scores
         result = []
@@ -358,7 +358,7 @@ class GPFInstance:
         return gene_score_id in self.gene_scores_db
 
     def get_gene_score(self, gene_score_id):
-        return self.gene_scores_db[gene_score_id]
+        return self.gene_scores_db.get_gene_score(gene_score_id)
 
     def get_all_gene_scores(self):
         return self.gene_scores_db.get_gene_scores()

--- a/dae/dae/gpf_instance/tests/test_empty_gpf_instance.py
+++ b/dae/dae/gpf_instance/tests/test_empty_gpf_instance.py
@@ -30,6 +30,18 @@ def test_empty_gene_scores(alla_instance):
     assert len(alla_instance.gene_scores_db) == 0
 
 
+def test_has_gene_score(alla_instance):
+    assert not alla_instance.has_gene_score("ala-bala")
+
+
+def test_get_gene_score(alla_instance):
+    assert alla_instance.get_gene_score("ala-bala") is None
+
+
+def test_get_all_gene_scores(alla_instance):
+    assert len(alla_instance.get_all_gene_scores()) == 0
+
+
 def test_empty_genomic_scores(alla_instance):
     assert len(alla_instance.genomic_scores_db) == 0
 

--- a/wdae/tests/integration/test_wgpf_command/test_wgpf_run.py
+++ b/wdae/tests/integration/test_wgpf_command/test_wgpf_run.py
@@ -21,7 +21,7 @@ def test_wgpf_run_simple(wgpf_fixture, wdae_django_setup, mocker):
         # pylint: disable=no-member
         wgpf.execute_from_command_line.assert_called_once_with([
             "wgpf", "runserver", "0.0.0.0:8000", "--skip-checks",
-            "--settings", "tests.integration.test_wgpf_command.wgpf_settings"])
+        ])
 
 
 def test_wgpf_run_without_init(wgpf_fixture, wdae_django_setup, mocker):
@@ -41,22 +41,21 @@ def test_wgpf_run_without_init(wgpf_fixture, wdae_django_setup, mocker):
         # pylint: disable=no-member
         wgpf.execute_from_command_line.assert_called_with([
             "wgpf", "runserver", "0.0.0.0:8000", "--skip-checks",
-            "--settings", "tests.integration.test_wgpf_command.wgpf_settings"])
+        ])
 
         wgpf.execute_from_command_line.assert_has_calls([
             mocker.call([
-                "wgpf", "migrate", "--skip-checks", "--settings",
-                "tests.integration.test_wgpf_command.wgpf_settings"]),
+                "wgpf", "migrate", "--skip-checks",
+            ]),
             mocker.call([
                 "wgpf", "createapplication", "public", "authorization-code",
                 "--client-id", "gpfjs", "--name", "GPF development server",
                 "--redirect-uris", "http://localhost:8000/datasets",
-                "--skip-checks", "--settings",
-                "tests.integration.test_wgpf_command.wgpf_settings"]),
+                "--skip-checks",
+            ]),
             mocker.call([
                 "wgpf", "runserver", "0.0.0.0:8000", "--skip-checks",
-                "--settings",
-                "tests.integration.test_wgpf_command.wgpf_settings"])
+            ])
         ])
 
 
@@ -78,7 +77,7 @@ def test_wgpf_run_with_port(wgpf_fixture, wdae_django_setup, mocker):
         # pylint: disable=no-member
         wgpf.execute_from_command_line.assert_called_once_with([
             "wgpf", "runserver", "0.0.0.0:9000", "--skip-checks",
-            "--settings", "tests.integration.test_wgpf_command.wgpf_settings"])
+        ])
 
 
 def test_wgpf_run_with_host(wgpf_fixture, wdae_django_setup, mocker):
@@ -99,4 +98,23 @@ def test_wgpf_run_with_host(wgpf_fixture, wdae_django_setup, mocker):
         # pylint: disable=no-member
         wgpf.execute_from_command_line.assert_called_once_with([
             "wgpf", "runserver", "localhost:8000", "--skip-checks",
-            "--settings", "tests.integration.test_wgpf_command.wgpf_settings"])
+        ])
+
+
+def test_wgpf_run_check_wdae_directory(
+        wgpf_fixture, wdae_django_setup, mocker):
+    # Given
+    with wdae_django_setup(
+            wgpf_fixture,
+            "tests.integration.test_wgpf_command.wgpf_settings"):
+
+        (wgpf_fixture.instance_dir / ".wgpf_init.flag").touch()
+        mocker.patch(
+            "wdae.wgpf.execute_from_command_line",
+            return_value=None)
+
+        # When
+        wgpf.cli(["wgpf", "run"])
+
+        # Then
+        assert (wgpf_fixture.instance_dir / "wdae").exists()

--- a/wdae/wdae/wdae/settings.py
+++ b/wdae/wdae/wdae/settings.py
@@ -3,6 +3,9 @@
 
 # pylint: disable=wildcard-import,unused-wildcard-import
 import os
+
+from gpf_instance.gpf_instance import get_wgpf_instance_path
+
 from .default_settings import *
 
 ALLOWED_HOSTS += ["localhost"]
@@ -26,7 +29,7 @@ OPEN_REGISTRATION = True
 ########################################################
 
 DEFAULT_WDAE_DIR = os.path.join(
-    os.environ.get("DAE_DB_DIR", ""), "wdae")
+    get_wgpf_instance_path(), "wdae")
 os.makedirs(DEFAULT_WDAE_DIR, exist_ok=True)
 
 DATABASES = {


### PR DESCRIPTION
## Background

While working with an empty GPF instance described in the `GPF Getting Started Guide,` an issue with an empty configuration of `Gene Scores` was found.
https://github.com/iossifovlab/gpf/issues/294

## Aim

Handle empty gene scores list in `GPFInstance.`

## Implementation

Adjustment of `wdae` to use GPF instance directory when configuring `DEFAULT_WDAE_DIR.`

Construction of `GeneScoreDb` with empty gene scores configuration was fixed. Some tests are added.


Closes #294.