### PR TITLE
In memory tags fix

### DIFF
--- a/dae/dae/impala_storage/schema1/impala_variants.py
+++ b/dae/dae/impala_storage/schema1/impala_variants.py
@@ -197,6 +197,7 @@ class ImpalaVariants:
         self.ped_df = self._fetch_pedigree()
         self.families = FamiliesData.from_pedigree_df(self.ped_df)
         # Temporary workaround for studies that are imported without tags
+        # e.g. production data that is too large to reimport
         FamiliesLoader._build_families_tags(
             self.families, {"ped_tags": True}
         )

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -122,12 +122,13 @@ class ImportProject():
         """Get params for loading the pedigree."""
         families_filename = self.get_pedigree_filename()
 
-        default_families_params = FamiliesLoader.cli_defaults()
-        families_params = self.import_config["input"]["pedigree"]
-        families_params = self._add_loader_prefix(families_params, "ped_")
-        default_families_params.update(families_params)
+        families_params = {}
+        families_params.update(FamiliesLoader.cli_defaults())
+        config_params = self.import_config["input"]["pedigree"]
+        config_params = self._add_loader_prefix(config_params, "ped_")
+        families_params.update(config_params)
 
-        return families_filename, default_families_params
+        return families_filename, families_params
 
     def get_pedigree_filename(self) -> str:
         """Return the path to the pedigree file."""

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -122,10 +122,12 @@ class ImportProject():
         """Get params for loading the pedigree."""
         families_filename = self.get_pedigree_filename()
 
+        default_families_params = FamiliesLoader.cli_defaults()
         families_params = self.import_config["input"]["pedigree"]
         families_params = self._add_loader_prefix(families_params, "ped_")
+        default_families_params.update(families_params)
 
-        return families_filename, families_params
+        return families_filename, default_families_params
 
     def get_pedigree_filename(self) -> str:
         """Return the path to the pedigree file."""

--- a/dae/dae/import_tools/tests/test_import_project.py
+++ b/dae/dae/import_tools/tests/test_import_project.py
@@ -49,3 +49,11 @@ def test_config_filenames_external_input_and_annotation():
     )
     project = ImportProject.build_from_config(import_config)
     assert project.config_filenames == ["annotation.yaml"]
+
+
+def test_tags_on_by_default(resources_dir):
+    config_fn = str(resources_dir / "vcf_import" / "import_config.yaml")
+    project = ImportProject.build_from_file(config_fn)
+    _, params = project.get_pedigree_params()
+    assert "ped_tags" in params
+    assert params["ped_tags"] is True

--- a/dae/dae/inmemory_storage/tests/test_inmemory_import_storage.py
+++ b/dae/dae/inmemory_storage/tests/test_inmemory_import_storage.py
@@ -16,6 +16,7 @@ def test_simple_project_pedigree_params(simple_project):
     assert params["ped_person"] == "pId"
     assert params["ped_mom"] == "mId"
     assert params["ped_dad"] == "dId"
+    assert params["ped_tags"] is True
 
 
 def test_simple_project_pedigree_size(simple_project):

--- a/dae/dae/variants_loaders/raw/loader.py
+++ b/dae/dae/variants_loaders/raw/loader.py
@@ -172,8 +172,14 @@ class CLILoader(ABC):
 
     @classmethod
     def cli_defaults(cls):
-        argument_destinations = [arg.destination for arg in cls._arguments()]
-        defaults = [arg.default_value for arg in cls._arguments()]
+        argument_destinations = [
+            arg.destination for arg in cls._arguments()
+            if arg.destination is not None
+        ]
+        defaults = [
+            arg.default_value for arg in cls._arguments()
+            if arg.destination is not None
+        ]
         return dict(zip(argument_destinations, defaults))
 
     @classmethod

--- a/dae/dae/variants_loaders/raw/tests/test_base_loader.py
+++ b/dae/dae/variants_loaders/raw/tests/test_base_loader.py
@@ -1,0 +1,36 @@
+from dae.variants_loaders.raw.loader import CLILoader, CLIArgument
+
+
+class TestLoader(CLILoader):  # pylint: disable=missing-class-docstring
+    @classmethod
+    def _arguments(cls):
+        arguments = []
+        arguments.append(CLIArgument(
+            "positional",
+            value_type=str,
+            metavar="<positional>",
+            help_text="Some positional argument",
+        ))
+        arguments.append(CLIArgument(
+            "--kwarg1",
+            default_value=1,
+            help_text="First kwarg",
+        ))
+        arguments.append(CLIArgument(
+            "--kwarg2",
+            default_value=2,
+            help_text="Second kwarg",
+        ))
+        return arguments
+
+
+def test_cli_defaults_does_not_include_positionals():
+    """
+    Test for a bug where positionals were included in cli_defaults.
+
+    Positional arguments have no destination and were mapped to None
+    in the output.
+    """
+    loader = TestLoader()
+    defaults = loader.cli_defaults()
+    assert set(defaults.keys()) == set(["kwarg1", "kwarg2"])


### PR DESCRIPTION
## Background

Following the getting started guide and creating an in memory study resulted in no tags being generated and later no tags being loaded.

## Aim

Restore tags when following the steps in the getting started guide.

## Implementation

While the original issue expected tags to be created when loading in-memory studies, I decided to fix it by restoring the default tag generation. Before we switched to import projects, ped-tags used to be True by default, which led to all newly imported studies having tags unless explicitly specified not to.
I also fixed a bug in the base CLILoader class where cli_defaults added positional arguments to the output dictionary as the following key-value pair (None, None).

Closes #307.