### PR TITLE
Remove leading slash

### DIFF
--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -747,7 +747,7 @@ repository_template = Template("""
             <tr>
                 <td class="nowrap">{{value['type']}}</td>
                 <td class="nowrap">
-                    <a href='/{{key}}/'>{{key}}</a>
+                    <a href='{{key}}/'>{{key}}</a>
                 </td>
                 <td class="nowrap">{{value['res_version']}}</td>
                 <td class="nowrap">{{value['res_files']}}</td>


### PR DESCRIPTION
## Background

When generating the index page for a genomic resource repository, links to all of the resources were created with leading slashes. Anchor tags with leading slashes behave differently when opened locally and hosted.

## Aim

Remove the leading slashes to make the index page behave similarly when opened locally.

## Implementation

Not much to say here, the leading slash has been removed.
The behavior is still different, because when hosted, it will automatically search for an index.html and use it, but locally it will default to your browser's folder viewer, but at least it isn't broken locally.

Closes #282.
