### PR TITLE
Resource implementation plugins

### DIFF
--- a/dae/dae/genomic_resources/__init__.py
+++ b/dae/dae/genomic_resources/__init__.py
@@ -23,11 +23,23 @@ _PLUGINS_LOADED = False
 def get_resource_implementation_factory(
     implementation_type: str
 ) -> Callable[[GenomicResource], GenomicResourceImplementation]:
-    if implementation_type not in _REGISTERED_RESOURCE_IMPLEMENTATIONS:
-        raise ValueError(
-            f"unsupported resource implementation type: {implementation_type}"
-        )
-    return _REGISTERED_RESOURCE_IMPLEMENTATIONS[implementation_type]
+    """
+    Return an implementation builder for a certain resource type.
+
+    If the builder is not registered, then it will search for an entry point
+    in the found implementations list. If an entry point is found, it will be
+    loaded and registered and returned.
+    """
+    if resource_type not in _REGISTERED_RESOURCE_IMPLEMENTATIONS:
+        if resource_type not in _FOUND_RESOURCE_IMPLEMENTATIONS:
+            raise ValueError(
+                f"unsupported resource implementation type: {resource_type}"
+            )
+        entry_point = _FOUND_RESOURCE_IMPLEMENTATIONS[resource_type]
+        loaded = entry_point.load()
+        register_implementation(resource_type, loaded)
+
+    return _REGISTERED_RESOURCE_IMPLEMENTATIONS[resource_type]
 
 
 def register_implementation(implementation_type, factory):

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -47,6 +47,8 @@ from dae.genomic_resources.histogram import HistogramBuilder
 from dae.genomic_resources.repository_factory import \
     build_genomic_resource_repository
 
+from dae.genomic_resources import get_resource_implementation_factory
+
 
 logger = logging.getLogger("grr_manage")
 
@@ -534,20 +536,9 @@ def _run_repo_info_command(proto, **kwargs):  # pylint: disable=unused-argument
             )
 
 
-RESOURCE_TYPE_BUILDERS = {
-    "position_score": build_position_score_from_resource,
-    "np_score": build_np_score_from_resource,
-    "allele_score": build_allele_score_from_resource,
-    "liftover_chain": build_liftover_chain_from_resource,
-    "gene_models": build_gene_models_from_resource,
-    "genome": build_reference_genome_from_resource,
-    "gene_set": build_gene_set_collection_from_resource,
-    "gene_score": build_gene_score_collection_from_resource
-}
-
-
 def build_resource_implementation(res):
-    return RESOURCE_TYPE_BUILDERS[res.get_type()](res)
+    factory = get_resource_implementation_factory(res.get_type())
+    return factory(res)
 
 
 def _do_resource_info_command(proto, res):

--- a/dae/dae/genomic_resources/tests/test_implementation_plugins.py
+++ b/dae/dae/genomic_resources/tests/test_implementation_plugins.py
@@ -1,0 +1,11 @@
+from dae.gene.gene_scores import build_gene_score_collection_from_resource
+from dae.genomic_resources import get_resource_implementation_factory, \
+    register_implementation
+
+
+def test_register_implementation(grr_test_repo):
+    register_implementation(
+        "test_gene_score", build_gene_score_collection_from_resource
+    )
+
+    assert get_resource_implementation_factory("test_gene_score") is not None

--- a/dae/dae/genomic_resources/vcf_info_score.py
+++ b/dae/dae/genomic_resources/vcf_info_score.py
@@ -298,3 +298,7 @@ class VcfInfoScore(GenomicScore):
             {% endfor %}
             {% endblock %}
         """))
+
+
+def build_vcf_info_from_resource(resource: GenomicResource) -> VcfInfoScore:
+    return VcfInfoScore(resource)

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -1,4 +1,5 @@
 """Defines GPFInstance class that gives access to different parts of GPF."""
+# pylint: disable=import-outside-toplevel
 
 import os
 import logging
@@ -10,7 +11,6 @@ from pathlib import Path
 from dae.utils.fs_utils import find_directory_with_a_file
 from dae.enrichment_tool.background_facade import BackgroundFacade
 
-from dae.gene.gene_scores import GeneScoresDb, GeneScoreCollection
 from dae.gene.scores import GenomicScoresDb
 from dae.gene.gene_sets_db import GeneSetsDb, \
     build_gene_set_collection_from_resource
@@ -160,6 +160,7 @@ class GPFInstance:
     @cached_property
     def gene_scores_db(self):
         """Load and return gene scores db."""
+        from dae.gene.gene_scores import GeneScoresDb, GeneScoreCollection
         if self.dae_config.gene_scores_db is None:
             return GeneScoresDb([])
 

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -50,6 +50,16 @@ setuptools.setup(
     default_grr=dae.genomic_resources.genomic_context:DefaultRepositoryContextProvider.register
     gpf_instance=dae.gpf_instance_plugin.gpf_instance_context_plugin:init_gpf_instance_genomic_context_plugin
 
+    [dae.genomic_resources.implementations]
+    gene_set=dae.gene.gene_sets_db:build_gene_set_collection_from_resource
+    gene_score=dae.gene.gene_scores:build_gene_score_collection_from_resource
+    position_score=dae.genomic_resources.genomic_scores:build_position_score_from_resource
+    np_score=dae.genomic_resources.genomic_scores:build_np_score_from_resource
+    allele_score=dae.genomic_resources.genomic_scores:build_allele_score_from_resource
+    liftover_chain=dae.genomic_resources.liftover_resource:build_liftover_chain_from_resource
+    genome=dae.genomic_resources.reference_genome:build_reference_genome_from_resource
+    vcf_info=dae.genomic_resources.vcf_info_score:build_vcf_info_from_resource
+
     [dae.genotype_storage.factories]
     impala=dae.impala_storage.schema1.impala_genotype_storage:ImpalaGenotypeStorage
     impala2=dae.impala_storage.schema2.schema2_genotype_storage:Schema2GenotypeStorage

--- a/dae_conftests/dae_conftests/dae_conftests.py
+++ b/dae_conftests/dae_conftests/dae_conftests.py
@@ -114,18 +114,23 @@ def default_dae_config(request, fixture_dirname):
 
 
 @pytest.fixture(scope="session")
-def gpf_instance(default_dae_config, fixture_dirname):
+def grr_test_repo(fixture_dirname):
+    return build_genomic_resource_repository(
+        {
+            "id": "grr_test_repo",
+            "type": "directory",
+            "directory": fixture_dirname("test_repo"),
+        }
+    )
+
+
+@pytest.fixture(scope="session")
+def gpf_instance(default_dae_config, fixture_dirname, grr_test_repo):
     from dae.gpf_instance.gpf_instance import GPFInstance
 
     def build(config_filename):
         repositories = [
-            build_genomic_resource_repository(
-                {
-                    "id": "grr_test_repo",
-                    "type": "directory",
-                    "directory": fixture_dirname("test_repo"),
-                }
-            ),
+            grr_test_repo,
             build_genomic_resource_repository(
                 {
                     "id": "fixtures",
@@ -145,15 +150,12 @@ def gpf_instance(default_dae_config, fixture_dirname):
 
 @pytest.fixture(scope="session")
 def gpf_instance_2013(
-        default_dae_config, fixture_dirname, global_dae_fixtures_dir):
+        default_dae_config, fixture_dirname,
+        global_dae_fixtures_dir, grr_test_repo):
     from dae.gpf_instance.gpf_instance import GPFInstance
 
     repositories = [
-        build_genomic_resource_repository({
-            "id": "grr_test_repo",
-            "type": "directory",
-            "directory": fixture_dirname("test_repo"),
-        }),
+        grr_test_repo,
         build_genomic_resource_repository({
             "id": "fixtures",
             "type": "directory",
@@ -189,15 +191,12 @@ def fixtures_gpf_instance(gpf_instance, global_dae_fixtures_dir):
 
 @pytest.fixture(scope="session")
 def gpf_instance_2019(
-        default_dae_config, fixture_dirname, global_dae_fixtures_dir):
+        default_dae_config, fixture_dirname,
+        global_dae_fixtures_dir, grr_test_repo):
     from dae.gpf_instance.gpf_instance import GPFInstance
 
     repositories = [
-        build_genomic_resource_repository({
-            "id": "grr_test_repo",
-            "type": "directory",
-            "directory": fixture_dirname("test_repo"),
-        }),
+        grr_test_repo,
         build_genomic_resource_repository({
             "id": "fixtures",
             "type": "directory",


### PR DESCRIPTION
## Background

Genomic resources used to be plugins when they were merged in one class with implementations. Ever since their split, the plugins were removed and left for later.

## Aim

Restore registering of implementations as entry points and accessing them through a central registry.

## Implementation

Every resource is expected to have a builder function, which takes a resource. This function will be registered to the resource's type, as specified in setup.py. Due to cyclic import issues, registered implementations are first discovered when running, but are loaded on demand.

Closes #309 