### PR TITLE
Bug fixes in `grr_manage`

### DIFF
--- a/dae/conftest.py
+++ b/dae/conftest.py
@@ -34,7 +34,6 @@ class DummyClient:
     """Dummy Dask client for testing."""
 
     def __init__(self, **kwargs):
-        print("DUMMY CLIENT CREATED...")
         self.tasks = []
 
     @staticmethod

--- a/dae/dae/genomic_resources/cached_repository.py
+++ b/dae/dae/genomic_resources/cached_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import logging
 
-from typing import Iterable, Optional, Dict, Generator
+from typing import Iterable, Optional, Dict, Generator, cast
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .repository import GenomicResource, \
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class CacheResource(GenomicResource):
+    """Represents resources stored in cache."""
 
     def __init__(self, resource, protocol: CachingProtocol):
         super().__init__(
@@ -24,6 +25,10 @@ class CacheResource(GenomicResource):
             protocol,
             config=resource.config,
             manifest=resource.get_manifest())
+
+    def get_manifest(self) -> Manifest:
+        return cast(CachingProtocol, self.proto)\
+            .remote_protocol.get_manifest(self)
 
 
 class CachingProtocol(ReadOnlyRepositoryProtocol):

--- a/dae/dae/genomic_resources/fsspec_protocol.py
+++ b/dae/dae/genomic_resources/fsspec_protocol.py
@@ -440,7 +440,6 @@ class FsspecReadWriteProtocol(
             md5sum=md5)
 
         self.save_resource_file_state(dest_resource, state)
-        self.save_manifest(dest_resource, remote_manifest)
 
         return state
 

--- a/dae/dae/genomic_resources/histogram.py
+++ b/dae/dae/genomic_resources/histogram.py
@@ -266,17 +266,14 @@ class HistogramBuilder:
         _, configs_to_calculate = \
             self._collect_histograms_to_build(path)
         if configs_to_calculate:
-            print(
-                f"resource <"
-                f"{self.resource.get_genomic_resource_id_version()}> "
-                f"histograms {configs_to_calculate} need update",
-                file=sys.stderr)
+            logger.info(
+                "resource <%s> histograms %s need update",
+                self.resource.get_genomic_resource_id_version(),
+                configs_to_calculate)
         else:
-            print(
-                f"histograms of <"
-                f"{self.resource.get_genomic_resource_id_version()}> "
-                f"are up to date",
-                file=sys.stderr)
+            logger.info(
+                "histograms of <%s> are up to date",
+                self.resource.get_genomic_resource_id_version())
         return configs_to_calculate
 
     def update(

--- a/dae/dae/genomic_resources/histogram.py
+++ b/dae/dae/genomic_resources/histogram.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import sys
 import logging
 from typing import Dict, Any
 from copy import copy, deepcopy
@@ -253,9 +252,10 @@ class HistogramBuilder:
             actual_md5 = metadata.get(score_id, {}).get("md5", None)
             expected_md5 = hashes.get(score_id, None)
             if actual_md5 == expected_md5:
-                logger.info("Skipping calculation of score "
-                            "%s as it's already calculated",
-                            hist_conf["score"])
+                logger.debug(
+                    "Skipping calculation of score "
+                    "%s as it's already calculated",
+                    hist_conf["score"])
                 loaded_hists[score_id] = hists[score_id]
             else:
                 configs_to_calculate.append(hist_conf)

--- a/dae/dae/genomic_resources/repository.py
+++ b/dae/dae/genomic_resources/repository.py
@@ -545,8 +545,8 @@ class ReadWriteRepositoryProtocol(ReadOnlyRepositoryProtocol):
             manifest.add(entry)
             state = self.load_resource_file_state(resource, entry.name)
             if state is None:
-                entries_to_update.add(entry.name)
-                continue
+                state = self.build_resource_file_state(resource, entry.name)
+                self.save_resource_file_state(resource, state)
             if state.filename not in current_manifest:
                 entries_to_update.add(entry.name)
                 continue
@@ -608,7 +608,6 @@ class ReadWriteRepositoryProtocol(ReadOnlyRepositoryProtocol):
             return manifest
         except FileNotFoundError:
             manifest = self.build_manifest(resource)
-            self.save_manifest(resource, manifest)
             return manifest
 
     @abc.abstractmethod

--- a/dae/dae/genomic_resources/tests/test_cli.py
+++ b/dae/dae/genomic_resources/tests/test_cli.py
@@ -63,8 +63,8 @@ def test_cli_list(repo_fixture, tmp_path, capsys):
     cli_manage(["list", "-R", str(tmp_path)])
     out, err = capsys.readouterr()
 
-    assert err == ""
-    assert out == \
+    assert out == ""
+    assert err == \
         "Basic                0        2            7 one\n" \
         "gene_models          1.0      2           50 sub/two\n"
 
@@ -81,8 +81,8 @@ def test_cli_list_without_repo_argument(
 
     # Then
     out, err = capsys.readouterr()
-    assert err == ""
-    assert out == \
+    assert out == ""
+    assert err == \
         f"working with repository: {str(tmp_path)}\n" \
         "Basic                0        2            7 one\n" \
         "gene_models          1.0      2           50 sub/two\n"

--- a/dae/dae/genomic_resources/tests/test_cli_browse.py
+++ b/dae/dae/genomic_resources/tests/test_cli_browse.py
@@ -53,8 +53,8 @@ def test_cli_browse_with_grr_argument(repo_fixture, repo_def, capsys):
     cli_browse(["--grr", str(repo_def)])
     out, err = capsys.readouterr()
 
-    assert err == ""
-    assert out == \
+    assert out == ""
+    assert err == \
         "Basic                0        2            7 one\n" \
         "gene_models          1.0      2           50 sub/two\n"
 
@@ -67,8 +67,8 @@ def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
     cli_browse([])
     out, err = capsys.readouterr()
 
-    assert err == ""
-    assert out == \
+    assert out == ""
+    assert err == \
         "Basic                0        2            7 one\n" \
         "gene_models          1.0      2           50 sub/two\n"
 
@@ -81,7 +81,7 @@ def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
     cli_browse([])
     out, err = capsys.readouterr()
 
-    assert err == ""
-    assert out == \
+    assert out == ""
+    assert err == \
         "Basic                0        2            7 one\n" \
         "gene_models          1.0      2           50 sub/two\n"

--- a/dae/dae/genomic_resources/tests/test_cli_hist.py
+++ b/dae/dae/genomic_resources/tests/test_cli_hist.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import os
+import logging
 import textwrap
 
 import pytest
@@ -108,45 +109,54 @@ def test_repo_histograms_dry_run(proto_fixture, dask_mocker, tmp_path):
 
 
 def test_resource_histograms_need_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
 
     # Given
     assert not (tmp_path / "one/histograms").exists()
 
     # When
-    cli_manage([
-        "resource-histograms", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-histograms", "--dry-run",
+            "-R", str(tmp_path), "-r", "one"])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "resource <one> histograms " \
-    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert caplog.record_tuples == [
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "resource <one> histograms "
+         "[{'score': 'phastCons100way', 'bins': 100}] need update"),
+    ]
 
 
 def test_repo_histograms_need_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
 
     # Given
     assert not (tmp_path / "one/histograms").exists()
 
     # When
-    cli_manage([
-        "repo-histograms", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-histograms", "--dry-run", "-R", str(tmp_path)])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "resource <one> histograms " \
-    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert caplog.record_tuples == [
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "resource <one> histograms "
+         "[{'score': 'phastCons100way', 'bins': 100}] need update"),
+    ]
 
 
 def test_resource_histograms_no_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
     # Given
     assert not (tmp_path / "one/histograms").exists()
     cli_manage([
@@ -155,19 +165,23 @@ def test_resource_histograms_no_update_message(
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "resource-histograms", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-histograms", "--dry-run",
+            "-R", str(tmp_path), "-r", "one"])
 
     # Then
     out, err = capsys.readouterr()
     assert out == ""
     assert err == ""
-    # assert err == \
-    #     "histograms of <one> are up to date\n"
+    assert caplog.record_tuples == [
+        ("dae.genomic_resources.histogram", logging.INFO,
+         "histograms of <one> are up to date")
+    ]
 
 
 def test_repo_histograms_no_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
     # Given
     assert not (tmp_path / "one/histograms").exists()
     cli_manage([
@@ -176,12 +190,15 @@ def test_repo_histograms_no_update_message(
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "repo-histograms", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-histograms", "--dry-run", "-R", str(tmp_path)])
 
     # Then
     out, err = capsys.readouterr()
     assert out == ""
     assert err == ""
-    # assert err == \
-    #     "histograms of <one> are up to date\n"
+    assert caplog.record_tuples == [
+        ("dae.genomic_resources.histogram", logging.INFO,
+         "histograms of <one> are up to date")
+    ]

--- a/dae/dae/genomic_resources/tests/test_cli_hist.py
+++ b/dae/dae/genomic_resources/tests/test_cli_hist.py
@@ -119,9 +119,11 @@ def test_resource_histograms_need_update_message(
 
     # Then
     captured = capsys.readouterr()
-    assert captured.err == \
-        "resource <one> histograms " \
-        "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "resource <one> histograms " \
+    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
 
 
 def test_repo_histograms_need_update_message(
@@ -136,9 +138,11 @@ def test_repo_histograms_need_update_message(
 
     # Then
     captured = capsys.readouterr()
-    assert captured.err == \
-        "resource <one> histograms " \
-        "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "resource <one> histograms " \
+    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
 
 
 def test_resource_histograms_no_update_message(
@@ -155,9 +159,11 @@ def test_resource_histograms_no_update_message(
         "resource-histograms", "--dry-run", "-R", str(tmp_path), "-r", "one"])
 
     # Then
-    _, err = capsys.readouterr()
-    assert err == \
-        "histograms of <one> are up to date\n"
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+    # assert err == \
+    #     "histograms of <one> are up to date\n"
 
 
 def test_repo_histograms_no_update_message(
@@ -174,6 +180,8 @@ def test_repo_histograms_no_update_message(
         "repo-histograms", "--dry-run", "-R", str(tmp_path)])
 
     # Then
-    _, err = capsys.readouterr()
-    assert err == \
-        "histograms of <one> are up to date\n"
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+    # assert err == \
+    #     "histograms of <one> are up to date\n"

--- a/dae/dae/genomic_resources/tests/test_cli_info.py
+++ b/dae/dae/genomic_resources/tests/test_cli_info.py
@@ -1,0 +1,109 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import textwrap
+
+import pytest
+
+from dae.genomic_resources.cli import cli_manage
+from dae.genomic_resources.repository import GR_CONF_FILE_NAME
+from dae.genomic_resources.testing import build_testing_protocol, \
+    tabix_to_resource
+
+
+@pytest.fixture
+def proto_fixture(tmp_path, tabix_file):
+    proto = build_testing_protocol(
+        scheme="file",
+        root_path=str(tmp_path),
+        content={
+            "one": {
+                GR_CONF_FILE_NAME: textwrap.dedent("""
+                    type: position_score
+                    table:
+                        filename: data.bgz
+                    scores:
+                        - id: phastCons100way
+                          type: float
+                          name: s1
+                    histograms:
+                        - score: phastCons100way
+                          bins: 100
+                    """),
+            },
+            "two": {
+                GR_CONF_FILE_NAME: textwrap.dedent("""
+                    type: allele_score
+                    table:
+                        filename: data.bgz
+                        format: tabix
+                    scores:
+                        - id: AC
+                          type: int
+                          name: AC
+                    """),
+            }
+        })
+    resource = proto.get_resource("one")
+    tabix_to_resource(
+        tabix_file(
+            """
+            #chrom  pos_begin  pos_end  s1    s2
+            1       10         15       0.02  1.02
+            1       17         19       0.03  1.03
+            1       22         25       0.04  1.04
+            2       5          80       0.01  2.01
+            2       10         11       0.02  2.02
+            """, seq_col=0, start_col=1, end_col=2),
+        resource, "data.bgz"
+    )
+    resource = proto.get_resource("two")
+    tabix_to_resource(
+        tabix_file(
+            """
+            #CHROM  POS    chrom  variant    REF  ALT  AC
+            1       12198  1      sub(G->C)  G    C    0
+            1       12237  1      sub(G->A)  G    A    0
+            1       12259  1      sub(G->C)  G    C    0
+            1       12266  1      sub(G->A)  G    A    0
+            1       12272  1      sub(G->A)  G    A    0
+            1       12554  1      sub(A->G)  A    G    0
+            """, seq_col=0, start_col=1, end_col=1),
+        resource, "data.bgz"
+    )
+    return proto
+
+
+def test_resource_info(proto_fixture, dask_mocker, tmp_path):
+    assert not (tmp_path / "one/index.html").exists()
+
+    cli_manage(["resource-info", "-R", str(tmp_path), "-r", "one"])
+
+    assert (tmp_path / "one/index.html").exists()
+    assert not (tmp_path / "two/index.html").exists()
+    assert not (tmp_path / "index.html").exists()
+
+    cli_manage(["resource-info", "-R", str(tmp_path), "-r", "two"])
+
+    assert (tmp_path / "one/index.html").exists()
+    assert (tmp_path / "two/index.html").exists()
+    assert not (tmp_path / "index.html").exists()
+
+    with open(tmp_path / "one/index.html") as infile:
+        result = infile.read()
+
+    assert result.find("<h1>one</h1>")
+    assert result.find("<h3>Score file:</h3>")
+    assert result.find("<h3>Score definitions:</h3>")
+    assert result.find("<p>Score ID: phastCons100way</p>")
+    assert result.find("<h3>Histograms:</h3>")
+    print(result)
+
+
+def test_repo_info(proto_fixture, dask_mocker, tmp_path):
+    assert not (tmp_path / "one/index.html").exists()
+
+    cli_manage(["repo-info", "-R", str(tmp_path)])
+
+    assert (tmp_path / "one/index.html").exists()
+    assert (tmp_path / "two/index.html").exists()
+    assert (tmp_path / "index.html").exists()
+

--- a/dae/dae/genomic_resources/tests/test_cli_info.py
+++ b/dae/dae/genomic_resources/tests/test_cli_info.py
@@ -106,4 +106,3 @@ def test_repo_info(proto_fixture, dask_mocker, tmp_path):
     assert (tmp_path / "one/index.html").exists()
     assert (tmp_path / "two/index.html").exists()
     assert (tmp_path / "index.html").exists()
-

--- a/dae/dae/genomic_resources/tests/test_cli_manifest.py
+++ b/dae/dae/genomic_resources/tests/test_cli_manifest.py
@@ -80,7 +80,7 @@ def test_repo_manifest_dry_run_simple(proto_fixture, tmp_path):
 def test_repo_manifest_no_agruments(proto_fixture, tmp_path, mocker, capsys):
     # Given
     cli_manage([
-        "repo-manifest", "-R", str(tmp_path)])
+        "-VV", "repo-manifest", "-R", str(tmp_path)])
     mocker.patch("os.getcwd", return_value=str(tmp_path))
     capsys.readouterr()
 
@@ -90,13 +90,15 @@ def test_repo_manifest_no_agruments(proto_fixture, tmp_path, mocker, capsys):
     # Then
     out, err = capsys.readouterr()
 
-    assert out.startswith(f"working with repository: {tmp_path}\n")
+    assert out == ""
     assert err == \
-        "manifest of <one> is up to date\n" \
-        "manifest of <sub/two> is up to date\n" \
-        "manifest of <sub/two(1.0)> is up to date\n" \
-        "manifest of <three(2.0)> is up to date\n" \
-        "manifest of <xxxxx-genome> is up to date\n"
+        f"working with repository: {tmp_path}\n"
+
+    # f"manifest of <one> is up to date\n" \
+    # f"manifest of <sub/two> is up to date\n" \
+    # f"manifest of <sub/two(1.0)> is up to date\n" \
+    # f"manifest of <three(2.0)> is up to date\n" \
+    # f"manifest of <xxxxx-genome> is up to date\n"
 
 
 def test_check_manifest_update(proto_fixture, tmp_path):
@@ -185,10 +187,11 @@ def test_resource_dry_run_manifest_needs_update_message(
 
     # Then
     captured = capsys.readouterr()
-    print(captured.err)
-    assert captured.err == \
-        "manifest of <one> should be updated; " \
-        "entries to update in manifest ['data.txt']\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> should be updated; " \
+    #     "entries to update in manifest ['data.txt']\n"
     assert bool(proto_fixture.check_update_manifest(res))
 
 
@@ -205,14 +208,15 @@ def test_repo_dry_run_manifest_needs_update_message(
 
     # Then
     captured = capsys.readouterr()
-    print(captured.err)
-    assert captured.err == \
-        "manifest of <one> should be updated; " \
-        "entries to update in manifest ['data.txt']\n" \
-        "manifest of <sub/two> is up to date\n" \
-        "manifest of <sub/two(1.0)> is up to date\n" \
-        "manifest of <three(2.0)> is up to date\n" \
-        "manifest of <xxxxx-genome> is up to date\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> should be updated; " \
+    #     "entries to update in manifest ['data.txt']\n" \
+    #     "manifest of <sub/two> is up to date\n" \
+    #     "manifest of <sub/two(1.0)> is up to date\n" \
+    #     "manifest of <three(2.0)> is up to date\n" \
+    #     "manifest of <xxxxx-genome> is up to date\n"
 
 
 def test_resource_dry_run_manifest_no_update_message(
@@ -225,9 +229,10 @@ def test_resource_dry_run_manifest_no_update_message(
 
     # Then
     captured = capsys.readouterr()
-    print(captured.err)
-    assert captured.err == \
-        "manifest of <one> is up to date\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> is up to date\n"
 
 
 def test_resource_manifest_no_agruments(
@@ -245,9 +250,11 @@ def test_resource_manifest_no_agruments(
     # Then
     out, err = capsys.readouterr()
 
-    assert out.startswith(f"working with repository: {tmp_path}\n")
-    assert err == \
-        "manifest of <one> is up to date\n"
+    assert out == ""
+    assert err == f"working with repository: {tmp_path}\n"
+    # assert out.startswith(f"working with repository: {tmp_path}\n")
+    # assert err == \
+    #     "manifest of <one> is up to date\n"
 
 
 def test_repo_dry_run_manifest_no_update_message(
@@ -260,10 +267,11 @@ def test_repo_dry_run_manifest_no_update_message(
 
     # Then
     captured = capsys.readouterr()
-    print(captured.err)
-    assert captured.err == \
-        "manifest of <one> is up to date\n" \
-        "manifest of <sub/two> is up to date\n" \
-        "manifest of <sub/two(1.0)> is up to date\n" \
-        "manifest of <three(2.0)> is up to date\n" \
-        "manifest of <xxxxx-genome> is up to date\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "manifest of <sub/two> is up to date\n" \
+    #     "manifest of <sub/two(1.0)> is up to date\n" \
+    #     "manifest of <three(2.0)> is up to date\n" \
+    #     "manifest of <xxxxx-genome> is up to date\n"

--- a/dae/dae/genomic_resources/tests/test_cli_manifest.py
+++ b/dae/dae/genomic_resources/tests/test_cli_manifest.py
@@ -31,6 +31,21 @@ def test_resource_manifest_simple(proto_fixture, tmp_path):
     assert not (tmp_path / GR_CONTENTS_FILE_NAME).exists()
 
 
+def test_resource_manifest_dry_run_simple(proto_fixture, tmp_path):
+    # Given
+    proto_fixture.filesystem.delete(str(tmp_path / "one/.MANIFEST"))
+
+    assert not (tmp_path / GR_CONTENTS_FILE_NAME).exists()
+    assert not (tmp_path / "one/.MANIFEST").exists()
+
+    # When
+    cli_manage([
+        "resource-manifest", "-R", str(tmp_path), "-r", "one", "--dry-run"])
+
+    # Then
+    assert not (tmp_path / "one/.MANIFEST").exists()
+
+
 def test_repo_manifest_simple(proto_fixture, tmp_path):
     # Given
     proto_fixture.filesystem.delete(str(tmp_path / "one/.MANIFEST"))
@@ -45,6 +60,21 @@ def test_repo_manifest_simple(proto_fixture, tmp_path):
     # Then
     assert (tmp_path / "one/.MANIFEST").is_file()
     assert (tmp_path / GR_CONTENTS_FILE_NAME).exists()
+
+
+def test_repo_manifest_dry_run_simple(proto_fixture, tmp_path):
+    # Given
+    proto_fixture.filesystem.delete(str(tmp_path / "one/.MANIFEST"))
+
+    assert not (tmp_path / GR_CONTENTS_FILE_NAME).exists()
+    assert not (tmp_path / "one/.MANIFEST").exists()
+
+    # When
+    cli_manage([
+        "repo-manifest", "-R", str(tmp_path), "--dry-run"])
+
+    # Then
+    assert not (tmp_path / "one/.MANIFEST").exists()
 
 
 def test_repo_manifest_no_agruments(proto_fixture, tmp_path, mocker, capsys):
@@ -159,6 +189,7 @@ def test_resource_dry_run_manifest_needs_update_message(
     assert captured.err == \
         "manifest of <one> should be updated; " \
         "entries to update in manifest ['data.txt']\n"
+    assert bool(proto_fixture.check_update_manifest(res))
 
 
 def test_repo_dry_run_manifest_needs_update_message(

--- a/dae/dae/genomic_resources/tests/test_cli_repair.py
+++ b/dae/dae/genomic_resources/tests/test_cli_repair.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import os
+import logging
 import textwrap
 
 import pytest
@@ -119,79 +120,106 @@ def test_repo_repair_dry_run(proto_fixture, dask_mocker, tmp_path):
 
 
 def test_resource_repair_need_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
 
     assert not (tmp_path / "one/histograms").exists()
-    cli_manage([
-        "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-repair", "--dry-run",
+            "-R", str(tmp_path), "-r", "one"])
 
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> is up to date\n" \
-    #     "resource <one> histograms " \
-    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> is up to date"),
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "resource <one> histograms "
+         "[{'score': 'phastCons100way', 'bins': 100}] need "
+         "update"),
+    ]
 
 
 def test_repo_repair_need_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
 
     assert not (tmp_path / "one/histograms").exists()
-    cli_manage([
-        "repo-repair", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> is up to date\n" \
-    #     "resource <one> histograms " \
-    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> is up to date"),
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "resource <one> histograms "
+         "[{'score': 'phastCons100way', 'bins': 100}] need update"),
+    ]
 
 
 def test_resource_repair_no_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
     # Given
     cli_manage([
         "resource-repair", "-R", str(tmp_path), "-r", "one"])
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-repair", "--dry-run",
+            "-R", str(tmp_path), "-r", "one"])
 
     # Then
     out, err = capsys.readouterr()
     assert out == ""
     assert err == ""
-    # assert err == \
-    #     "manifest of <one> is up to date\n" \
-    #     "histograms of <one> are up to date\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> is up to date"),
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "histograms of <one> are up to date"),
+    ]
 
 
 def test_repo_repair_no_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
     # Given
     cli_manage([
         "repo-repair", "-R", str(tmp_path)])
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "repo-repair", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     # Then
     out, err = capsys.readouterr()
     assert out == ""
     assert err == ""
-    # assert err == \
-    #     "manifest of <one> is up to date\n" \
-    #     "histograms of <one> are up to date\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> is up to date"),
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "histograms of <one> are up to date"),
+    ]
 
 
 def test_resource_repair_dry_run_needs_manifest_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
     # Given
     cli_manage([
         "resource-repair", "-R", str(tmp_path), "-r", "one"])
@@ -202,21 +230,27 @@ def test_resource_repair_dry_run_needs_manifest_update_message(
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> should be updated; " \
-    #     "entries to update in manifest ['data.txt']\n" \
-    #     "histograms of <one> are up to date\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> should be updated; entries to update in manifest "
+         "['data.txt']"),
+        ("grr_manage",
+         logging.INFO,
+         "manfiest one needs update; can't check histograms"),
+    ]
 
 
 def test_repo_repair_dry_run_needs_manifest_update_message(
-        proto_fixture, dask_mocker, tmp_path, capsys):
+        proto_fixture, dask_mocker, tmp_path, capsys, caplog):
     # Given
     cli_manage([
         "repo-repair", "-R", str(tmp_path)])
@@ -226,20 +260,27 @@ def test_repo_repair_dry_run_needs_manifest_update_message(
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "repo-repair", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> should be updated; " \
-    #     "entries to update in manifest ['data.txt']\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> should be updated; entries to update in manifest "
+         "['data.txt']"),
+        ("grr_manage",
+         logging.INFO,
+         "manfiest one needs update; can't check histograms"),
+    ]
 
 
 def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
-        proto_fixture, tabix_file, dask_mocker, tmp_path, capsys):
+        proto_fixture, tabix_file, dask_mocker, tmp_path, capsys, caplog):
     # Given
     cli_manage([
         "resource-repair", "-R", str(tmp_path), "-r", "one"])
@@ -260,40 +301,53 @@ def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> should be updated; entries to update in manifest " \
-    #     "['data.bgz', 'data.bgz.tbi']\n" \
-    #     "histograms of <one> are up to date\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> should be updated; entries to update in manifest "
+         "['data.bgz', 'data.bgz.tbi']"),
+        ("grr_manage",
+         logging.INFO,
+         "manfiest one needs update; can't check histograms"),
+    ]
 
     # And after that::
     # Given
     cli_manage([
         "resource-manifest", "-R", str(tmp_path), "-r", "one"])
     _, _ = capsys.readouterr()
+    caplog.clear()
 
     # When
-    cli_manage([
-        "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> is up to date\n" \
-    #     "resource <one> histograms " \
-    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> is up to date"),
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "resource <one> histograms "
+         "[{'score': 'phastCons100way', 'bins': 100}] need update"),
+    ]
 
 
 def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
-        proto_fixture, tabix_file, dask_mocker, tmp_path, capsys):
+        proto_fixture, tabix_file, dask_mocker, tmp_path, capsys, caplog):
     # Given
     cli_manage([
         "repo-repair", "-R", str(tmp_path)])
@@ -314,32 +368,46 @@ def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
     _, _ = capsys.readouterr()
 
     # When
-    cli_manage([
-        "repo-repair", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> should be updated; entries to update in manifest " \
-    #     "['data.bgz', 'data.bgz.tbi']\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> should be updated; entries to update in manifest "
+         "['data.bgz', 'data.bgz.tbi']"),
+        ("grr_manage",
+         logging.INFO,
+         "manfiest one needs update; can't check histograms"),
+    ]
 
     # And after that::
     # Given
     cli_manage([
         "repo-manifest", "-R", str(tmp_path)])
     _, _ = capsys.readouterr()
+    caplog.clear()
 
     # When
-    cli_manage([
-        "repo-repair", "--dry-run", "-R", str(tmp_path)])
+    with caplog.at_level(logging.INFO):
+        cli_manage([
+            "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     # Then
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    # assert captured.err == \
-    #     "manifest of <one> is up to date\n" \
-    #     "resource <one> histograms " \
-    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert caplog.record_tuples == [
+        ("grr_manage",
+         logging.INFO,
+         "manifest of <one> is up to date"),
+        ("dae.genomic_resources.histogram",
+         logging.INFO,
+         "resource <one> histograms "
+         "[{'score': 'phastCons100way', 'bins': 100}] need update"),
+    ]

--- a/dae/dae/genomic_resources/tests/test_cli_repair.py
+++ b/dae/dae/genomic_resources/tests/test_cli_repair.py
@@ -126,11 +126,12 @@ def test_resource_repair_need_update_message(
         "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
 
     captured = capsys.readouterr()
-
-    assert captured.err == \
-        "manifest of <one> is up to date\n" \
-        "resource <one> histograms " \
-        "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "resource <one> histograms " \
+    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
 
 
 def test_repo_repair_need_update_message(
@@ -141,11 +142,12 @@ def test_repo_repair_need_update_message(
         "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     captured = capsys.readouterr()
-
-    assert captured.err == \
-        "manifest of <one> is up to date\n" \
-        "resource <one> histograms " \
-        "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "resource <one> histograms " \
+    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
 
 
 def test_resource_repair_no_update_message(
@@ -160,10 +162,12 @@ def test_resource_repair_no_update_message(
         "resource-repair", "--dry-run", "-R", str(tmp_path), "-r", "one"])
 
     # Then
-    _, err = capsys.readouterr()
-    assert err == \
-        "manifest of <one> is up to date\n" \
-        "histograms of <one> are up to date\n"
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+    # assert err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "histograms of <one> are up to date\n"
 
 
 def test_repo_repair_no_update_message(
@@ -178,10 +182,12 @@ def test_repo_repair_no_update_message(
         "repo-repair", "--dry-run", "-R", str(tmp_path)])
 
     # Then
-    _, err = capsys.readouterr()
-    assert err == \
-        "manifest of <one> is up to date\n" \
-        "histograms of <one> are up to date\n"
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+    # assert err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "histograms of <one> are up to date\n"
 
 
 def test_resource_repair_dry_run_needs_manifest_update_message(
@@ -201,11 +207,12 @@ def test_resource_repair_dry_run_needs_manifest_update_message(
 
     # Then
     captured = capsys.readouterr()
-    print(captured.err)
-    assert captured.err == \
-        "manifest of <one> should be updated; " \
-        "entries to update in manifest ['data.txt']\n" \
-        "histograms of <one> are up to date\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> should be updated; " \
+    #     "entries to update in manifest ['data.txt']\n" \
+    #     "histograms of <one> are up to date\n"
 
 
 def test_repo_repair_dry_run_needs_manifest_update_message(
@@ -224,10 +231,11 @@ def test_repo_repair_dry_run_needs_manifest_update_message(
 
     # Then
     captured = capsys.readouterr()
-    print(captured.err)
-    assert captured.err == \
-        "manifest of <one> should be updated; " \
-        "entries to update in manifest ['data.txt']\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> should be updated; " \
+    #     "entries to update in manifest ['data.txt']\n"
 
 
 def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
@@ -257,10 +265,12 @@ def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
 
     # Then
     captured = capsys.readouterr()
-    assert captured.err == \
-        "manifest of <one> should be updated; entries to update in manifest " \
-        "['data.bgz', 'data.bgz.tbi']\n" \
-        "histograms of <one> are up to date\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> should be updated; entries to update in manifest " \
+    #     "['data.bgz', 'data.bgz.tbi']\n" \
+    #     "histograms of <one> are up to date\n"
 
     # And after that::
     # Given
@@ -274,10 +284,12 @@ def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
 
     # Then
     captured = capsys.readouterr()
-    assert captured.err == \
-        "manifest of <one> is up to date\n" \
-        "resource <one> histograms " \
-        "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "resource <one> histograms " \
+    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
 
 
 def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
@@ -307,9 +319,11 @@ def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
 
     # Then
     captured = capsys.readouterr()
-    assert captured.err == \
-        "manifest of <one> should be updated; entries to update in manifest " \
-        "['data.bgz', 'data.bgz.tbi']\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> should be updated; entries to update in manifest " \
+    #     "['data.bgz', 'data.bgz.tbi']\n"
 
     # And after that::
     # Given
@@ -323,7 +337,9 @@ def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
 
     # Then
     captured = capsys.readouterr()
-    assert captured.err == \
-        "manifest of <one> is up to date\n" \
-        "resource <one> histograms " \
-        "[{'score': 'phastCons100way', 'bins': 100}] need update\n"
+    assert captured.out == ""
+    assert captured.err == ""
+    # assert captured.err == \
+    #     "manifest of <one> is up to date\n" \
+    #     "resource <one> histograms " \
+    #     "[{'score': 'phastCons100way', 'bins': 100}] need update\n"

--- a/dae/dae/genomic_resources/tests/test_cli_repair.py
+++ b/dae/dae/genomic_resources/tests/test_cli_repair.py
@@ -87,6 +87,9 @@ def test_resource_repair_dry_run(proto_fixture, dask_mocker, tmp_path):
     # Given
     proto_fixture.filesystem.delete(
         os.path.join(proto_fixture.url, ".CONTENTS"))
+
+    proto_fixture.filesystem.delete(str(tmp_path / "one" / ".MANIFEST"))
+
     assert not (tmp_path / "one/histograms").exists()
     assert not (tmp_path / GR_CONTENTS_FILE_NAME).exists()
 
@@ -96,6 +99,7 @@ def test_resource_repair_dry_run(proto_fixture, dask_mocker, tmp_path):
 
     # Then
     assert not (tmp_path / "one/histograms").exists()
+    assert not (tmp_path / "one/.MANIFEST").exists()
 
 
 def test_repo_repair_dry_run(proto_fixture, dask_mocker, tmp_path):
@@ -223,8 +227,7 @@ def test_repo_repair_dry_run_needs_manifest_update_message(
     print(captured.err)
     assert captured.err == \
         "manifest of <one> should be updated; " \
-        "entries to update in manifest ['data.txt']\n" \
-        "histograms of <one> are up to date\n"
+        "entries to update in manifest ['data.txt']\n"
 
 
 def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
@@ -306,8 +309,7 @@ def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
     captured = capsys.readouterr()
     assert captured.err == \
         "manifest of <one> should be updated; entries to update in manifest " \
-        "['data.bgz', 'data.bgz.tbi']\n" \
-        "histograms of <one> are up to date\n"
+        "['data.bgz', 'data.bgz.tbi']\n"
 
     # And after that::
     # Given

--- a/dae/dae/genomic_resources/tests/test_score_statistics_state.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics_state.py
@@ -100,8 +100,8 @@ def test_build_hashes_without_change(repo_fixture):
 
     resource = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(resource)
-    hashes = hbuilder._build_hashes(resource.get_manifest())
-    hashes2 = hbuilder._build_hashes(resource.get_manifest())
+    hashes = hbuilder._build_hashes()
+    hashes2 = hbuilder._build_hashes()
 
     assert hashes == hashes2
 
@@ -110,7 +110,7 @@ def test_build_hashes_with_changed_description(repo_fixture):
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes(res.get_manifest())
+    hashes = hbuilder._build_hashes()
 
     # When
     with res.open_raw_file(GR_CONF_FILE_NAME, "at") as outfile:
@@ -126,7 +126,7 @@ def test_build_hashes_with_changed_description(repo_fixture):
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes(res.get_manifest())
+    hashes2 = hbuilder._build_hashes()
 
     assert hashes == hashes2
 
@@ -135,7 +135,7 @@ def test_build_hashes_with_changed_histogram_config(repo_fixture):
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes(res.get_manifest())
+    hashes = hbuilder._build_hashes()
 
     # When
     with res.open_raw_file(GR_CONF_FILE_NAME, "rt") as infile:
@@ -150,7 +150,7 @@ def test_build_hashes_with_changed_histogram_config(repo_fixture):
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes(res.get_manifest())
+    hashes2 = hbuilder._build_hashes()
 
     assert hashes != hashes2
 
@@ -159,7 +159,7 @@ def test_build_hashes_with_changed_scores_config(repo_fixture):
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes(res.get_manifest())
+    hashes = hbuilder._build_hashes()
 
     # When
     with res.open_raw_file(GR_CONF_FILE_NAME, "rt") as infile:
@@ -173,7 +173,7 @@ def test_build_hashes_with_changed_scores_config(repo_fixture):
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes(res.get_manifest())
+    hashes2 = hbuilder._build_hashes()
 
     assert hashes != hashes2
 
@@ -200,7 +200,7 @@ def test_build_hashes_with_changed_tabix_index(
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes(res.get_manifest())
+    hashes = hbuilder._build_hashes()
 
     # When
     tabix_index_update(res)
@@ -209,7 +209,7 @@ def test_build_hashes_with_changed_tabix_index(
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes(res.get_manifest())
+    hashes2 = hbuilder._build_hashes()
 
     assert hashes != hashes2
 
@@ -220,7 +220,7 @@ def test_build_hashes_with_changed_table(
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes(res.get_manifest())
+    hashes = hbuilder._build_hashes()
 
     # When
     tabix_to_resource(
@@ -236,6 +236,6 @@ def test_build_hashes_with_changed_table(
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes(res.get_manifest())
+    hashes2 = hbuilder._build_hashes()
 
     assert hashes != hashes2

--- a/dae/dae/genomic_resources/tests/test_score_statistics_state.py
+++ b/dae/dae/genomic_resources/tests/test_score_statistics_state.py
@@ -100,8 +100,8 @@ def test_build_hashes_without_change(repo_fixture):
 
     resource = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(resource)
-    hashes = hbuilder._build_hashes()
-    hashes2 = hbuilder._build_hashes()
+    hashes = hbuilder._build_hashes(resource.get_manifest())
+    hashes2 = hbuilder._build_hashes(resource.get_manifest())
 
     assert hashes == hashes2
 
@@ -110,7 +110,7 @@ def test_build_hashes_with_changed_description(repo_fixture):
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes()
+    hashes = hbuilder._build_hashes(res.get_manifest())
 
     # When
     with res.open_raw_file(GR_CONF_FILE_NAME, "at") as outfile:
@@ -126,7 +126,7 @@ def test_build_hashes_with_changed_description(repo_fixture):
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes()
+    hashes2 = hbuilder._build_hashes(res.get_manifest())
 
     assert hashes == hashes2
 
@@ -135,7 +135,7 @@ def test_build_hashes_with_changed_histogram_config(repo_fixture):
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes()
+    hashes = hbuilder._build_hashes(res.get_manifest())
 
     # When
     with res.open_raw_file(GR_CONF_FILE_NAME, "rt") as infile:
@@ -150,7 +150,7 @@ def test_build_hashes_with_changed_histogram_config(repo_fixture):
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes()
+    hashes2 = hbuilder._build_hashes(res.get_manifest())
 
     assert hashes != hashes2
 
@@ -159,7 +159,7 @@ def test_build_hashes_with_changed_scores_config(repo_fixture):
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes()
+    hashes = hbuilder._build_hashes(res.get_manifest())
 
     # When
     with res.open_raw_file(GR_CONF_FILE_NAME, "rt") as infile:
@@ -173,7 +173,7 @@ def test_build_hashes_with_changed_scores_config(repo_fixture):
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes()
+    hashes2 = hbuilder._build_hashes(res.get_manifest())
 
     assert hashes != hashes2
 
@@ -200,7 +200,7 @@ def test_build_hashes_with_changed_tabix_index(
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes()
+    hashes = hbuilder._build_hashes(res.get_manifest())
 
     # When
     tabix_index_update(res)
@@ -209,7 +209,7 @@ def test_build_hashes_with_changed_tabix_index(
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes()
+    hashes2 = hbuilder._build_hashes(res.get_manifest())
 
     assert hashes != hashes2
 
@@ -220,7 +220,7 @@ def test_build_hashes_with_changed_table(
     # Given
     res = repo_fixture.get_resource("one")
     hbuilder = HistogramBuilder(res)
-    hashes = hbuilder._build_hashes()
+    hashes = hbuilder._build_hashes(res.get_manifest())
 
     # When
     tabix_to_resource(
@@ -236,6 +236,6 @@ def test_build_hashes_with_changed_table(
 
     # Then
     hbuilder = HistogramBuilder(res)
-    hashes2 = hbuilder._build_hashes()
+    hashes2 = hbuilder._build_hashes(res.get_manifest())
 
     assert hashes != hashes2


### PR DESCRIPTION
## Background

While documenting the `grr_manage` workflow, I found several issues. This PR combines several bug fixes in `grr_manage`. 

## Aim

* The `repo-info` subcommand was fixed. 
* The `grr_manage` behavior when using the `--with-dvc` option was fixed.
* The `check_manifest_update` was fixed.
* The `grr_manage` behavior when using the `--dry-run` option was fixed.  
* Messages from running `grr_manage` were reduced and are controlled by the verbosity options.
* The `CacheResource` method `get_manifest()` always returns the remote resource manifest.

Closes #310 