### PR TITLE
Variant reports download fix

### DIFF
--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -89,11 +89,9 @@ def test_family_counters(admin_client):
 
 def test_family_counters_download(admin_client):
     data = {
-        "queryData": json.dumps({
-            "study_id": "study4",
-            "group_name": "Phenotype",
-            "counter_id": "0"
-        })
+        "study_id": "study4",
+        "group_name": "Phenotype",
+        "counter_id": "0"
     }
     url = "/api/v3/common_reports/family_counters/download"
     response = admin_client.post(

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -73,7 +73,7 @@ class FamilyCounterListView(QueryDatasetView):
 
 class FamilyCounterDownloadView(QueryDatasetView):
     def post(self, request):
-        data = json.loads(request.data["queryData"])
+        data = request.data
 
         study_id = data["study_id"]
         group_name = data["group_name"]

--- a/wdae/wdae/reset_dev.sh
+++ b/wdae/wdae/reset_dev.sh
@@ -12,3 +12,4 @@ rm -rf $DAE_DB_DIR/wdae/wdae_django_default.cache
 wdaemanage.py migrate
 $SCRIPTPATH/wdae_create_dev_users.sh
 $SCRIPTPATH/wdae_create_dev_gpfjs_app.sh
+$SCRIPTPATH/wdae_create_dev_federation_app.sh


### PR DESCRIPTION
## Background

Family counters download follows the old type of requests that parse JSON which is unnecessary and outdated.

## Aim

The aim is to follow the consistency of the other download requests. This is also backed up by a small change in the gpfjs method of making requests.

## Implementation

The implementation is to remove the unneeded JSON logic, change the test in order to follow the new logic, and also a new call has been added in the reset_dev.sh script in case the setup doesn't call wdae_create_dev_federation_app, which prevents testing
