### PR TITLE
Configuration of preview and download columns for genotype browser

### DIFF
--- a/dae/dae/configuration/schemas/study_config.py
+++ b/dae/dae/configuration/schemas/study_config.py
@@ -127,7 +127,13 @@ genotype_browser_schema = {
         "preview_columns": {
             "type": "list", "schema": {"type": "string"}
         },
+        "preview_columns_ext": {
+            "type": "list", "schema": {"type": "string"}
+        },
         "download_columns": {
+            "type": "list", "schema": {"type": "string"}
+        },
+        "download_columns_ext": {
             "type": "list", "schema": {"type": "string"}
         },
         "summary_preview_columns": {

--- a/dae/dae/configuration/tests/test_study_config.py
+++ b/dae/dae/configuration/tests/test_study_config.py
@@ -172,6 +172,8 @@ def full_study_config():
             },
             "preview_columns": ["test"],
             "download_columns": ["test"],
+            "preview_columns_ext": ["test"],
+            "download_columns_ext": ["test"],
             "summary_preview_columns": ["test"],
             "summary_download_columns": ["test"],
             "person_filters": {

--- a/dae/dae/studies/variants_db.py
+++ b/dae/dae/studies/variants_db.py
@@ -63,7 +63,7 @@ preview_columns = [
 	"variant",
 	"genotype",
 	"effect",
-	"scores",
+	"gene_scores",
 	"freq"
 ]
 
@@ -84,7 +84,7 @@ download_columns = [
 	"effect",
 	"geneeffect",
 	"effectdetails",
-	"scores",
+	"gene_scores",
 ]
 
 summary_preview_columns = ["variant", "effect", "scores", "freq"]
@@ -94,8 +94,8 @@ summary_download_columns = ["variant", "effect", "scores", "freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]
@@ -257,12 +257,13 @@ class VariantsDb:
         self.gene_models = gene_models
         self.genotype_storage_factory = genotype_storage_factory
 
-        self._genotype_study_cache = {}
-        self._genotype_group_cache = {}
         self.reload()
 
     def reload(self):
         """Load all studies and groups again."""
+        self._genotype_study_cache = {}
+        self._genotype_group_cache = {}
+
         genotype_study_configs = self._load_study_configs()
         genotype_group_configs = self._load_group_configs()
 

--- a/dae/dae/studies/variants_db.py
+++ b/dae/dae/studies/variants_db.py
@@ -63,7 +63,7 @@ preview_columns = [
 	"variant",
 	"genotype",
 	"effect",
-	"weights",
+	"scores",
 	"freq"
 ]
 
@@ -84,18 +84,18 @@ download_columns = [
 	"effect",
 	"geneeffect",
 	"effectdetails",
-	"weights",
+	"scores",
 ]
 
-summary_preview_columns = ["variant", "effect", "weights", "freq"]
-summary_download_columns = ["variant", "effect", "weights", "freq"]
+summary_preview_columns = ["variant", "effect", "scores", "freq"]
+summary_download_columns = ["variant", "effect", "scores", "freq"]
 
 [genotype_browser.column_groups]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-weights.name = "vulnerability/intolerance"
-weights.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+scores.name = "vulnerability/intolerance"
+scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae/dae/testing/__init__.py
+++ b/dae/dae/testing/__init__.py
@@ -3,7 +3,7 @@ from .setup_helpers import convert_to_tab_separated, setup_directories, \
     setup_genome, setup_gene_models, setup_empty_gene_models, \
     setup_gpf_instance
 from .import_helpers import vcf_import, vcf_study, \
-    denovo_import, denovo_study, setup_dataset
+    denovo_import, denovo_study, setup_dataset, study_update
 from .acgt_import import acgt_gpf
 from .alla_import import alla_gpf
 from .foobar_import import foobar_gpf
@@ -17,7 +17,7 @@ __all__ = [
 
     "vcf_import", "vcf_study",
     "denovo_import", "denovo_study",
-    "setup_dataset",
+    "setup_dataset", "study_update",
 
     "acgt_gpf",
     "alla_gpf",

--- a/dae_conftests/dae_conftests/tests/fixtures/defaultConfiguration.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/defaultConfiguration.conf
@@ -21,20 +21,20 @@ has_pedigree_selector = false
 has_graphical_preview = true
 
 preview_columns = [
-    "family", "variant", "genotype", "effect", "scores", "freq", "effect"
+    "family", "variant", "genotype", "effect", "gene_scores", "freq", "effect"
 ]
 
 download_columns = [
     "family", "phenotype", "variant", "best", "fromparent", "inchild", "effect",
-    "count", "geneeffect", "effectdetails", "scores", "freq"
+    "count", "geneeffect", "effectdetails", "gene_scores", "freq"
 ]
 
 summary_preview_columns = [
-    "variant", "effect", "scores", "mpc_cadd", "freq"
+    "variant", "effect", "gene_scores", "mpc_cadd", "freq"
 ]
 
 summary_download_columns = [
-    "variant", "effect", "geneeffect", "effectdetails", "scores", "freq"
+    "variant", "effect", "geneeffect", "effectdetails", "gene_scores", "freq"
 ]
 
 [genotype_browser.columns.genotype]
@@ -96,8 +96,8 @@ pli_rank.format="pLI %%d"
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae_conftests/dae_conftests/tests/fixtures/studies/inheritance_trio/inheritance_trio.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/studies/inheritance_trio/inheritance_trio.conf
@@ -79,8 +79,8 @@ freq.columns = ["ssc_freq", "evs_freq", "e65_freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae_conftests/dae_conftests/tests/fixtures/studies/quads_f1/quads_f1.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/studies/quads_f1/quads_f1.conf
@@ -27,22 +27,22 @@ has_family_filters = false
 has_pedigree_selector = true
 
 preview_columns = [
-    "family", "variant", "genotype", "effect", "scores", "freq", "effect",
+    "family", "variant", "genotype", "effect", "gene_scores", "freq", "effect",
     "continuous", "categorical", "ordinal", "raw"
 ]
 
 download_columns = [
     "family", "phenotype", "variant", "best", "fromparent", "inchild", "effect",
-    "count", "geneeffect", "effectdetails", "scores", "freq", "continuous", "categorical", "ordinal", "raw"
+    "count", "geneeffect", "effectdetails", "gene_scores", "freq", "continuous", "categorical", "ordinal", "raw"
 ]
 
 summary_preview_columns = [
-    "variant", "effect", "scores", "freq", "effect",
+    "variant", "effect", "gene_scores", "freq", "effect",
     "continuous", "categorical", "ordinal", "raw"
 ]
 
 summary_download_columns = [
-    "variant", "effect", "scores", "freq", "effect",
+    "variant", "effect", "gene_scores", "freq", "effect",
     "geneeffect", "effectdetails", "continuous",
     "categorical", "ordinal", "raw"
 ]
@@ -124,8 +124,8 @@ freq.columns = ["ssc_freq", "evs_freq", "e65_freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae_conftests/dae_conftests/tests/fixtures/studies/quads_f1_disabled/quads_f1.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/studies/quads_f1_disabled/quads_f1.conf
@@ -78,8 +78,8 @@ freq.columns = ["ssc_freq", "evs_freq", "e65_freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae_conftests/dae_conftests/tests/fixtures/studies/quads_f2/quads_f2.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/studies/quads_f2/quads_f2.conf
@@ -79,8 +79,8 @@ freq.columns = ["ssc_freq", "evs_freq", "e65_freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae_conftests/dae_conftests/tests/fixtures/studies/quads_in_child/quads_in_child.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/studies/quads_in_child/quads_in_child.conf
@@ -96,8 +96,8 @@ freq.columns = ["ssc_freq", "evs_freq", "e65_freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/dae_conftests/dae_conftests/tests/fixtures/studies/quads_in_parent/quads_in_parent.conf
+++ b/dae_conftests/dae_conftests/tests/fixtures/studies/quads_in_parent/quads_in_parent.conf
@@ -79,8 +79,8 @@ freq.columns = ["ssc_freq", "evs_freq", "e65_freq"]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/integration/local/data/defaultConfiguration.conf
+++ b/integration/local/data/defaultConfiguration.conf
@@ -78,7 +78,7 @@ preview_columns = [
 	"variant",
 	"genotype",
 	"effect",
-	"scores",
+	"gene_scores",
 	"mpc_cadd",
 	"freq"
 ]
@@ -100,7 +100,7 @@ download_columns = [
 	"effect",
 	"geneeffect",
 	"effectdetails",
-	"scores",
+	"gene_scores",
 	"cadd_raw",
 	"cadd_phred",
 	"mpc",
@@ -110,15 +110,15 @@ download_columns = [
 	"exome_gnomad_af_percent"
 ]
 
-summary_preview_columns = ["variant", "effect", "scores", "mpc_cadd", "freq"]
-summary_download_columns = ["variant", "effect", "scores", "mpc_cadd", "freq"]
+summary_preview_columns = ["variant", "effect", "gene_scores", "mpc_cadd", "freq"]
+summary_download_columns = ["variant", "effect", "gene_scores", "mpc_cadd", "freq"]
 
 [genotype_browser.column_groups]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/integration/remote/data/defaultConfiguration.conf
+++ b/integration/remote/data/defaultConfiguration.conf
@@ -78,7 +78,7 @@ preview_columns = [
 	"variant",
 	"genotype",
 	"effect",
-	"scores",
+	"gene_scores",
 	"mpc_cadd",
 	"freq"
 ]
@@ -100,7 +100,7 @@ download_columns = [
 	"effect",
 	"geneeffect",
 	"effectdetails",
-	"scores",
+	"gene_scores",
 	"cadd_raw",
 	"cadd_phred",
 	"mpc",
@@ -110,15 +110,15 @@ download_columns = [
 	"exome_gnomad_af_percent"
 ]
 
-summary_preview_columns = ["variant", "effect", "scores", "mpc_cadd", "freq"]
-summary_download_columns = ["variant", "effect", "scores", "mpc_cadd", "freq"]
+summary_preview_columns = ["variant", "effect", "gene_scores", "mpc_cadd", "freq"]
+summary_download_columns = ["variant", "effect", "gene_scores", "mpc_cadd", "freq"]
 
 [genotype_browser.column_groups]
 effect.name = "effect"
 effect.columns = ["worst_effect", "genes"]
 
-scores.name = "vulnerability/intolerance"
-scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
+gene_scores.name = "vulnerability/intolerance"
+gene_scores.columns = ["lgd_rank", "rvis_rank", "pli_rank"]
 
 family.name = "family"
 family.columns = ["family_id", "study"]

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -277,7 +277,14 @@ class StudyWrapper(StudyWrapperBase):
         self.column_groups = genotype_browser_config.column_groups
         self._validate_column_groups()
         self.preview_columns = genotype_browser_config.preview_columns
+        if genotype_browser_config.preview_columns_ext:
+            self.preview_columns.extend(
+                genotype_browser_config.preview_columns_ext)
         self.download_columns = genotype_browser_config.download_columns
+        if genotype_browser_config.download_columns_ext:
+            self.download_columns.extend(
+                genotype_browser_config.download_columns_ext)
+
         self.summary_preview_columns = \
             genotype_browser_config.summary_preview_columns
         self.summary_download_columns = \
@@ -293,7 +300,12 @@ class StudyWrapper(StudyWrapperBase):
     def _validate_column_groups(self):
         genotype_cols = self.columns.get("genotype") or []
         phenotype_cols = self.columns.get("phenotype") or []
-        for column_group in self.column_groups.values():
+        for column_group_name, column_group in self.column_groups.items():
+            if column_group is None:
+                logger.warning(
+                    "bad configuration for column group %s",
+                    column_group_name)
+                continue
             for column_id in column_group.columns:
                 if column_id not in genotype_cols \
                    and column_id not in phenotype_cols:

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -262,11 +262,12 @@ class StudyWrapper(StudyWrapperBase):
 
         # GENE SCORES
         if genotype_browser_config.column_groups and \
-                genotype_browser_config.column_groups.scores:
+                genotype_browser_config.column_groups.gene_scores:
             self.gene_score_column_sources = [
                 genotype_browser_config.columns.genotype[slot].source
                 for slot in (
-                    genotype_browser_config.column_groups.scores.columns or []
+                    genotype_browser_config.column_groups.gene_scores.columns
+                    or []
                 )
             ]
         else:

--- a/wdae/wdae/studies/tests/test_study_config_genotype_browser_columns.py
+++ b/wdae/wdae/studies/tests/test_study_config_genotype_browser_columns.py
@@ -1,0 +1,150 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import textwrap
+
+import pytest
+
+from studies.study_wrapper import StudyWrapper
+
+from dae.testing import setup_pedigree, setup_denovo, denovo_study, alla_gpf, \
+    study_update
+
+
+@pytest.fixture
+def gpf_fixture(tmp_path_factory):
+    root_path = tmp_path_factory.mktemp(
+        "genotype_browser_columns_config")
+    gpf_instance = alla_gpf(root_path)
+    return gpf_instance
+
+
+@pytest.fixture
+def trio_study(tmp_path_factory, gpf_fixture):
+    root_path = tmp_path_factory.mktemp(
+        "genotype_browser_columns_config")
+    ped_path = setup_pedigree(
+        root_path / "trio_data" / "in.ped",
+        """
+        familyId personId dadId	 momId	sex status role
+        f1       m1       0      0      2   1      mom
+        f1       d1       0      0      1   1      dad
+        f1       p1       d1     m1     1   2      prb
+        """)
+    vcf_path = setup_denovo(
+        root_path / "trio_data" / "in.tsv",
+        """
+          familyId  location  variant    bestState
+          f1        foo:7     sub(A->G)  2||2||1||1/0||0||1||0
+        """
+    )
+
+    study = denovo_study(
+        root_path,
+        "trio", ped_path, [vcf_path],
+        gpf_fixture,
+        study_config_update=textwrap.dedent("""
+        id: trio
+        """))
+    return study
+
+
+def test_genotype_browser_preview_columns_default(trio_study):
+    config = trio_study.config.genotype_browser
+
+    assert config.preview_columns == [
+        "family", "variant", "genotype", "effect", "gene_scores", "freq"
+    ]
+
+
+def test_genotype_browser_download_columns_default(trio_study):
+    config = trio_study.config.genotype_browser
+
+    assert config.download_columns == [
+        "family", "study_phenotype", "variant", "variant_extra",
+        "family_person_ids", "family_structure", "best", "family_genotype",
+        "carriers", "inheritance", "phenotypes",
+        "par_called", "allele_freq",
+        "effect", "geneeffect", "effectdetails",
+        "gene_scores"
+    ]
+
+
+def test_genotype_browser_preview_columns_ext(trio_study, gpf_fixture):
+    study = study_update(
+        gpf_fixture, trio_study, textwrap.dedent("""
+        genotype_browser:
+            columns:
+                genotype:
+                    aaa:
+                        name: AAA
+                        source: aaa
+            preview_columns_ext:
+                - aaa
+        """)
+    )
+    config = study.config.genotype_browser
+    assert config.preview_columns_ext == [
+        "aaa"
+    ]
+
+
+def test_genotype_browser_download_columns_ext(trio_study, gpf_fixture):
+    study = study_update(
+        gpf_fixture, trio_study, textwrap.dedent("""
+        genotype_browser:
+            columns:
+                genotype:
+                    aaa:
+                        name: AAA
+                        source: aaa
+            download_columns_ext:
+                - aaa
+        """)
+    )
+    config = study.config.genotype_browser
+    assert config.download_columns_ext == [
+        "aaa"
+    ]
+
+
+def test_study_wrapper_preview_columns_ext(trio_study, gpf_fixture):
+    study = study_update(
+        gpf_fixture, trio_study, textwrap.dedent("""
+        genotype_browser:
+            columns:
+                genotype:
+                    aaa:
+                        name: AAA
+                        source: aaa
+            preview_columns_ext:
+                - aaa
+        """)
+    )
+    wrapper = StudyWrapper(study, None, None)
+    assert wrapper.preview_columns == [
+        "family", "variant", "genotype", "effect", "gene_scores", "freq", "aaa"
+    ]
+
+
+def test_study_wrapper_download_columns_ext(trio_study, gpf_fixture):
+    study = study_update(
+        gpf_fixture, trio_study, textwrap.dedent("""
+        genotype_browser:
+            columns:
+                genotype:
+                    aaa:
+                        name: AAA
+                        source: aaa
+            download_columns_ext:
+                - aaa
+        """)
+    )
+    wrapper = StudyWrapper(study, None, None)
+    assert wrapper.download_columns == [
+        "family", "study_phenotype", "variant", "variant_extra",
+        "family_person_ids", "family_structure", "best", "family_genotype",
+        "carriers", "inheritance", "phenotypes",
+        "par_called", "allele_freq",
+        "effect", "geneeffect", "effectdetails",
+        "gene_scores",
+        "aaa"
+    ]


### PR DESCRIPTION
## Background

While working on *the GPF Getting Started Guide*  section on preview and download columns (https://www.iossifovlab.com/gpfuserdocs/administration/getting_started.html#getting-started-with-preview-and-download-columns), I needed a way to extend the preview and download columns instead of replacing them.

## Aim

To allow extension of default preview and download columns, I have introduced `preview_columns_ext` and `download_columns_ext` (check https://www.iossifovlab.com/gpfuserdocs/administration/getting_started.html#getting-started-with-preview-and-download-columns).

Working on this, I have noticed that in the default study configuration defined in `dae/studies/variants_db.py` the column name for gene scores was outdated. I have changed this column name to `gene_scores` to reflect better the purpose of this column.

## Implementation

While working on columns configuration tests I had to fix a bug in the `VariantsDb.reload()` method.