### PR TITLE
Import kubernetes support

### DIFF
--- a/dae/dae/dask/client_factory.py
+++ b/dae/dae/dask/client_factory.py
@@ -33,8 +33,7 @@ class DaskClient:
             "kubernetes workers")
         group.add_argument(
             "--container-image",
-            default="registry.seqpipe.org/iossifovlab-gpf:"
-            "master",
+            default="registry.seqpipe.org/iossifovlab-gpf:latest",
             help="Docker image to use when submitting "
             "jobs to kubernetes")
         group.add_argument(
@@ -100,15 +99,16 @@ class DaskClient:
                       file=sys.stderr)
                 return None
 
-            cluster = SGECluster(n_workers=n_jobs,
-                                 queue="all.q",
+            cluster = SGECluster(queue="all.q",
                                  walltime="1500000",
                                  cores=1,
                                  processes=1,
-                                 memory="2GB",
+                                 memory="7GB",
+                                 resource_spec="h_rss=7G",
                                  log_directory=log_dir,
                                  local_directory=tmp_dir.name,
                                  **dashboard_config)
+            cluster.adapt(minimum=1, maximum=n_jobs)
         else:
             cluster = LocalCluster(n_workers=n_jobs, threads_per_worker=1,
                                    local_directory=tmp_dir.name,

--- a/dae/dae/impala_storage/helpers/hdfs_helpers.py
+++ b/dae/dae/impala_storage/helpers/hdfs_helpers.py
@@ -87,7 +87,7 @@ class HdfsHelpers:
         self.hdfs.rename(path, new_path)
 
     def put(self, local_filename, hdfs_filename):
-        assert os.path.exists(local_filename)
+        assert os.path.exists(local_filename), local_filename
 
         self.hdfs.upload(local_filename, hdfs_filename)
 

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -77,7 +77,9 @@ def _cmd_run(args, project, task_cache):
 
 def _cmd_list(args, project, task_cache):
     storage = project.get_import_storage()
+    print("Generating Task Graph ...", end="")
     task_graph = storage.generate_import_task_graph(project)
+    print("Done")
     task_graph.input_files.extend(project.config_filenames)
     task_graph = _prune_tasks(task_graph, args.task_ids or [])
 

--- a/dae/dae/parquet/helpers.py
+++ b/dae/dae/parquet/helpers.py
@@ -1,0 +1,33 @@
+from typing import Any
+from urllib.parse import urlparse
+from fsspec.core import url_to_fs
+import pyarrow as pa
+
+
+def url_to_pyarrow_fs(filename: str, filesystem: Any = None):
+    """Turn URL into pyarrow filesystem instance.
+
+    Parameters
+    ----------
+    filename : str
+        The fsspec-compatible URL
+    filesystem : fsspec.FileSystem
+        An fsspec filesystem for ``filename``.
+
+    Returns
+    -------
+    filesystem : pyarrow.fs.FileSystem
+        The new filesystem discovered from ``filename`` and ``filesystem``.
+    """
+    if isinstance(filesystem, pa.fs.FileSystem):
+        return filesystem, filename
+
+    if filesystem is None:
+        if urlparse(filename).scheme:
+            fsspec_fs, path = url_to_fs(filename)
+            pa_fs = pa.fs.PyFileSystem(pa.fs.FSSpecHandler(fsspec_fs))
+            return pa_fs, path
+        return None, filename
+
+    pa_fs = pa.fs.PyFileSystem(pa.fs.FSSpecHandler(filesystem))
+    return pa_fs, filename

--- a/dae/dae/parquet/schema1/parquet_io.py
+++ b/dae/dae/parquet/schema1/parquet_io.py
@@ -23,6 +23,7 @@ import pyarrow.parquet as pq
 
 import fsspec
 
+from dae.parquet.helpers import url_to_pyarrow_fs
 from dae.utils.variant_utils import GenotypeType
 from dae.variants.attributes import TransmissionType
 from dae.variants.family_variant import FamilyAllele, FamilyVariant, \
@@ -419,6 +420,7 @@ class ContinuousParquetFileWriter:
                 os.makedirs(dirname)
             self.dirname = dirname
 
+        filesystem, filepath = url_to_pyarrow_fs(filepath, filesystem)
         self._writer = pq.ParquetWriter(
             filepath, self.schema, compression="snappy", filesystem=filesystem,
             version="1.0"
@@ -837,4 +839,5 @@ def save_ped_df_to_parquet(ped_df, filename, filesystem=None):
 
     table = pa.Table.from_pandas(ped_df, schema=pps)
 
+    filesystem, filename = url_to_pyarrow_fs(filename, filesystem)
     pq.write_table(table, filename, filesystem=filesystem, version="1.0")

--- a/dae/dae/parquet/tests/test_parquet_helpers.py
+++ b/dae/dae/parquet/tests/test_parquet_helpers.py
@@ -1,0 +1,16 @@
+import pyarrow as pa
+from dae.parquet.helpers import url_to_pyarrow_fs
+
+
+def test_url_to_pyarrow_fs():
+    filename = "path/to/some/file.txt"
+    fs, path = url_to_pyarrow_fs(filename)
+    assert fs is None
+    assert path == filename
+
+
+def test_url_to_pyarrow_fs_s3_url():
+    filename = "s3://bucket/file.txt"
+    fs, path = url_to_pyarrow_fs(filename)
+    assert isinstance(fs, pa.fs.PyFileSystem)
+    assert path == "bucket/file.txt"

--- a/dae/dae/task_graph/tests/test_cache.py
+++ b/dae/dae/task_graph/tests/test_cache.py
@@ -117,6 +117,15 @@ def test_file_cache_mod_flag_file_of_intermediate_node(
         assert cache.get_record(task).type == CacheRecordType.NEEDS_COMPUTE
 
 
+def test_file_cache_very_large_task_name(tmpdir):
+    graph = TaskGraph()
+    graph.create_task("Task" * 500, noop, [], [])
+
+    executor = SequentialExecutor(FileTaskCache(cache_dir=tmpdir))
+    for _ in executor.execute(graph):
+        pass
+
+
 def touch(filename):
     if os.path.exists(filename):
         # fsspec local file system has a resolution of 1 second so we have to

--- a/dae/dae/variants_loaders/vcf/loader.py
+++ b/dae/dae/variants_loaders/vcf/loader.py
@@ -270,8 +270,13 @@ class SingleVcfLoader(VariantsGenotypesLoader):
         logger.debug("SingleVcfLoader input files: %s", self.filenames)
 
         for file in self.filenames:
+            # pylint: disable=no-member
             self.vcfs.append(
-                pysam.VariantFile(file))  # pylint: disable=no-member
+                pysam.VariantFile(
+                    fs_utils.sign(file),
+                    index_filename=fs_utils.sign(file + ".tbi")
+                )
+            )
 
     def _build_vcf_iterators(self, region):
         if region is None:
@@ -310,7 +315,11 @@ class SingleVcfLoader(VariantsGenotypesLoader):
             res = seqnames
 
         try:
-            with pysam.Tabixfile(filename) as tbx:  # pylint: disable=no-member
+            # pylint: disable=no-member
+            with pysam.Tabixfile(
+                fs_utils.sign(filename),
+                index=fs_utils.sing(tabix_index_filename)
+            ) as tbx:
                 res = list(tbx.contigs)
         except Exception:  # pylint: disable=broad-except
             res = seqnames

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ channels:
 dependencies:
   - python=3.9.12
   - importlib_metadata=4.11.3
-  - pysam=0.19.1
+  - pysam=0.20.0
   - samtools=1.15.1
   - htslib=1.15.1
   - impyla=0.17.0


### PR DESCRIPTION
## Background

Import works with k8s but not with k8s and non-standard s3 endpoint urls

## Aim

Provide support for non-standard s3 endpoints when importing

## Implementation

When it comes to supporting non standard s3 (i.e. ceph) there are 3 relevant apis:

    1. pysam - which uses it's own implementation. Arguments can be passed
       to that implementation using env variables. Unfortunatelly not all
       required argumentes can be passed. Specifically the aws endpoint
       cannot be propagaed to the necessary code. To circumvent this
       limitation we sign the s3 urls before passing them to pysam. The
       sigining transforms them into http urls with the endpoint and
       credentials all embedded into the url so pysam can just make a
       http get.

    2. fsspec - which has its own api to configure non standard s3

    3. pyarrow - also has its own api. But fortunatelly fsspec filesystems
       can be wrapped and given to pyarrow.

    So in the end we configure just fsspec. For pysam we use signed urls.
    For pyarrow we wrap fsspec filesystem objects.

The s3 endpoint itself is configured using the S3_ENDPOINT_URL environment variable. This is a temporary solution and will probably be removed in the future and replaced by a line in a config file.
