### PR TITLE
Management adjustments

### DIFF
--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -245,6 +245,23 @@ def test_datasets_permissions(admin_client, wdae_gpf_instance):
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
+def test_datasets_permissions_single(admin_client, wdae_gpf_instance):
+    response = admin_client.get("/api/v3/datasets/permissions/Dataset1")
+    assert response.status_code == status.HTTP_200_OK
+    assert set(response.data.keys()) == set([
+        "dataset_id",
+        "dataset_name",
+        "broken",
+        "users",
+        "groups"
+    ])
+
+
+def test_datasets_permissions_single_missing(admin_client, wdae_gpf_instance):
+    response = admin_client.get("/api/v3/datasets/permissions/alabala")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_datasets_permissions_search(admin_client, wdae_gpf_instance):
     response = admin_client.get("/api/v3/datasets/permissions?search=we2014")
     assert len(response.data) == 1

--- a/wdae/wdae/datasets_api/urls.py
+++ b/wdae/wdae/datasets_api/urls.py
@@ -39,6 +39,11 @@ urlpatterns = [
         name="management_details"
     ),
     re_path(
+        r"^/permissions/(?P<dataset_id>.+)/?$",
+        views.DatasetPermissionsSingleView.as_view(),
+        name="management_details"
+    ),
+    re_path(
         r"^/studies/?$",
         views.StudiesView.as_view(),
         name="list_studies"

--- a/wdae/wdae/groups_api/tests/test_groups_rest.py
+++ b/wdae/wdae/groups_api/tests/test_groups_rest.py
@@ -51,7 +51,7 @@ def test_groups_have_users_and_datasets(admin_client):
 def test_single_group_has_users_and_datasets(admin_client):
     groups = Group.objects.all()
     for group in groups:
-        url = "/api/v3/groups/{}".format(group.id)
+        url = "/api/v3/groups/{}".format(group.name)
         response = admin_client.get(url)
 
         assert response.status_code is status.HTTP_200_OK
@@ -115,7 +115,7 @@ def test_admin_can_rename_groups(admin_client, group_with_user):
     test_name = "AwesomeGroup"
     assert group.name is not test_name
 
-    url = "/api/v3/groups/{}".format(group.pk)
+    url = "/api/v3/groups/{}".format(group.name)
 
     data = {"id": group.id, "name": test_name}
 
@@ -135,7 +135,7 @@ def test_group_has_all_users(admin_client, group):
     for email in test_emails:
         group.user_set.create(email=email)
 
-    url = "/api/v3/groups/{}".format(group.id)
+    url = "/api/v3/groups/{}".format(group.name)
     response = admin_client.get(url)
 
     assert response.status_code is status.HTTP_200_OK
@@ -181,14 +181,14 @@ def test_empty_group_with_permissions_is_shown(admin_client, dataset):
 def test_group_has_all_datasets(admin_client, group_with_user, dataset):
     group, _ = group_with_user
 
-    url = "/api/v3/groups/{}".format(group.id)
+    url = "/api/v3/groups/{}".format(group.name)
     response = admin_client.get(url)
     assert response.status_code is status.HTTP_200_OK
     assert len(response.data["datasets"]) == 0
 
     dataset.groups.add(group)
 
-    url = "/api/v3/groups/{}".format(group.id)
+    url = "/api/v3/groups/{}".format(group.name)
     response = admin_client.get(url)
     assert response.status_code is status.HTTP_200_OK
     assert len(response.data["datasets"]) == 1

--- a/wdae/wdae/groups_api/tests/test_groups_rest.py
+++ b/wdae/wdae/groups_api/tests/test_groups_rest.py
@@ -411,3 +411,24 @@ def test_user_group_routes(admin_client, user):
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not user.groups.filter(name="Test group").exists()
+
+
+def test_group_retrieve(admin_client, hundred_groups):
+    url = "/api/v3/groups/Group1"
+    response = admin_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.data
+
+    assert data["name"] == "Group1"
+    assert data["users"] == ["user@example.com"]
+    assert data["datasets"] == [{
+        "datasetName": "Dataset1",
+        "datasetId": "Dataset1",
+        "broken": False,
+    }]
+
+
+def test_group_retrieve_missing(admin_client):
+    url = "/api/v3/groups/somegroupthatdoesnotexist"
+    response = admin_client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/wdae/wdae/groups_api/views.py
+++ b/wdae/wdae/groups_api/views.py
@@ -23,6 +23,7 @@ class GroupsViewSet(
     permission_classes = (permissions.IsAdminUser,)
     filter_backends = (filters.SearchFilter,)
     search_fields = ("name",)
+    lookup_field = "name"
 
     def get_serializer_class(self):
         serializer_class = self.serializer_class


### PR DESCRIPTION
## Background

We experienced a miscommunication on what some routes should return and how the API should be used on the frontend with the new management rework. After updating a group, user or a dataset, we could only re-retrieve the user, but not the group or dataset. The groups API supports retrieving, but it requires the group ID, which is not exposed anywhere in the API.

## Aim

Add retrieve support for datasets and groups.

## Implementation

Groups API was changed to use the group name for retrieval, datasets had a new route implemented that allows a client to retrieve the dataset permissions info for a specific dataset.

Closes #336 
Closes #337