### PR TITLE
Permissions tests

### DIFF
--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -9,6 +9,43 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/common_reports/studies/study4", "get", None),
+    ("/api/v3/common_reports/studies/study4/full", "get", None),
+    (
+        "/api/v3/common_reports/family_counters",
+        "post",
+        {
+            "study_id": "study4",
+            "group_name": "Phenotype",
+            "counter_id": "0"
+        }),
+    (
+        "/api/v3/common_reports/family_counters/download",
+        "post",
+        {
+            "queryData": json.dumps({
+                "study_id": "study4",
+                "group_name": "Phenotype",
+                "counter_id": "0"
+            })
+        }
+    ),
+    ("/api/v3/common_reports/families_data/Study1", "get", None),
+])
+def test_variant_reports_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    print(response.headers)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
 def test_variant_reports(admin_client):
     url = "/api/v3/common_reports/studies/study4"
     response = admin_client.get(url)

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -5,14 +5,14 @@ from rest_framework.response import Response
 
 from datasets_api.permissions import user_has_permission
 
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 
 from dae.pedigrees.family import FamiliesData
 from dae.pedigrees.family_tag_builder import check_tag
 from dae.pedigrees.serializer import FamiliesTsvSerializer
 
 
-class VariantReportsView(QueryBaseView):
+class VariantReportsView(QueryDatasetView):
     def get(self, request, common_report_id):
         assert common_report_id
 
@@ -28,7 +28,7 @@ class VariantReportsView(QueryBaseView):
         )
 
 
-class VariantReportsFullView(QueryBaseView):
+class VariantReportsFullView(QueryDatasetView):
     def get(self, request, common_report_id):
         assert common_report_id
 
@@ -44,7 +44,7 @@ class VariantReportsFullView(QueryBaseView):
         )
 
 
-class FamilyCounterListView(QueryBaseView):
+class FamilyCounterListView(QueryDatasetView):
     def post(self, request):
         data = request.data
 
@@ -71,7 +71,7 @@ class FamilyCounterListView(QueryBaseView):
         return Response(counter.families)
 
 
-class FamilyCounterDownloadView(QueryBaseView):
+class FamilyCounterDownloadView(QueryDatasetView):
     def post(self, request):
         data = json.loads(request.data["queryData"])
 
@@ -114,7 +114,7 @@ class FamilyCounterDownloadView(QueryBaseView):
         return response
 
 
-class FamiliesDataDownloadView(QueryBaseView):
+class FamiliesDataDownloadView(QueryDatasetView):
     def get(self, request, dataset_id):
         tags = request.GET.get("tags")
 

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -235,9 +235,7 @@ def _get_allowed_datasets_for_user(user, dataset, collect=None):
 
 
 def get_allowed_genotype_studies(user, dataset):
-    """
-    Collect and return datasets IDs the user has access to.
-    """
+    """Collect and return datasets IDs the user has access to."""
     allowed_datasets = _get_allowed_datasets_for_user(user, dataset)
 
     result = []

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -120,23 +120,29 @@ def get_wdae_children(dataset, leaves=False):
 
 def _user_has_permission_strict(user, dataset):
     """Check if a user has access strictly to the given datasets."""
+    if settings.DISABLE_PERMISSIONS:
+        return True
+
     dataset = get_wdae_dataset(dataset)
     if dataset is None:
         return False
 
-    if user.is_superuser or user.is_staff or settings.DISABLE_PERMISSIONS:
+    dataset_groups = get_dataset_groups(dataset)
+
+    if "any_user" in dataset_groups:
         return True
 
     if not user.is_active:
         return False
 
+    if user.is_superuser or user.is_staff:
+        return True
+
+
     user_groups = get_user_groups(user)
     if "admin" in user_groups:
         return True
 
-    dataset_groups = get_dataset_groups(dataset)
-    if "any_user" in dataset_groups:
-        return True
 
     return bool(user_groups & dataset_groups)
 

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -125,7 +125,7 @@ def _user_has_permission_strict(user, dataset):
 
     dataset = get_wdae_dataset(dataset)
     if dataset is None:
-        return False
+        return True
 
     dataset_groups = get_dataset_groups(dataset)
 
@@ -155,7 +155,7 @@ def _user_has_permission_up(user, dataset):
     """
     dataset = get_wdae_dataset(dataset)
     if dataset is None:
-        return False
+        return True
 
     if _user_has_permission_strict(user, dataset):
         return True
@@ -176,7 +176,7 @@ def _user_has_permission_down(user, dataset):
     """
     dataset = get_wdae_dataset(dataset)
     if dataset is None:
-        return False
+        return True
 
     if _user_has_permission_strict(user, dataset):
         return True
@@ -193,8 +193,9 @@ def user_has_permission(user, dataset):
     """Check if a user has permission to browse the given dataset."""
     logger.debug("checking user <%s> permissions on %s", user, dataset)
     dataset = get_wdae_dataset(dataset)
+    print(dataset)
     if dataset is None:
-        return False
+        return True
 
     allowed_dataset_leaves = get_allowed_genotype_studies(user, dataset)
     return bool(allowed_dataset_leaves)

--- a/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
+++ b/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
@@ -2,9 +2,36 @@
 import json
 import pytest
 
+from rest_framework import status
+
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
+
+
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/enrichment/models/f1_trio", "get", None),
+    (
+        "/api/v3/enrichment/test",
+        "post",
+        {
+            "datasetId": "f1_trio",
+            "enrichmentBackgroundModel": "coding_len_background_model",
+            "enrichmentCountingModel": "enrichment_gene_counting",
+            "geneSymbols": ["SAMD11", "PLEKHN1", "POGZ"],
+        }
+    ),
+])
+def test_enrichment_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_enrichment_models(admin_client):

--- a/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
+++ b/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
@@ -109,7 +109,7 @@ def test_enrichment_test_missing_study(admin_client):
     )
 
     assert response
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_enrichment_test_missing_gene_symbols(admin_client):

--- a/wdae/wdae/family_api/tests/test_family_api.py
+++ b/wdae/wdae/family_api/tests/test_family_api.py
@@ -7,6 +7,26 @@ pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
 
 
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/families/Study1", "get", None),
+    ("/api/v3/families/Study1/f6", "get", None),
+    ("/api/v3/families/Study1/f6/members", "get", None),
+    ("/api/v3/families/Study1/f6/members/ch6", "get", None),
+    ("/api/v3/families/Study1/f6/members/all", "get", None),
+    ("/api/v3/families/Study1/all", "get", None),
+])
+def test_family_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
 def test_list_families_view(admin_client):
     url = "/api/v3/families/Study1"
     response = admin_client.get(url)

--- a/wdae/wdae/family_api/views.py
+++ b/wdae/wdae/family_api/views.py
@@ -1,11 +1,11 @@
 from rest_framework.response import Response
 from rest_framework import status
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 
 from dae.pedigrees.family_tag_builder import FamilyTagsBuilder, check_tag
 
 
-class ListFamiliesView(QueryBaseView):
+class ListFamiliesView(QueryDatasetView):
     def get(self, request, dataset_id):
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -41,7 +41,7 @@ class ListFamiliesView(QueryBaseView):
         )
 
 
-class FamilyDetailsView(QueryBaseView):
+class FamilyDetailsView(QueryDatasetView):
     def get(self, request, dataset_id, family_id):
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -67,7 +67,7 @@ class FamilyDetailsView(QueryBaseView):
         )
 
 
-class TagsView(QueryBaseView):
+class TagsView(QueryDatasetView):
     def get(self, request):
         # pylint: disable=unused-argument,no-self-use
         return Response(
@@ -76,7 +76,7 @@ class TagsView(QueryBaseView):
         )
 
 
-class ListMembersView(QueryBaseView):
+class ListMembersView(QueryDatasetView):
     def get(self, request, dataset_id, family_id):
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -102,7 +102,7 @@ class ListMembersView(QueryBaseView):
         )
 
 
-class MemberDetailsView(QueryBaseView):
+class MemberDetailsView(QueryDatasetView):
     def get(self, request, dataset_id, family_id, member_id):
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -136,7 +136,7 @@ class MemberDetailsView(QueryBaseView):
         )
 
 
-class AllMemberDetailsView(QueryBaseView):
+class AllMemberDetailsView(QueryDatasetView):
     def get(self, request, dataset_id, family_id):
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -167,7 +167,7 @@ class AllMemberDetailsView(QueryBaseView):
         )
 
 
-class ListAllDetailsView(QueryBaseView):
+class ListAllDetailsView(QueryDatasetView):
     def get(self, request, dataset_id):
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
+++ b/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
@@ -3,44 +3,9 @@ import json
 
 import pytest
 
-from rest_framework import status
-
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
-
-
-@pytest.mark.parametrize("url,method,body", [
-    ("/api/v3/gene_scores", "get", None),
-    (
-        "/api/v3/gene_scores/genes",
-        "post",
-        {
-            "score": "LGD_rank",
-            "min": 1.5,
-            "max": 5.0,
-        }
-    ),
-    (
-        "/api/v3/gene_scores/partitions",
-        "post",
-        {
-            "score": "LGD_rank",
-            "min": 1.5,
-            "max": 5.0,
-        }
-    ),
-])
-def test_gene_scores_api_permissions(anonymous_client, url, method, body):
-    if method == "get":
-        response = anonymous_client.get(url)
-    else:
-        response = anonymous_client.post(
-            url, json.dumps(body), content_type="application/json"
-        )
-
-    assert response
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_gene_scores_list_view(user_client):

--- a/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
+++ b/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
@@ -3,9 +3,44 @@ import json
 
 import pytest
 
+from rest_framework import status
+
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
+
+
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/gene_scores", "get", None),
+    (
+        "/api/v3/gene_scores/genes",
+        "post",
+        {
+            "score": "LGD_rank",
+            "min": 1.5,
+            "max": 5.0,
+        }
+    ),
+    (
+        "/api/v3/gene_scores/partitions",
+        "post",
+        {
+            "score": "LGD_rank",
+            "min": 1.5,
+            "max": 5.0,
+        }
+    ),
+])
+def test_gene_scores_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_gene_scores_list_view(user_client):

--- a/wdae/wdae/gene_sets/tests/test_gene_sets_api.py
+++ b/wdae/wdae/gene_sets/tests/test_gene_sets_api.py
@@ -7,32 +7,6 @@ import pytest
 from rest_framework import status  # type: ignore
 
 
-@pytest.mark.parametrize("url,method,body", [
-    ("/api/v3/gene_sets/gene_sets_collections", "get", None),
-    (
-        "/api/v3/gene_sets/gene_set_download",
-        "post",
-        {
-            "geneSetsCollection": "denovo",
-            "geneSet": "Synonymous",
-            "geneSetsTypes": {
-                "f1_group": {"phenotype": ["phenotype1", "unaffected"]}
-            },
-        }
-    ),
-])
-def test_gene_sets_api_permissions(anonymous_client, url, method, body):
-    if method == "get":
-        response = anonymous_client.get(url)
-    else:
-        response = anonymous_client.post(
-            url, json.dumps(body), content_type="application/json"
-        )
-
-    assert response
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
 

--- a/wdae/wdae/gene_sets/tests/test_gene_sets_api.py
+++ b/wdae/wdae/gene_sets/tests/test_gene_sets_api.py
@@ -7,6 +7,32 @@ import pytest
 from rest_framework import status  # type: ignore
 
 
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/gene_sets/gene_sets_collections", "get", None),
+    (
+        "/api/v3/gene_sets/gene_set_download",
+        "post",
+        {
+            "geneSetsCollection": "denovo",
+            "geneSet": "Synonymous",
+            "geneSetsTypes": {
+                "f1_group": {"phenotype": ["phenotype1", "unaffected"]}
+            },
+        }
+    ),
+])
+def test_gene_sets_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
 

--- a/wdae/wdae/gene_view/tests/test_gene_view.py
+++ b/wdae/wdae/gene_view/tests/test_gene_view.py
@@ -1,9 +1,40 @@
-import pytest
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+
 import json
+import pytest
 from rest_framework import status
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
+
+
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/gene_view/config?datasetId=quads_f2", "get", None),
+    (
+        "/api/v3/gene_view/query_summary_variants",
+        "post",
+        {
+            "datasetId": "quads_f2",
+        }
+    ),
+    (
+        "/api/v3/gene_view/download_summary_variants",
+        "post",
+        {
+            "datasetId": "quads_f2",
+        }
+    ),
+])
+def test_gene_view_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_gene_view_summary_variants_query(db, admin_client):
@@ -21,8 +52,8 @@ def test_gene_view_summary_variants_query(db, admin_client):
     res = json.loads("".join(map(lambda x: x.decode("utf-8"), res)))
 
     assert len(res) == 7
-    for v in res:
-        assert len(v['alleles']) == 2
+    for sv in res:
+        assert len(sv["alleles"]) == 2
 
 
 def test_gene_view_config(db, admin_client):

--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from django.http.response import StreamingHttpResponse, FileResponse
 
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 
 from utils.logger import request_logging
 from utils.streaming_response_util import iterator_to_json
@@ -16,7 +16,7 @@ from datasets_api.permissions import \
 LOGGER = logging.getLogger(__name__)
 
 
-class ConfigView(QueryBaseView):
+class ConfigView(QueryDatasetView):
     @expand_gene_set
     @request_logging(LOGGER)
     def get(self, request):
@@ -36,7 +36,7 @@ class ConfigView(QueryBaseView):
         return Response(config, status=status.HTTP_200_OK)
 
 
-class QueryVariantsView(QueryBaseView):
+class QueryVariantsView(QueryDatasetView):
     @expand_gene_set
     @request_logging(LOGGER)
     def post(self, request):
@@ -68,7 +68,7 @@ class QueryVariantsView(QueryBaseView):
         return response
 
 
-class DownloadSummaryVariantsView(QueryBaseView):
+class DownloadSummaryVariantsView(QueryDatasetView):
     DOWNLOAD_LIMIT = 10000
 
     @expand_gene_set

--- a/wdae/wdae/genotype_browser/views.py
+++ b/wdae/wdae/genotype_browser/views.py
@@ -11,7 +11,7 @@ from utils.logger import LOGGER
 from utils.streaming_response_util import iterator_to_json
 from utils.logger import request_logging
 
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 
 from gene_sets.expand_gene_set_decorator import expand_gene_set
 
@@ -25,7 +25,7 @@ from dae.utils.dae_utils import join_line
 logger = logging.getLogger(__name__)
 
 
-class GenotypeBrowserQueryView(QueryBaseView):
+class GenotypeBrowserQueryView(QueryDatasetView):
     """Genotype browser queries view."""
 
     MAX_SHOWN_VARIANTS = 1000

--- a/wdae/wdae/measures_api/tests/test_measures_api.py
+++ b/wdae/wdae/measures_api/tests/test_measures_api.py
@@ -1,5 +1,8 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import json
 import pytest
 
+from rest_framework import status  # type: ignore
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
@@ -7,6 +10,22 @@ pytestmark = pytest.mark.usefixtures(
 
 MEASURES_URL = "/api/v3/measures/type"
 REGRESSIONS_URL = "/api/v3/measures/regressions"
+
+
+@pytest.mark.parametrize("url,method,body", [
+    (f"{MEASURES_URL}/continuous?datasetId=quads_f1", "get", None),
+    (f"{REGRESSIONS_URL}?datasetId=comp", "get", None),
+])
+def test_measures_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_measures_list_categorical(admin_client):

--- a/wdae/wdae/measures_api/views.py
+++ b/wdae/wdae/measures_api/views.py
@@ -6,12 +6,12 @@ from rest_framework.response import Response
 
 from dae.pheno.common import MeasureType
 
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 
 logger = logging.getLogger(__name__)
 
 
-class PhenoMeasuresView(QueryBaseView):
+class PhenoMeasuresView(QueryDatasetView):
     def get(self, request, measure_type):
         data = request.query_params
 
@@ -42,7 +42,7 @@ class PhenoMeasuresView(QueryBaseView):
         return Response(res, status=status.HTTP_200_OK)
 
 
-class PhenoMeasureHistogramView(QueryBaseView):
+class PhenoMeasureHistogramView(QueryDatasetView):
     def post(self, request):
         data = request.data
         dataset_id = data["datasetId"]
@@ -77,7 +77,7 @@ class PhenoMeasureHistogramView(QueryBaseView):
         return Response(result, status=status.HTTP_200_OK)
 
 
-class PhenoMeasurePartitionsView(QueryBaseView):
+class PhenoMeasurePartitionsView(QueryDatasetView):
     def post(self, request):
         data = request.data
         dataset_id = data["datasetId"]
@@ -117,7 +117,7 @@ class PhenoMeasurePartitionsView(QueryBaseView):
         return Response(res)
 
 
-class PhenoMeasureRegressionsView(QueryBaseView):
+class PhenoMeasureRegressionsView(QueryDatasetView):
     def __init__(self):
         super(PhenoMeasureRegressionsView, self).__init__()
         self.pheno_config = self.gpf_instance.get_phenotype_db_config()

--- a/wdae/wdae/person_sets_api/tests/test_person_sets_api.py
+++ b/wdae/wdae/person_sets_api/tests/test_person_sets_api.py
@@ -1,10 +1,27 @@
 # pylint: disable=redefined-outer-name,C0114,C0116,protected-access
 
+import json
 import pytest
 from rest_framework import status  # type: ignore
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
+
+
+@pytest.mark.parametrize("url,method,body", [
+    ("/api/v3/person_sets/Study1/configs", "get", None),
+    ("/api/v3/person_sets/Study1/stats/phenotype", "get", None),
+])
+def test_person_sets_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_collection_configs_view(admin_client):

--- a/wdae/wdae/person_sets_api/tests/test_person_sets_api.py
+++ b/wdae/wdae/person_sets_api/tests/test_person_sets_api.py
@@ -8,22 +8,6 @@ pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
 
 
-@pytest.mark.parametrize("url,method,body", [
-    ("/api/v3/person_sets/Study1/configs", "get", None),
-    ("/api/v3/person_sets/Study1/stats/phenotype", "get", None),
-])
-def test_person_sets_api_permissions(anonymous_client, url, method, body):
-    if method == "get":
-        response = anonymous_client.get(url)
-    else:
-        response = anonymous_client.post(
-            url, json.dumps(body), content_type="application/json"
-        )
-
-    assert response
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
 def test_collection_configs_view(admin_client):
     url = "/api/v3/person_sets/Study1/configs"
     response = admin_client.get(url)

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from django.http.response import StreamingHttpResponse
 
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 
 from utils.streaming_response_util import iterator_to_json
 
@@ -12,7 +12,7 @@ from utils.streaming_response_util import iterator_to_json
 logger = logging.getLogger(__name__)
 
 
-class PhenoBrowserBaseView(QueryBaseView):
+class PhenoBrowserBaseView(QueryDatasetView):
     def __init__(self):
         super(PhenoBrowserBaseView, self).__init__()
         self.pheno_config = self.gpf_instance.get_phenotype_db_config()
@@ -35,7 +35,7 @@ class PhenoConfigView(PhenoBrowserBaseView):
         return Response(self.pheno_config[dbname])
 
 
-class PhenoInstrumentsView(QueryBaseView):
+class PhenoInstrumentsView(QueryDatasetView):
     def get(self, request):
         if "dataset_id" not in request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -125,7 +125,7 @@ class PhenoMeasuresView(PhenoBrowserBaseView):
         return response
 
 
-class PhenoMeasuresDownload(QueryBaseView):
+class PhenoMeasuresDownload(QueryDatasetView):
     def post(self, request):
         data = request.data
         if "dataset_id" not in data:

--- a/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
+++ b/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
@@ -1,7 +1,8 @@
-import pytest
-
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 import copy
 import json
+
+import pytest
 
 from rest_framework import status  # type: ignore
 
@@ -20,6 +21,66 @@ QUERY = {
     "presentInParent": {"presentInParent": ["neither"]},
     "effectTypes": ["missense", "frame-shift", "synonymous"],
 }
+
+
+@pytest.mark.parametrize("url,method,body", [
+    (TOOL_URL, "post", QUERY),
+    (TOOL_DOWNLOAD_URL, "post", QUERY),
+    (
+        "/api/v3/pheno_tool/persons",
+        "post",
+        {
+            "datasetId": "f1_trio",
+        }
+    ),
+    (
+        "/api/v3/pheno_tool/persons_values",
+        "post",
+        {
+            "datasetId": "f1_trio",
+            "measureIds": ["i1.m1"]
+        }
+    ),
+    (
+        "/api/v3/pheno_tool/measure",
+        "post",
+        {
+            "datasetId": "f1_trio",
+            "measureId": "i1.m1"
+        }
+    ),
+    (
+        "/api/v3/pheno_tool/measures?datasetId=f1_trio&instrument=i1",
+        "get", None
+    ),
+    (
+        "/api/v3/pheno_tool/measure_values",
+        "post",
+        {
+            "datasetId": "f1_trio",
+            "measureId": "i1.m1"
+        }
+    ),
+    ("/api/v3/pheno_tool/instruments?datasetId=f1_trio", "get", None),
+    (
+        "/api/v3/pheno_tool/instrument_values",
+        "post",
+        {
+            "datasetId": "f1_trio",
+            "instrumentName": "i1"
+        }
+    ),
+])
+def test_pheno_tool_api_permissions(anonymous_client, url, method, body):
+    if method == "get":
+        response = anonymous_client.get(url)
+    else:
+        response = anonymous_client.post(
+            url, json.dumps(body), content_type="application/json"
+        )
+
+    assert response
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_pheno_tool_view_valid_request(admin_client):

--- a/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
+++ b/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
@@ -291,7 +291,7 @@ def test_pheno_tool_view_missing_dataset(admin_client):
         format="json",
         content_type="application/json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_pheno_tool_view_missing_measure(admin_client):

--- a/wdae/wdae/pheno_tool_api/urls.py
+++ b/wdae/wdae/pheno_tool_api/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
         name="pheno_tool_measure"
     ),
     re_path(
-        r"^/measures.*",
+        r"^/measures/?",
         views.PhenoToolMeasures.as_view(),
         name="pheno_tool_measures"
     ),

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -8,7 +8,7 @@ from django.http.response import StreamingHttpResponse
 
 from gene_sets.expand_gene_set_decorator import expand_gene_set
 
-from query_base.query_base import QueryBaseView
+from query_base.query_base import QueryDatasetView
 from datasets_api.permissions import user_has_permission
 
 from dae.pheno_tool.tool import PhenoTool, PhenoToolHelper
@@ -20,7 +20,7 @@ from .pheno_tool_adapter import PhenoToolAdapter, RemotePhenoToolAdapter
 logger = logging.getLogger(__name__)
 
 
-class PhenoToolView(QueryBaseView):
+class PhenoToolView(QueryDatasetView):
     @staticmethod
     def get_result_by_sex(result, sex):
         return {
@@ -160,7 +160,7 @@ class PhenoToolDownload(PhenoToolView):
         return response
 
 
-class PhenoToolPersons(QueryBaseView):
+class PhenoToolPersons(QueryDatasetView):
     def post(self, request):
         data = request.data
         dataset_id = data["datasetId"]
@@ -187,7 +187,7 @@ class PhenoToolPersons(QueryBaseView):
         return Response(result)
 
 
-class PhenoToolPersonsValues(QueryBaseView):
+class PhenoToolPersonsValues(QueryDatasetView):
 
     def post(self, request):
         data = request.data
@@ -213,7 +213,7 @@ class PhenoToolPersonsValues(QueryBaseView):
         return Response(result)
 
 
-class PhenoToolMeasure(QueryBaseView):
+class PhenoToolMeasure(QueryDatasetView):
     def get(self, request):
         params = request.GET
         dataset_id = params.get("datasetId", None)
@@ -237,7 +237,7 @@ class PhenoToolMeasure(QueryBaseView):
         return Response(result.to_json())
 
 
-class PhenoToolMeasures(QueryBaseView):
+class PhenoToolMeasures(QueryDatasetView):
     def get(self, request):
         params = request.GET
         dataset_id = params.get("datasetId", None)
@@ -262,7 +262,7 @@ class PhenoToolMeasures(QueryBaseView):
         return Response([m.to_json() for m in result.values()])
 
 
-class PhenoToolMeasureValues(QueryBaseView):
+class PhenoToolMeasureValues(QueryDatasetView):
     def post(self, request):
         data = request.data
         dataset_id = data["datasetId"]
@@ -281,7 +281,7 @@ class PhenoToolMeasureValues(QueryBaseView):
         return Response(result)
 
 
-class PhenoToolValues(QueryBaseView):
+class PhenoToolValues(QueryDatasetView):
     def post(self, request):
         data = request.data
         dataset_id = data["datasetId"]
@@ -300,7 +300,7 @@ class PhenoToolValues(QueryBaseView):
         return Response(result.to_dict("records"))
 
 
-class PhenoToolInstruments(QueryBaseView):
+class PhenoToolInstruments(QueryDatasetView):
 
     def measure_to_json(self, measure):
         return {
@@ -341,7 +341,7 @@ class PhenoToolInstruments(QueryBaseView):
         return Response(result)
 
 
-class PhenoToolInstrumentValues(QueryBaseView):
+class PhenoToolInstrumentValues(QueryDatasetView):
     def post(self, request):
         data = request.data
         dataset_id = data["datasetId"]

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -169,9 +169,9 @@ class PhenoToolPersons(QueryBaseView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         result = dataset.phenotype_data.get_persons(
-            data["roles"],
-            data["personIds"],
-            data["familyIds"],
+            data.get("roles", None),
+            data.get("personIds", None),
+            data.get("familyIds", None),
         )
 
         for key in result.keys():
@@ -198,9 +198,9 @@ class PhenoToolPersonsValues(QueryBaseView):
 
         result = dataset.phenotype_data.get_persons_values_df(
             data["measureIds"],
-            data["personIds"],
-            data["familyIds"],
-            data["roles"],
+            data.get("personIds", None),
+            data.get("familyIds", None),
+            data.get("roles", None),
         )
 
         result = result.to_dict("records")
@@ -265,7 +265,6 @@ class PhenoToolMeasures(QueryBaseView):
 class PhenoToolMeasureValues(QueryBaseView):
     def post(self, request):
         data = request.data
-        print(data)
         dataset_id = data["datasetId"]
         dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
         if not dataset:
@@ -273,10 +272,10 @@ class PhenoToolMeasureValues(QueryBaseView):
 
         result = dataset.phenotype_data.get_measure_values(
             data["measureId"],
-            data["personIds"],
-            data["familyIds"],
-            data["roles"],
-            data["defaultFilter"],
+            data.get("personIds", None),
+            data.get("familyIds", None),
+            data.get("roles", None),
+            data.get("defaultFilter", "skip"),
         )
 
         return Response(result)
@@ -292,10 +291,10 @@ class PhenoToolValues(QueryBaseView):
 
         result = dataset.phenotype_data.get_values_df(
             data["measureIds"],
-            data["personIds"],
-            data["familyIds"],
-            data["roles"],
-            data["defaultFilter"],
+            data.get("personIds", None),
+            data.get("familyIds", None),
+            data.get("roles", None),
+            data.get("defaultFilter", "apply"),
         )
 
         return Response(result.to_dict("records"))
@@ -361,10 +360,10 @@ class PhenoToolInstrumentValues(QueryBaseView):
 
         result = dataset.phenotype_data.get_instrument_values(
             instrument_name,
-            data["personIds"],
-            data["familyIds"],
-            data["roles"],
-            data.get("measures")
+            data.get("personIds", None),
+            data.get("familyIds", None),
+            data.get("roles", None),
+            data.get("measures", None)
         )
 
         return Response(result)

--- a/wdae/wdae/query_base/query_base.py
+++ b/wdae/wdae/query_base/query_base.py
@@ -16,7 +16,6 @@ class QueryBaseView(views.APIView):
     """
 
     authentication_classes = (GPFOAuth2Authentication,)
-    permission_classes = (IsDatasetAllowed,)
 
     def __init__(self):
         super().__init__()
@@ -27,3 +26,10 @@ class QueryBaseView(views.APIView):
     @staticmethod
     def get_permitted_datasets(user):
         return IsDatasetAllowed.permitted_datasets(user)
+
+
+class QueryDatasetView(QueryBaseView):
+    permission_classes = (IsDatasetAllowed,)
+
+    def __init__(self):
+        super().__init__()

--- a/wdae/wdae/utils/datasets.py
+++ b/wdae/wdae/utils/datasets.py
@@ -1,11 +1,31 @@
+import json
+
+def find_dataset_id_in_dict(dictionary):
+    dataset_id = dictionary.get("dataset_id", None)
+    if dataset_id is None:
+        dataset_id = dictionary.get("datasetId", None)
+    if dataset_id is None:
+        dataset_id = dictionary.get("study_id", None)
+    if dataset_id is None:
+        dataset_id = dictionary.get("studyId", None)
+    if dataset_id is None:
+        dataset_id = dictionary.get("common_report_id", None)
+    if dataset_id is None:
+        dataset_id = dictionary.get("commonReportId", None)
+    if dataset_id is None:
+        query_data = dictionary.get("queryData", None)
+        if query_data:
+            if isinstance(query_data, str):
+                query_data = json.loads(query_data)
+            dataset_id = find_dataset_id_in_dict(query_data)
+    return dataset_id
+
 def find_dataset_id_in_request(request):
-    dataset_id = request.query_params.get("dataset_id", None)
+    dataset_id = find_dataset_id_in_dict(request.query_params)
     if dataset_id is None:
-        dataset_id = request.query_params.get("datasetId", None)
+        dataset_id = find_dataset_id_in_dict(request.data)
     if dataset_id is None:
-        dataset_id = request.data.get("datasetId", None)
-    if dataset_id is None:
-        dataset_id = request.data.get("dataset_id", None)
+        dataset_id = find_dataset_id_in_dict(request.resolver_match.kwargs)
     if dataset_id is None:
         dataset_id = request.parser_context.get("kwargs", {}).get(
             "common_report_id", None


### PR DESCRIPTION
## Background

Many routes in our API are supposed to check for dataset permissions to determine whether the user has access to them or not. This did not work for some routes and was untested.

## Aim

Add tests for dataset permissions for all affected routes and fix the permissions check.

## Implementation

All tests were made with a general parametrized test to check only for a 401 with anonymous clients. Dataset permissions were checked by searching for `datasetId` and `dataset_id` in request body and query parameters and for  `common_report_id`. 
This has been expanded to search for the following in the request body, query parameters, URL parameters and in `queryData` for certain downloads: 
- `datasetId`
- `dataset_id`
- `studyId`
- `study_id`
- `common_report_id`
- `commonReportId`

The pheno tool API was also changed slightly to be more broad.
A fix was also implemented for "any_user" datasets since they were not accessible when anonymous.

Closes #292.