### PR TITLE
Enrichment tool not receiving the right arguments fix

### DIFF
--- a/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
+++ b/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
@@ -192,6 +192,26 @@ def test_enrichment_test_gene_symbols(admin_client):
     assert result["result"][1]["synonymous"]["female"]["count"] == 1
 
 
+def test_enrichment_test_gene_scores(admin_client, wdae_gpf_instance):
+    url = "/api/v3/enrichment/test"
+    query = {
+        "datasetId": "f1_trio",
+        "enrichmentBackgroundModel": "coding_len_background_model",
+        "enrichmentCountingModel": "enrichment_gene_counting",
+        "geneScores": {
+            "score": "LGD_rank",
+            "rangeStart": 1,
+            "rangeEnd": 1000
+        },
+    }
+    response = admin_client.post(
+        url, json.dumps(query), content_type="application/json", format="json"
+    )
+
+    assert response
+    assert response.status_code == 200
+
+
 def test_enrichment_test_gene_set(admin_client, wdae_gpf_instance):
     url = "/api/v3/enrichment/test"
     query = {

--- a/wdae/wdae/enrichment_api/views.py
+++ b/wdae/wdae/enrichment_api/views.py
@@ -128,8 +128,8 @@ class EnrichmentTestView(QueryDatasetView):
                     gene_score_id
                 )
                 gene_syms = gene_score.get_genes(
-                    wmin=range_start,
-                    wmax=range_end
+                    score_min=range_start,
+                    score_max=range_end
                 )
             else:
                 return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Due to recent linting, some arguments have been changed. This prevents the function call to receive the right arguments and this creates an error in the gpfjs enrichment tool table.