### PR TITLE
Add TypeError to except block in GeneScoresPartitionsView

### DIFF
--- a/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
+++ b/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
@@ -59,54 +59,38 @@ def test_gene_scores_partitions(user_client):
     assert data["right"]["count"] == 18454
 
 
-def test_gene_scores_partitions_bad_request_no_min(user_client):
-    url = "/api/v3/gene_scores/partitions"
-    data = {
+@pytest.mark.parametrize("data", [
+    {
         "score": "LGD_rank",
         "min": 1.5
-    }
-
-    response = user_client.post(
-        url, json.dumps(data), content_type="application/json", format="json"
-    )
-    assert response.status_code == 400
-
-
-def test_gene_scores_partitions_bad_request_no_max(user_client):
-    url = "/api/v3/gene_scores/partitions"
-    data = {
+    },
+    {
         "score": "LGD_rank",
         "max": 5.0
-    }
-
-    response = user_client.post(
-        url, json.dumps(data), content_type="application/json", format="json"
-    )
-    assert response.status_code == 400
-
-
-def test_gene_scores_partitions_bad_request_non_float_min(user_client):
-    url = "/api/v3/gene_scores/partitions"
-    data = {
+    },
+    {
         "score": "LGD_rank",
         "min": "non-float-value",
         "max": 5.0
-    }
-
-    response = user_client.post(
-        url, json.dumps(data), content_type="application/json", format="json"
-    )
-    assert response.status_code == 400
-
-
-def test_gene_scores_partitions_bad_request_non_float_max(user_client):
-    url = "/api/v3/gene_scores/partitions"
-    data = {
+    },
+    {
         "score": "LGD_rank",
         "min": 1.5,
         "max": "non-float-value"
+    },
+    {
+        "score": "LGD_rank",
+        "min": None,
+        "max": 5.0
+    },
+    {
+        "score": "LGD_rank",
+        "min": 1.5,
+        "max": None
     }
-
+])
+def test_gene_scores_partitions_bad_request(user_client, data):
+    url = "/api/v3/gene_scores/partitions"
     response = user_client.post(
         url, json.dumps(data), content_type="application/json", format="json"
     )

--- a/wdae/wdae/gene_scores/views.py
+++ b/wdae/wdae/gene_scores/views.py
@@ -99,12 +99,12 @@ class GeneScoresPartitionsView(QueryBaseView):
 
         try:
             score_min = float(data["min"])
-        except ValueError:
+        except (ValueError, TypeError):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         try:
             score_max = float(data["max"])
-        except ValueError:
+        except (ValueError, TypeError):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         total = 1.0 * len(df)


### PR DESCRIPTION
## Background

GeneScoresPartitionsView tries to convert to float some of the data it is given - the "min" and "max" arguments.

## Aim

Handle invalid values properly, without throwing an exception and returning 500. We had already handled non-float values, but missed NoneType values as they raised a different exception when being converted to float.

## Implementation

Add TypeError to the list of exceptions caught when converting those arguments to float. Updated unit tests to check for that behaviour. Parametrized those unit tests into a single test for brevity and clarity.

Closes #284
Closes #287