### PR TITLE
Add file locking when caching filesystem genomic resource

### DIFF
--- a/dae/dae/genomic_resources/tests/test_line_buffer.py
+++ b/dae/dae/genomic_resources/tests/test_line_buffer.py
@@ -37,7 +37,7 @@ def test_line_buffer_simple_2():
 ])
 def test_line_buffer_prune(pos, expected):
     buffer = LineBuffer()
-    buffer.PRUNE_CUTOFF = 0  # pylint: disable=C0103
+    buffer.PRUNE_CUTOFF = 0  # pylint: disable=invalid-name
 
     buffer.append(Line("1", 2, 2, {}, {}))
     buffer.append(Line("1", 4, 4, {}, {}))


### PR DESCRIPTION
## Background

When caching a resource, problems would occur when another process would try to cache the same resource, leading to the resource's files being overwritten with invalid data. 

## Aim

Lock genomic resources' files if they are currently being written to, and release the lock when the file has been cached.

## Implementation

The current implementation has been done only for filesystem repositories, S3 repositories do not have locking. Locking has been implemented by creating a .lockfile for the genomic resource file being cached, and placing a lock on it using the `fcntl` module. The lock is obtained in CachingProtocol before the `update_resource_file` method is called, and automatically released after that method finishes.

## Related issues

Closes #335