### PR TITLE
Fix usage of index for configuring columns in GenomicPositionTables

### DIFF
--- a/dae/dae/genomic_resources/genomic_position_table/table_tabix.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table_tabix.py
@@ -239,7 +239,7 @@ class TabixGenomicPositionTable(GenomicPositionTable):
                     zip(other_columns, (raw[i] for i in other_indices))
                 )
             else:
-                attributes = {str(idx): value for idx, value in enumerate(raw)
+                attributes = {idx: value for idx, value in enumerate(raw)
                               if idx not in (self.chrom_column_i,
                                              self.pos_begin_column_i,
                                              self.pos_end_column_i)}

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -136,7 +136,7 @@ class GenomicScore(GenomicResourceImplementation):
             col_type = score_conf.get(
                 "type", config.get("default.score.type", "float"))
 
-            col_key = score_conf.get("name") or str(score_conf["index"])
+            col_key = score_conf.get("name") or score_conf["index"]
 
             col_def = ScoreDef(
                 col_key,


### PR DESCRIPTION
Would stringify the index from the configuration, while the internal
functions for getting a column's index would return an int, resulting in
KeyErrors when looking up the attribute dict