### PR TITLE
Log filter string formatting

### DIFF
--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -358,7 +358,8 @@ def change_password(request):
     if not is_password_valid(password):
         LOGGER.error(log_filter(
             request,
-            f"Password change failed: Invalid password: '{str(password)}'"
+            "Password change failed: Invalid password: '%s'",
+            str(password)
         ))
         return Response(
             {"error_msg": ("Invalid password entered. Password is either too"
@@ -391,8 +392,8 @@ def register(request):
         LOGGER.info(
             log_filter(
                 request,
-                "registration succeded; "
-                "email: '" + str(email) + "'",
+                "registration succeeded; email: '%s'",
+                str(email)
             )
         )
         return Response({}, status=status.HTTP_201_CREATED)
@@ -400,8 +401,8 @@ def register(request):
         LOGGER.error(
             log_filter(
                 request,
-                "Registration failed: IntegrityError; "
-                "email: '" + str(email) + "'",
+                "Registration failed: IntegrityError; email: '%s'",
+                str(email)
             )
         )
         return Response({}, status=status.HTTP_201_CREATED)
@@ -410,7 +411,8 @@ def register(request):
             log_filter(
                 request,
                 "Registration failed: Email or Researcher Id not found; "
-                "email: '" + str(email) + "'",
+                "email: '%s'",
+                str(email)
             )
         )
         return Response(
@@ -421,7 +423,9 @@ def register(request):
     except KeyError:
         LOGGER.error(
             log_filter(
-                request, "Registration failed: KeyError; " + str(request.data)
+                request,
+                "Registration failed: KeyError; %s",
+                str(request.data)
             )
         )
         return Response({}, status=status.HTTP_201_CREATED)
@@ -429,7 +433,8 @@ def register(request):
         LOGGER.error(
             log_filter(
                 request,
-                f"Registration failed: Invalid email; email: '{str(email)}'"
+                f"Registration failed: Invalid email; email: '%s'",
+                str(email)
             )
         )
         return Response(

--- a/wdae/wdae/utils/logger.py
+++ b/wdae/wdae/utils/logger.py
@@ -40,10 +40,12 @@ def request_logging(logger):
         @wraps(func)
         def func_wrapper(self, request, *args, **kwargs):
             message = []
+            if args:
+                message.append(f"{args}")
             if kwargs:
                 message.append(f"{kwargs}")
             message = "; ".join(message)
-            logger.info(log_filter(request, message, *args).strip())
+            logger.info(log_filter(request, message).strip())
 
             return func(self, request, *args, **kwargs)
 
@@ -59,10 +61,12 @@ def request_logging_function_view(logger):
         @wraps(func)
         def func_wrapper(request, *args, **kwargs):
             message = []
+            if args:
+                message.append(f"{args}")
             if kwargs:
                 message.append(f"{kwargs}")
             message = "; ".join(message)
-            logger.info(log_filter(request, message, *args).strip())
+            logger.info(log_filter(request, message).strip())
 
             return func(request, *args, **kwargs)
 

--- a/wdae/wdae/utils/logger.py
+++ b/wdae/wdae/utils/logger.py
@@ -9,7 +9,9 @@ from functools import wraps
 LOGGER = logging.getLogger("wdae.api")
 
 
-def log_filter(request, message):
+def log_filter(request, message, *args):
+    if len(args) > 0:
+        message = message % args
     request_method = getattr(request, "method", "-")
     path_info = getattr(request, "path_info", "-")
     username = "guest"
@@ -38,12 +40,10 @@ def request_logging(logger):
         @wraps(func)
         def func_wrapper(self, request, *args, **kwargs):
             message = []
-            if args:
-                message.append(f"{args}")
             if kwargs:
                 message.append(f"{kwargs}")
             message = "; ".join(message)
-            logger.info(log_filter(request, message).strip())
+            logger.info(log_filter(request, message, *args).strip())
 
             return func(self, request, *args, **kwargs)
 
@@ -59,12 +59,10 @@ def request_logging_function_view(logger):
         @wraps(func)
         def func_wrapper(request, *args, **kwargs):
             message = []
-            if args:
-                message.append(f"{args}")
             if kwargs:
                 message.append(f"{kwargs}")
             message = "; ".join(message)
-            logger.info(log_filter(request, message).strip())
+            logger.info(log_filter(request, message, *args).strip())
 
             return func(request, *args, **kwargs)
 


### PR DESCRIPTION
## Background

We use a custom function to log our WDAE API messages. This function does not support internal string formatting and we cannot avoid constructing the strings with which it *might* be called.

## Aim

Add support for positional arguments to the function and use these positional arguments to perform % formatting.

## Implementation

% formatting has been added and the places where we use log_filter in users_api have been updated to use % formatting.

Closes #232.
