### PR TITLE
Annotation pipeline internal attributes should be removed from the annotation result

### DIFF
--- a/dae/dae/annotation/annotation_pipeline.py
+++ b/dae/dae/annotation/annotation_pipeline.py
@@ -51,11 +51,11 @@ class AnnotationPipeline:
             context.update(attributes)
 
         # TODO: Decide where context should be cleaned up
-        # for annotator in self.annotators:
-        #     for attr in annotator.get_annotation_config():
-        #         if attr.get("internal", False):
-        #             key = attr["destination"]
-        #             del context[key]
+        for annotator in self.annotators:
+            for attr in annotator.get_annotation_config():
+                if attr.get("internal", False):
+                    key = attr["destination"]
+                    del context[key]
 
         return context
 

--- a/dae/dae/annotation/tests/test_normalize_variant.py
+++ b/dae/dae/annotation/tests/test_normalize_variant.py
@@ -149,6 +149,10 @@ def test_normalize_allele_annotator_pipeline(grr_fixture, pos, ref, alt):
     config = textwrap.dedent("""
         - normalize_allele_annotator:
             genome: hg19/GATK_ResourceBundle_5777_b37_phiX174_short/genome
+            attributes:
+            - source: normalized_allele
+              dest: normalized_allele
+              internal: False
         """)
 
     annotation_pipeline = build_annotation_pipeline(
@@ -184,6 +188,10 @@ def test_normalize_tandem_repeats(pos, ref, alt, npos, nref, nalt):
     config = textwrap.dedent("""
         - normalize_allele_annotator:
             genome: hg38/genomes/GRCh38-hg38
+            attributes:
+            - source: normalized_allele
+              dest: normalized_allele
+              internal: False
         """)
 
     annotation_pipeline = build_annotation_pipeline(

--- a/dae/dae/tools/tests/test_vcf2parquet.py
+++ b/dae/dae/tools/tests/test_vcf2parquet.py
@@ -8,7 +8,7 @@ from dae.tools.vcf2parquet import main
 
 def test_vcf2parquet_vcf(
     fixture_dirname,
-    annotation_pipeline_config,
+    annotation_pipeline_no_effects_config,
     annotation_scores_dirname,
     temp_filename,
     gpf_instance_2013,
@@ -18,7 +18,7 @@ def test_vcf2parquet_vcf(
     argv = [
         "--rows", "10",
         "--annotation",
-        annotation_pipeline_config,
+        annotation_pipeline_no_effects_config,
         "-o",
         temp_filename,
         f"{prefix}.ped",
@@ -48,7 +48,7 @@ def test_vcf2parquet_vcf(
 
 def test_vcf2parquet_vcf_partition(
     fixture_dirname,
-    annotation_pipeline_config,
+    annotation_pipeline_no_effects_config,
     annotation_scores_dirname,
     temp_dirname,
     gpf_instance_2013,
@@ -62,7 +62,7 @@ def test_vcf2parquet_vcf_partition(
     argv = [
         "--rows", "10",
         "--annotation",
-        annotation_pipeline_config,
+        annotation_pipeline_no_effects_config,
         "-o",
         temp_dirname,
         "--pd",

--- a/dae_conftests/dae_conftests/dae_conftests.py
+++ b/dae_conftests/dae_conftests/dae_conftests.py
@@ -339,6 +339,13 @@ def annotation_pipeline_config():
 
 
 @pytest.fixture(scope="session")
+def annotation_pipeline_no_effects_config():
+    filename = relative_to_this_test_folder(
+        "fixtures/annotation_pipeline/import_annotation_no_effects.yaml")
+    return filename
+
+
+@pytest.fixture(scope="session")
 def annotation_pipeline_default_config(default_dae_config):
     return default_dae_config.annotation.conf_file
 

--- a/dae_conftests/dae_conftests/tests/fixtures/annotation_pipeline/import_annotation.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/annotation_pipeline/import_annotation.yaml
@@ -5,7 +5,7 @@
     attributes:
     - source: allele_effects
       destination: allele_effects
-      internal: true
+      internal: false
 
 
 - position_score: hg19/internal/scores1

--- a/dae_conftests/dae_conftests/tests/fixtures/annotation_pipeline/import_annotation_no_effects.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/annotation_pipeline/import_annotation_no_effects.yaml
@@ -1,0 +1,13 @@
+
+# - effect_annotator:
+#     genome: "hg19/genomes/GATK_ResourceBundle_5777_b37_phiX174"
+#     gene_models: "hg19/gene_models/refGene_v201309"
+#     attributes:
+#     - source: allele_effects
+#       destination: allele_effects
+#       internal: false
+
+
+- position_score: hg19/internal/scores1
+
+- position_score: hg19/internal/scores_incomplete_coverage


### PR DESCRIPTION
Tests are adjusted with this change.

## Background

When we use LiftoverAnnotator and NormalizeAlleleAnnotator, they produce VCFAllele attributes marked as internal.

## Aim

Internal annotation attributes should not be part of the annotation pipeline result.

## Implementation

I restored the code that filters internal attributes from the annotation pipeline result. Some tests needed some adjustment.

## Related issues

Closes #358.