### PR TITLE
Change genomic score schema to accept any default_annotation format

### DIFF
--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -467,16 +467,7 @@ class GenomicScore(GenomicResourceImplementation):
                     "y_scale": {"type": "string"},
                 }
             }},
-            "default_annotation": {"type": "dict", "schema": {
-                "attributes": {"type": "list", "schema": {
-                    "type": "dict",
-                    "schema": {
-                        "source": {"type": "string"},
-                        "destination": {"type": "string"},
-                        "internal": {"type": "boolean", "default": False}
-                    }
-                }}
-            }}
+            "default_annotation": {"type": "dict", "allow_unknown": True}
         }
 
 

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -477,11 +477,8 @@ class PositionScore(GenomicScore):
     @staticmethod
     def get_schema():
         schema = copy.deepcopy(GenomicScore.get_schema())
-        annotation_schema = schema["default_annotation"]["schema"]
         scores_schema = schema["scores"]["schema"]["schema"]
         scores_schema["position_aggregator"] = AGGREGATOR_SCHEMA
-        attr_schema = annotation_schema["attributes"]["schema"]["schema"]
-        attr_schema["position_aggregator"] = AGGREGATOR_SCHEMA
         return schema
 
     def open(self) -> PositionScore:
@@ -575,10 +572,6 @@ class NPScore(GenomicScore):
                 "name": {"type": "string", "excludes": "index"}
             }
         }
-        annotation_schema = schema["default_annotation"]["schema"]
-        attr_schema = annotation_schema["attributes"]["schema"]["schema"]
-        attr_schema["position_aggregator"] = AGGREGATOR_SCHEMA
-        attr_schema["nucleotide_aggregator"] = AGGREGATOR_SCHEMA
 
         scores_schema = schema["scores"]["schema"]["schema"]
         scores_schema["position_aggregator"] = AGGREGATOR_SCHEMA

--- a/dae/dae/genomic_resources/tests/test_genomic_scores.py
+++ b/dae/dae/genomic_resources/tests/test_genomic_scores.py
@@ -1,0 +1,30 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+from dae.genomic_resources.repository import GenomicResource, GR_CONF_FILE_NAME
+from dae.genomic_resources.testing import build_test_resource
+
+
+def test_default_annotation_pre_normalize_validates():
+    res: GenomicResource = build_test_resource({
+        GR_CONF_FILE_NAME: """
+            type: position_score
+            table:
+                filename: data.mem
+            scores:
+              - id: phastCons100way
+                type: float
+                desc: "The phastCons computed over the tree of 100 \
+                       verterbarte species"
+                name: s1
+            default_annotation:
+              attributes:
+                - phastCons100way""",
+        "data.mem": """
+            chrom  pos_begin  s1
+            1      10         0.02
+            1      11         0.03
+            1      15         0.46
+            2      8          0.01
+            """
+    })
+    assert res is not None
+    assert res.get_type() == "position_score"


### PR DESCRIPTION
## Background

default_annotation passes through a normalization step when used by the annotation pipeline, but the genomic resource implementation validated the configuration against the final normalized format of the pipeline. This resulted in valid resources not being created because of the implementation validation.

## Implementation

After discussing the issue with @lchorbadjiev, we agreed that the resource implementation should care only for the vital parts of the configuration - parts without which the resource cannot be opened and is not functional. Thus default_annotation will be  treated as an accepted field, which is going to be used by the clients of the implementation and validated by the clients of the implementation and we should keep this distinction between essential resource configuration and configuration segments on the client's side.

Closes #332.