### PR TITLE
Kubernetes bug fixes

### DIFF
--- a/dae/dae/dask/client_factory.py
+++ b/dae/dae/dask/client_factory.py
@@ -71,12 +71,10 @@ class DaskClient:
                 "dashboard_address":
                 f":{kwargs.get('dashboard_port', 8787)}"
             }
-        if kwargs.get("log_dir"):
-            log_dir = kwargs.get("log_dir")
-        else:
-            # pylint: disable=consider-using-with
-            tmp_dir = tempfile.TemporaryDirectory()
-            log_dir = tmp_dir.name
+
+        # pylint: disable=consider-using-with
+        tmp_dir = tempfile.TemporaryDirectory()
+        log_dir = kwargs.get("log_dir", tmp_dir.name)
 
         if kwargs.get("kubernetes"):
             env = cls._get_env_vars(kwargs.get("envvars"))

--- a/dae/dae/dask/client_factory.py
+++ b/dae/dae/dask/client_factory.py
@@ -8,7 +8,8 @@ import tempfile
 from typing import Optional, Dict, Any
 
 from dask.distributed import Client, LocalCluster  # type: ignore
-from dask_kubernetes import KubeCluster, make_pod_spec  # type: ignore
+from dask_kubernetes import make_pod_spec  # type: ignore
+from dask_kubernetes.classic import KubeCluster  # type: ignore
 
 
 class DaskClient:

--- a/dae/dae/dask/client_factory.py
+++ b/dae/dae/dask/client_factory.py
@@ -32,8 +32,8 @@ class DaskClient:
             "kubernetes workers")
         group.add_argument(
             "--container-image",
-            default="registry.seqpipe.org/seqpipe-gpf:"
-            "dask-for-hist-compute_fc69179-14",
+            default="registry.seqpipe.org/iossifovlab-gpf:"
+            "master",
             help="Docker image to use when submitting "
             "jobs to kubernetes")
         group.add_argument(

--- a/dae/dae/dask/tests/test_client_factory.py
+++ b/dae/dae/dask/tests/test_client_factory.py
@@ -1,0 +1,13 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+from dae.dask.client_factory import DaskClient
+
+
+def test_from_dict_with_log_dir(tmpdir):
+    args = {
+        "jobs": 1,  # speeds up the test
+        "log_dir": str(tmpdir)
+    }
+
+    client = DaskClient.from_dict(args)
+    assert client is not None
+    client.__exit__()

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import logging
 from abc import abstractmethod, ABC
@@ -109,7 +108,7 @@ class ImportProject():
         :param import_filename: Path to the config file
         :param gpf_instance: Gpf Instance to use.
         """
-        base_input_dir = os.path.dirname(os.path.realpath(import_filename))
+        base_input_dir = fs_utils.containing_path(import_filename)
         import_config = GPFConfigParser.parse_and_interpolate_file(
             import_filename)
         project = ImportProject.build_from_config(
@@ -584,7 +583,7 @@ class ImportConfigNormalizer:
             sub_config = GPFConfigParser.validate_config(
                 sub_config, schema
             )
-            base_input_dir = os.path.dirname(os.path.realpath(external_fn))
+            base_input_dir = fs_utils.containing_path(external_fn)
         config[section_key] = sub_config
         return base_input_dir
 

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -66,6 +66,9 @@ class ImportProject():
         It is best not to call this ctor directly but to use one of the
         provided build_* methods.
         :param import_config: The parsed, validated and normalized config.
+        :param gpf_instance: Allow overwiting the gpf instance as described in
+        the configuration and instead injecting our own instance. Ideal for
+        testing.
         """
         self.import_config = import_config
         if "denovo" in import_config["input"]:
@@ -259,19 +262,19 @@ class ImportProject():
 
     def get_gpf_instance(self):
         """Create and return a gpf instance as desribed in the config."""
-        if self._gpf_instance is None:
-            instance_config = self.import_config.get("gpf_instance", {})
-            # pylint: disable=import-outside-toplevel
-            from dae.gpf_instance.gpf_instance import GPFInstance
-            instance_dir = instance_config.get("path")
-            if instance_dir is None:
-                config_filename = None
-            else:
-                config_filename = fs_utils.join(
-                    instance_dir, "gpf_instance.yaml")
-            self._gpf_instance = \
-                GPFInstance.build(config_filename)
-        return self._gpf_instance
+        if self._gpf_instance:
+            return self._gpf_instance
+
+        instance_config = self.import_config.get("gpf_instance", {})
+        # pylint: disable=import-outside-toplevel
+        from dae.gpf_instance.gpf_instance import GPFInstance
+        instance_dir = instance_config.get("path")
+        if instance_dir is None:
+            config_filename = None
+        else:
+            config_filename = fs_utils.join(
+                instance_dir, "gpf_instance.yaml")
+        return GPFInstance.build(config_filename)
 
     def get_import_storage(self):
         """Create an import storage as described in the import config."""

--- a/dae/dae/import_tools/tests/test_cli.py
+++ b/dae/dae/import_tools/tests/test_cli.py
@@ -35,3 +35,5 @@ def test_list(simple_study_dir):
     cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
     cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
     cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
+    cli.main([str(simple_study_dir / "import_config.yaml"), "list",
+              "--verbose"])

--- a/dae/dae/import_tools/tests/test_import_project.py
+++ b/dae/dae/import_tools/tests/test_import_project.py
@@ -17,6 +17,15 @@ def test_import_project_is_cpickle_serializable(fixture_dirname):
     _ = cloudpickle.dumps(project)
 
 
+def test_project_is_serializable_after_loader_reference_genome(resources_dir):
+    config_fn = str(resources_dir / "vcf_import" / "import_config.yaml")
+    project = ImportProject.build_from_file(config_fn)
+    assert project.get_gpf_instance().reference_genome is not None
+    pickled = cloudpickle.dumps(project)
+    unpickled_project = cloudpickle.loads(pickled)
+    assert unpickled_project.get_gpf_instance().reference_genome is not None
+
+
 def test_config_filenames_just_one_config(resources_dir):
     config_fn = str(resources_dir / "vcf_import" / "import_config.yaml")
     project = ImportProject.build_from_file(config_fn)

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -47,3 +47,19 @@ def modified(filename: str) -> datetime.datetime:
     """Return the modified timestamp of a file."""
     fs, relative_path = url_to_fs(filename)
     return cast(datetime.datetime, fs.modified(relative_path))
+
+
+def containing_path(path: Union[str, os.PathLike]) -> str:
+    """Return url to the resource that contains path.
+
+    For file paths this is equivalent to the containing directory.
+    For urls this is equivalent to the containing resource.
+    """
+    if not path:
+        return str(path)
+    url = urlparse(str(path))
+    if url.scheme:
+        if url.path:
+            return os.path.dirname(path)
+        return url.scheme + "://"
+    return os.path.dirname(os.path.realpath(path))

--- a/dae/dae/utils/tests/test_fs_utils.py
+++ b/dae/dae/utils/tests/test_fs_utils.py
@@ -1,5 +1,7 @@
-from dae.utils import fs_utils
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
 import pytest
+from dae.utils import fs_utils
 
 
 @pytest.mark.parametrize("segments, expected", [
@@ -11,3 +13,19 @@ import pytest
 ])
 def test_join(segments, expected):
     assert fs_utils.join(*segments) == expected
+
+
+@pytest.mark.parametrize("url, expected", [
+    ("/filename", "/"),
+    ("/dir/filename", "/dir"),
+    ("file:///dir/filename", "file:///dir"),
+    ("s3://bucket", "s3://"),
+    ("s3://bucket/dir/filename", "s3://bucket/dir"),
+    ("file", None),  # None signifies cwd
+    ("", ""),
+    ("/", "/"),
+    ("s3://", "s3://"),
+])
+def test_containing_path(url, expected):
+    expected = expected if expected is not None else os.getcwd()
+    assert fs_utils.containing_path(url) == expected

--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - jinja2=3.1.2
   - snakemake-minimal=7.18.2
   - ijson=3.1.4
-  - dask=2022.7.1
-  - dask-kubernetes=2022.7.0
+  - dask=2022.12.0
+  - dask-kubernetes=2022.12.0
   - tqdm=4.64.0
   - markdown2=2.4.0


### PR DESCRIPTION
## Background

Minor bug fixes to our integration with kubernetes.

## Implementation

The only major change is making the `_gpf_instance` in `ImportProject` transient to pickle. The gpf instance contains references to a whole bunch of objects some of which may not be pickleable. We tried making these objects pickleable but that required a lot of changes and there was always some edge-case we didn't cover. Making the gpf instance transient allows us to pickle the project without worrying about the gpf instance. The gpf instance will be automatically recreated when the import project is deserialized.
