### PR TITLE
Ensure that GPF instance `dae_dir` is handled by import project serialization and deserialization

### DIFF
--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -80,10 +80,10 @@ class GPFInstance:
             dae_config,
             dae_dir,
             **kwargs):
+        assert dae_dir is not None
 
         self.dae_config = dae_config
         self.dae_dir = str(dae_dir)
-        assert self.dae_dir is not None
 
         self._grr = kwargs.get("grr")
         self._reference_genome = kwargs.get("reference_genome")

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -430,9 +430,9 @@ class ImportProject():
         if target_chromosomes is None:
             target_chromosomes = loader_chromosomes
 
-        # cannot use self.get_partition_description() here as the processing
-        # region length might be different than the region length specified in
-        # the parition description section of the import config
+        # cannot use self.get_partition_description() here as the
+        # processing region length might be different than the region length
+        # specified in the parition description section of the import config
         partition_description = ParquetPartitionDescriptor(
             target_chromosomes,
             self._get_processing_region_length(loader_type),
@@ -541,6 +541,7 @@ class ImportProject():
         state = self.__dict__.copy()
         del state["_gpf_instance"]
         state["_gpf_dae_config"] = gpf_instance.dae_config
+        state["_gpf_dae_dir"] = gpf_instance.dae_dir
         return state
 
     def __setstate__(self, state):
@@ -548,7 +549,8 @@ class ImportProject():
         self.__dict__.update(state)
         # pylint: disable=import-outside-toplevel
         from dae.gpf_instance.gpf_instance import GPFInstance
-        self._gpf_instance = GPFInstance(state["_gpf_dae_config"], None)
+        self._gpf_instance = GPFInstance(
+            state["_gpf_dae_config"], state["_gpf_dae_dir"])
 
 
 class ImportConfigNormalizer:


### PR DESCRIPTION
## Background

While running `import_tools` following the GPF Getting Started Guide a bug was found as described in #361. The problem boils down to improper serialization and deserialization of GPF instance configuration directory.

## Aim

Fix the issue with handling of GPF instance configuration directory.

## Implementation

The GPF instance `dae_dir` field is stored in the state and used when deserializing the instance. A tests to check the serialization was added.

## Related issues

Closes #361 