### PR TITLE
Fix `grr_browse` with caching repository

### DIFF
--- a/dae/dae/genomic_resources/cached_repository.py
+++ b/dae/dae/genomic_resources/cached_repository.py
@@ -139,8 +139,7 @@ class GenomicResourceCachedRepo(GenomicResourceRepo):
             proto.invalidate()
 
     def get_all_resources(self):
-        for cache_proto in self.cache_protos.values():
-            yield from cache_proto.get_all_resources()
+        yield from self.child.get_all_resources()
 
     def _get_or_create_cache_proto(
             self, proto: ReadOnlyRepositoryProtocol) -> CachingProtocol:

--- a/dae/dae/genomic_resources/tests/test_cached_repo.py
+++ b/dae/dae/genomic_resources/tests/test_cached_repo.py
@@ -64,7 +64,7 @@ def test_get_cached_resource(cache_repository, scheme):
     assert res.resource_id == "one"
 
 
-def test_cached_get_all_resources(cache_repository):
+def test_cached_repo_get_all_resources(cache_repository):
 
     demo_gtf_content = "TP53\tchr3\t300\t200"
     cache_repo = cache_repository(content={
@@ -84,7 +84,30 @@ def test_cached_get_all_resources(cache_repository):
         }
     })
 
-    assert len(list(cache_repo.get_all_resources())) == 0
+    assert len(list(cache_repo.get_all_resources())) == 3
+
+
+def test_cached_resource_after_access(cache_repository):
+
+    demo_gtf_content = "TP53\tchr3\t300\t200"
+    cache_repo = cache_repository(content={
+        "one": {
+            GR_CONF_FILE_NAME: "",
+            "data.txt": "alabala"
+        },
+        "sub": {
+            "two-unstable(1.0)": {
+                GR_CONF_FILE_NAME: "type: gene_models\nfile: genes.gtf",
+                "genes.txt": demo_gtf_content
+            },
+            "two(1.0)": {
+                GR_CONF_FILE_NAME: "type: gene_models\nfile: genes.gtf",
+                "genes.txt": demo_gtf_content,
+            }
+        }
+    })
+
+    # assert len(list(cache_repo.get_all_resources())) == 0
 
     src_gr = cache_repo.child.get_resource("sub/two")
     cache_gr = cache_repo.get_resource("sub/two")
@@ -124,11 +147,7 @@ def test_cache_all(cache_repository):
         }
     })
 
-    assert len(list(cache_repo.get_all_resources())) == 0
-
     cache_repo.cache_resources()
-
-    assert len(list(cache_repo.get_all_resources())) == 3
 
     cache_proto = cache_repo.get_resource("one").proto
     filesystem = cache_proto.local_protocol.filesystem


### PR DESCRIPTION
## Background

The `grr_browse` command, when working with caching repository shows only the cached resources and does not show the resources in the child repository.

## Aim

We want to show all resources from the child repository with some additional information about whether the resource is cached.

## Implementation

I have changed the behavior of the `get_all_resources()` method of the caching repository to show all resources in the child repository.

The work on displaying the cache status of a resource is in a separate issue #267.

Closes #290