### PR TITLE
Command line interface helpers for executing task graphs.

### DIFF
--- a/dae/dae/dask/__init__.py
+++ b/dae/dae/dask/__init__.py
@@ -1,0 +1,1 @@
+from . import config

--- a/dae/dae/dask/__init__.py
+++ b/dae/dae/dask/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa: F401
 from . import config

--- a/dae/dae/dask/__init__.py
+++ b/dae/dae/dask/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa: F401
-from . import config
+from dae.dask import config

--- a/dae/dae/dask/config.py
+++ b/dae/dae/dask/config.py
@@ -5,11 +5,12 @@ import yaml
 
 
 def reconfigure():
-    fn = os.path.join(os.path.dirname(__file__), "named_cluster.yaml")
-    dask.config.ensure_file(source=fn)
+    """Load default config into dask."""
+    filename = os.path.join(os.path.dirname(__file__), "named_cluster.yaml")
+    dask.config.ensure_file(source=filename)
 
-    with open(fn) as f:
-        defaults = yaml.safe_load(f)
+    with open(filename) as file:
+        defaults = yaml.safe_load(file)
 
     dask.config.update_defaults(defaults)
 

--- a/dae/dae/dask/config.py
+++ b/dae/dae/dask/config.py
@@ -1,0 +1,17 @@
+import os
+
+import dask
+import yaml
+
+
+def reconfigure():
+    fn = os.path.join(os.path.dirname(__file__), "named_cluster.yaml")
+    dask.config.ensure_file(source=fn)
+
+    with open(fn) as f:
+        defaults = yaml.safe_load(f)
+
+    dask.config.update_defaults(defaults)
+
+
+reconfigure()

--- a/dae/dae/dask/named_cluster.py
+++ b/dae/dae/dask/named_cluster.py
@@ -5,43 +5,34 @@ import dask
 _CLUSTER_TYPES = {}
 
 
-def set_up_local_cluster(cluster_conf, number_of_threads):
+def set_up_local_cluster(cluster_conf):
     from distributed.deploy.local import LocalCluster
-    cluster = LocalCluster(**cluster_conf)
-    if number_of_threads is not None:
-        cluster.scale(cores=number_of_threads)
-    return cluster
+    return LocalCluster(**cluster_conf)
 
-def set_up_sge_cluster(cluster_conf, number_of_threads):
+
+def set_up_sge_cluster(cluster_conf):
     from dask_jobqueue import SGECluster
 
-    cluster = SGECluster(**cluster_conf)
-    if number_of_threads is not None:
-        cluster.scale(cores=number_of_threads)
-    return cluster
+    return SGECluster(**cluster_conf)
 
-def set_up_slurm_cluster(cluster_conf, number_of_threads):
+
+def set_up_slurm_cluster(cluster_conf):
     from dask_jobqueue import SLURMCluster
+    return SLURMCluster(**cluster_conf)
 
-    cluster = SLURMCluster(**cluster_conf)
-    if number_of_threads is not None:
-        cluster.scale(cores=number_of_threads)
-    return cluster
 
-def set_up_kubernetes_cluster(cluster_conf, number_of_threads):
+def set_up_kubernetes_cluster(cluster_conf):
     from dask_kubernetes import KubeCluster, make_pod_spec
     import os
 
     env = {}
     if 'envvars' in cluster_conf:
-        env = {v:os.environ[v] for v in cluster_conf['envvars']}
-    
+        env = {v: os.environ[v] for v in cluster_conf['envvars']}
+
     pod_spec = make_pod_spec(
-                image=cluster_conf["container_image"],
-                extra_pod_config=cluster_conf.get("extra_pod_config",{}))
+        image=cluster_conf["container_image"],
+        extra_pod_config=cluster_conf.get("extra_pod_config", {}))
     cluster = KubeCluster(pod_spec, env=env)
-    if number_of_threads is not None:
-        cluster.scale(cores=number_of_threads)
     return cluster
 
 
@@ -51,18 +42,27 @@ _CLUSTER_TYPES["slurm"] = set_up_slurm_cluster
 _CLUSTER_TYPES["kubernetes"] = set_up_kubernetes_cluster
 
 
-
 def setup_client_from_config(cluster_config,
-                 number_of_threads: Optional[int] = None) \
+                             number_of_threads_param: Optional[int] = None) \
         -> Tuple[Client, Dict[str, Any]]:
 
     print("CLUSTER CONFIG:", cluster_config)
     cluster_type = cluster_config["type"]
 
-    cluster_params = cluster_config.get("params",{})
-    cluster = _CLUSTER_TYPES[cluster_type](cluster_params, number_of_threads)
+    cluster_params = cluster_config.get("params", {})
+    cluster = _CLUSTER_TYPES[cluster_type](cluster_params)
+
+    number_of_threads = cluster_config.get("number_of_threads", None)
+    if number_of_threads_param is not None:
+        number_of_threads = number_of_threads_param
+    if number_of_threads is not None:
+        cluster.scale(n=number_of_threads)
+    elif "adapt_params" in cluster_config:
+        cluster.adapt(**cluster_config["adapt_params"])
+
     client = Client(cluster)
     return client, cluster_config
+
 
 def setup_client(cluster_name: Optional[str] = None,
                  number_of_threads: Optional[int] = None) \

--- a/dae/dae/dask/named_cluster.py
+++ b/dae/dae/dask/named_cluster.py
@@ -20,9 +20,35 @@ def set_up_sge_cluster(cluster_conf, number_of_threads):
         cluster.scale(cores=number_of_threads)
     return cluster
 
+def set_up_slurm_cluster(cluster_conf, number_of_threads):
+    from dask_jobqueue import SLURMCluster
+
+    cluster = SLURMCluster(**cluster_conf)
+    if number_of_threads is not None:
+        cluster.scale(cores=number_of_threads)
+    return cluster
+
+def set_up_kubernetes_cluster(cluster_conf, number_of_threads):
+    from dask_kubernetes import KubeCluster, make_pod_spec
+    import os
+
+    env = {}
+    if 'envvars' in cluster_conf:
+        env = {v:os.environ[v] for v in cluster_conf['envvars']}
+    
+    pod_spec = make_pod_spec(
+                image=cluster_conf["container_image"],
+                extra_pod_config=cluster_conf.get("extra_pod_config",{}))
+    cluster = KubeCluster(pod_spec, env=env)
+    if number_of_threads is not None:
+        cluster.scale(cores=number_of_threads)
+    return cluster
+
 
 _CLUSTER_TYPES["local"] = set_up_local_cluster
 _CLUSTER_TYPES["sge"] = set_up_sge_cluster
+_CLUSTER_TYPES["slurm"] = set_up_slurm_cluster
+_CLUSTER_TYPES["kubernetes"] = set_up_kubernetes_cluster
 
 
 
@@ -30,10 +56,11 @@ def setup_client_from_config(cluster_config,
                  number_of_threads: Optional[int] = None) \
         -> Tuple[Client, Dict[str, Any]]:
 
+    print("CLUSTER CONFIG:", cluster_config)
     cluster_type = cluster_config["type"]
 
-    cluster = _CLUSTER_TYPES[cluster_type](
-        cluster_config["params"], number_of_threads)
+    cluster_params = cluster_config.get("params",{})
+    cluster = _CLUSTER_TYPES[cluster_type](cluster_params, number_of_threads)
     client = Client(cluster)
     return client, cluster_config
 

--- a/dae/dae/dask/named_cluster.py
+++ b/dae/dae/dask/named_cluster.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from distributed.client import Client
 import dask
 
@@ -12,23 +12,40 @@ def set_up_local_cluster(cluster_conf, number_of_threads):
         cluster.scale(cores=number_of_threads)
     return cluster
 
+def set_up_sge_cluster(cluster_conf, number_of_threads):
+    from dask_jobqueue import SGECluster
+
+    cluster = SGECluster(**cluster_conf)
+    if number_of_threads is not None:
+        cluster.scale(cores=number_of_threads)
+    return cluster
+
 
 _CLUSTER_TYPES["local"] = set_up_local_cluster
+_CLUSTER_TYPES["sge"] = set_up_sge_cluster
 
+
+
+def setup_client_from_config(cluster_config,
+                 number_of_threads: Optional[int] = None) \
+        -> Tuple[Client, Dict[str, Any]]:
+
+    cluster_type = cluster_config["type"]
+
+    cluster = _CLUSTER_TYPES[cluster_type](
+        cluster_config["params"], number_of_threads)
+    client = Client(cluster)
+    return client, cluster_config
 
 def setup_client(cluster_name: Optional[str] = None,
                  number_of_threads: Optional[int] = None) \
-        -> Tuple[Client, str, str]:
+        -> Tuple[Client, Dict[str, Any]]:
 
     if cluster_name is None:
         cluster_name = dask.config.get("dae_named_cluster.default")
 
-    cluster_config = dict(dask.config.get(
-        f"dae_named_cluster.clusters.{cluster_name}"))
-    cluster_type = cluster_config["type"]
-    del cluster_config['type']
+    clusters = {conf["name"]: conf
+                for conf in dask.config.get("dae_named_cluster.clusters")}
 
-    cluster = _CLUSTER_TYPES[cluster_type](
-        cluster_config, number_of_threads)
-    client = Client(cluster)
-    return client, cluster_name, cluster_type
+    cluster_config = clusters[cluster_name]
+    return setup_client_from_config(cluster_config, number_of_threads)

--- a/dae/dae/dask/named_cluster.py
+++ b/dae/dae/dask/named_cluster.py
@@ -1,0 +1,34 @@
+from typing import Optional, Tuple
+from distributed.client import Client
+import dask
+
+_CLUSTER_TYPES = {}
+
+
+def set_up_local_cluster(cluster_conf, number_of_threads):
+    from distributed.deploy.local import LocalCluster
+    cluster = LocalCluster(**cluster_conf)
+    if number_of_threads is not None:
+        cluster.scale(cores=number_of_threads)
+    return cluster
+
+
+_CLUSTER_TYPES["local"] = set_up_local_cluster
+
+
+def setup_client(cluster_name: Optional[str] = None,
+                 number_of_threads: Optional[int] = None) \
+        -> Tuple[Client, str, str]:
+
+    if cluster_name is None:
+        cluster_name = dask.config.get("dae_named_cluster.default")
+
+    cluster_config = dict(dask.config.get(
+        f"dae_named_cluster.clusters.{cluster_name}"))
+    cluster_type = cluster_config["type"]
+    del cluster_config['type']
+
+    cluster = _CLUSTER_TYPES[cluster_type](
+        cluster_config, number_of_threads)
+    client = Client(cluster)
+    return client, cluster_name, cluster_type

--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -39,13 +39,12 @@ dae_named_cluster:
     - name: kubernetes
       type: kubgernetes
       params:
-        container_image: xxxxx
-        extra_pod_config:
-          A: B
-          b: 234234
-        envvars: 
-          - PATH
-          - MY_ENV
+        container_image: registry.seqpipe.org/iossifovlab-gpf:latest
+        # extra_pod_config:
+        #   A: B
+        #   b: 234234
+        # envvars: 
+        #   - PATH
     - name: slurm
       type: slurm
       number_of_threads: 10

--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -1,5 +1,5 @@
 dae_named_cluster:
   default: default
   clusters:
-    default: 
+    - name: default 
       type: local

--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -1,18 +1,41 @@
 dae_named_cluster:
   default: local
   clusters:
-    - name: local 
+    - name: local
       type: local
-    - name: sge_quick 
+      # By default, the local cluster will allocate by default as many threads 
+      # as the number of cores on the host, spread accross several workers each
+      # with cerain number of threads.  See the documentation of LocalCluster
+      # for more information. 
+      # To set the default a number of threads we can set:
+      # number_of_threads: 10
+      #
+      # If present, the params will be provided to the LocalCluster 
+      # constructor. Some usefull params are given, but the LocalCluster 
+      # documentation provides the complete description.
+      # params:
+      #  threads_per_worker: 1
+      #   dashboard_address: :8898
+    - name: sge_small
       type: sge
+      number_of_threads: 10
       params:
+        scheduler_options:
+          dashboard_address: :8898
         cores: 1
         memory: 1GB
-    - name: slurm
-      type: slurm
+        log_directory: ./sge_worker_logs
+    - name: sge_large
+      type: sge
+      adapt_params:
+        minimum: 3
+        maximum: 200
       params:
+        scheduler_options:
+          dashboard_address: :8898
         cores: 1
-        memory: 1GB
+        memory: 10GB
+        log_directory: ./sge_worker_logs
     - name: kubernetes
       type: kubgernetes
       params:
@@ -23,5 +46,12 @@ dae_named_cluster:
         envvars: 
           - PATH
           - MY_ENV
+    - name: slurm
+      type: slurm
+      number_of_threads: 10
+      params:
+        cores: 1
+        memory: 1GB
+        log_directory: ./slurm_worker_logs
 
 

--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -1,5 +1,27 @@
 dae_named_cluster:
-  default: default
+  default: local
   clusters:
-    - name: default 
+    - name: local 
       type: local
+    - name: sge_quick 
+      type: sge
+      params:
+        cores: 1
+        memory: 1GB
+    - name: slurm
+      type: slurm
+      params:
+        cores: 1
+        memory: 1GB
+    - name: kubernetes
+      type: kubgernetes
+      params:
+        container_image: xxxxx
+        extra_pod_config:
+          A: B
+          b: 234234
+        envvars: 
+          - PATH
+          - MY_ENV
+
+

--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -1,0 +1,5 @@
+dae_named_cluster:
+  default: default
+  clusters:
+    default: 
+      type: local

--- a/dae/dae/dask/tests/test_named_cluster.py
+++ b/dae/dae/dask/tests/test_named_cluster.py
@@ -1,0 +1,14 @@
+from dae.dask.named_cluster import setup_client
+import dask.config as config
+
+
+def test_default():
+    client, _, _ = setup_client(number_of_threads=4)
+    print(client)
+    assert client
+
+
+def test_config_access():
+    with config.set({'dask.config.get': None}):
+        client, _, _ = setup_client()
+        assert client

--- a/dae/dae/dask/tests/test_named_cluster.py
+++ b/dae/dae/dask/tests/test_named_cluster.py
@@ -3,12 +3,12 @@ import dask.config as config
 
 
 def test_default():
-    client, _, _ = setup_client(number_of_threads=4)
+    client, _ = setup_client(number_of_threads=4)
     print(client)
     assert client
 
 
 def test_config_access():
     with config.set({'dask.config.get': None}):
-        client, _, _ = setup_client()
+        client, _ = setup_client()
         assert client

--- a/dae/dae/genomic_resources/tests/test_testing.py
+++ b/dae/dae/genomic_resources/tests/test_testing.py
@@ -221,13 +221,13 @@ def test_process_server_stop_failed():
 
 def test_s3_threaded_server_simple():
     with s3_threaded_test_server() as endpoint_url:
-        response = requests.get(endpoint_url, timeout=1.0)
+        response = requests.get(endpoint_url, timeout=10.0)
         assert response.status_code == 200
 
     with s3_threaded_test_server() as endpoint_url:
-        response = requests.get(endpoint_url, timeout=1.0)
+        response = requests.get(endpoint_url, timeout=10.0)
         assert response.status_code == 200
 
     with s3_threaded_test_server() as endpoint_url:
-        response = requests.get(endpoint_url, timeout=1.0)
+        response = requests.get(endpoint_url, timeout=10.0)
         assert response.status_code == 200

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -4,7 +4,7 @@ import sys
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.import_tools.import_tools import ImportProject
 
-from dae.task_graph.executor import SequentialExecutor
+from dae.task_graph.executor import SequentialExecutor, task_graph_run
 from dae.utils import fs_utils
 
 from dae.task_graph import TaskGraphCli
@@ -41,4 +41,4 @@ def run_with_project(project, executor=SequentialExecutor()):
     task_graph = storage.generate_import_task_graph(project)
     task_graph.input_files.extend(project.config_filenames)
 
-    return TaskGraphCli.run(task_graph, executor, keep_going=False)
+    return task_graph_run(task_graph, executor, keep_going=False)

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import textwrap
 import traceback
-from dae.dae.utils.verbosity_configuration import VerbosityConfiguration
+from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.import_tools.import_tools import ImportProject
 from dae.task_graph.cache import CacheRecordType, FileTaskCache
 
@@ -22,14 +22,16 @@ def main(argv=None):
     )
     parser.add_argument("config", type=str,
                         help="Path to the import configuration")
-    TaskGraphCli.add_arguments(parser)
+    TaskGraphCli.add_arguments(parser, default_task_status_dir=None)
     VerbosityConfiguration.set_argumnets(parser)
     args = parser.parse_args(argv or sys.argv[1:])
     VerbosityConfiguration.set(args)
-    
+
     project = ImportProject.build_from_file(args.config)
 
-    # task_cache = _create_task_cache(args, project)
+    if args.task_status_dir is None:
+        args.task_status_dir = fs_utils.join(
+            project.work_dir, ".task-progress", project.study_id)
 
     storage = project.get_import_storage()
     task_graph = storage.generate_import_task_graph(project)

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -33,7 +33,7 @@ def main(argv=None):
     task_graph = storage.generate_import_task_graph(project)
     task_graph.input_files.extend(project.config_filenames)
 
-    return TaskGraphCli.process_graph(task_graph, args)
+    return TaskGraphCli.process_graph(task_graph, **vars(args))
 
 
 def run_with_project(project, executor=SequentialExecutor()):

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -1,6 +1,5 @@
 import argparse
 import sys
-import textwrap
 import traceback
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.import_tools.import_tools import ImportProject
@@ -37,15 +36,7 @@ def main(argv=None):
     task_graph = storage.generate_import_task_graph(project)
     task_graph.input_files.extend(project.config_filenames)
 
-    TaskGraphCli.process_graph(args, task_graph)
-
-    # if args.command is None or args.command == "run":
-    #     return _cmd_run(args, project, task_cache)
-    # if args.command in {"list", "status"}:
-    #     return _cmd_list(args, project, task_cache)
-    # parser.exit(message=f"Unknown command {args.command}\n")
-
-    return 0
+    return TaskGraphCli.process_graph(args, task_graph)
 
 
 def _cmd_run(args, project, task_cache):

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -33,7 +33,7 @@ def main(argv=None):
     task_graph = storage.generate_import_task_graph(project)
     task_graph.input_files.extend(project.config_filenames)
 
-    return TaskGraphCli.process_graph(args, task_graph)
+    return TaskGraphCli.process_graph(task_graph, args)
 
 
 def run_with_project(project, executor=SequentialExecutor()):

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -1,7 +1,5 @@
 import argparse
 import sys
-import traceback
-from typing import Union
 
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.import_tools.import_tools import ImportProject

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -5,11 +5,8 @@ from typing import Union
 
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.import_tools.import_tools import ImportProject
-from dae.task_graph.cache import CacheRecordType, FileTaskCache
 
-from dae.task_graph.executor import \
-    DaskExecutor, SequentialExecutor
-from dae.dask.client_factory import DaskClient
+from dae.task_graph.executor import SequentialExecutor
 from dae.utils import fs_utils
 
 from dae.task_graph import TaskGraphCli
@@ -41,139 +38,9 @@ def main(argv=None):
     return TaskGraphCli.process_graph(args, task_graph)
 
 
-def _cmd_run(args, project, task_cache):
-    ids_to_run = args.task_ids or []
-    executor: Union[SequentialExecutor, DaskExecutor]
-    if args.jobs == 1:
-        executor = SequentialExecutor(task_cache=task_cache)
-        return run_with_project(
-            project, executor, ids_to_run=ids_to_run,
-            keep_going=args.keep_going
-        )
-
-    dask_client = DaskClient.from_arguments(args)
-    if dask_client is None:
-        sys.exit(1)
-    with dask_client as client:
-        executor = DaskExecutor(client, task_cache=task_cache)
-        return run_with_project(
-            project, executor, ids_to_run=ids_to_run,
-            keep_going=args.keep_going
-        )
-
-
-def _cmd_list(args, project, task_cache):
-    storage = project.get_import_storage()
-    print("Generating Task Graph ...", end="")
-    task_graph = storage.generate_import_task_graph(project)
-    print("Done")
-    task_graph.input_files.extend(project.config_filenames)
-    task_graph = _prune_tasks(task_graph, args.task_ids or [])
-
-    task_cache.set_task_graph(task_graph)
-    id_col_len = max(len(t.task_id) for t in task_graph.tasks)
-    id_col_len = min(120, max(50, id_col_len))
-    if not args.verbose:
-        columns = ["TaskID", "Status"]
-        print(f"{columns[0]:{id_col_len}s} {columns[1]}")
-    for task in task_graph.tasks:
-        record = task_cache.get_record(task)
-        status = record.type.name
-        is_error = record.type == CacheRecordType.ERROR
-
-        if args.verbose:
-            print(f"Task-Id={task.task_id}")
-            print(f"Status={status}")
-        else:
-            id_and_status = f"{task.task_id:{id_col_len}s} {status}"
-            if is_error:
-                id_and_status += " (-v to see exception)"
-            print(id_and_status)
-
-        if args.verbose:
-            task_dep_ids_str = ",".join(dep.task_id for dep in task.deps)
-            print(f"Deps=[{task_dep_ids_str}]")
-            inputs = task.input_files if task.deps else task_graph.input_files
-            inputs_str = ",".join(inputs)
-            print(f"Input-files=[{inputs_str}]")
-        if is_error and args.verbose:
-            print("Error=", end="")
-            traceback.print_exception(
-                etype=None, value=record.error,
-                tb=record.error.__traceback__,
-                file=sys.stdout
-            )
-        if args.verbose:
-            print()
-
-
-def _prune_tasks(graph, ids_to_run):
-    if not ids_to_run:
-        return graph
-
-    try:
-        return graph.prune(ids_to_keep=ids_to_run)
-    except KeyError as exp:
-        print(f"Task IDs {exp.args[0]} not found", file=sys.stderr)
-        sys.exit(1)
-
-
-def _add_task_deps(task, task_set):
-    for dep in task.deps:
-        if dep not in task_set:
-            task_set.add(dep)
-            _add_task_deps(dep, task_set)
-
-
-def run_with_project(project, executor=SequentialExecutor(), ids_to_run=None,
-                     keep_going=False):
-    """Import the project using the provided executor."""
+def run_with_project(project, executor=SequentialExecutor()):
     storage = project.get_import_storage()
     task_graph = storage.generate_import_task_graph(project)
     task_graph.input_files.extend(project.config_filenames)
-    task_graph = _prune_tasks(task_graph, ids_to_run)
 
-    any_errors = False
-
-    tasks_iter = executor.execute(task_graph)
-    last_stagenames = _get_current_stagenames(executor)
-    _print_stagenames(last_stagenames)
-    for task, result_or_error in tasks_iter:
-        if isinstance(result_or_error, Exception):
-            if keep_going:
-                print(f"Task {task.task_id} failed with:", file=sys.stderr)
-                traceback.print_exception(
-                    etype=None, value=result_or_error,
-                    tb=result_or_error.__traceback__
-                )
-                any_errors = True
-            else:
-                raise result_or_error
-        current_stagenames = _get_current_stagenames(executor)
-        if current_stagenames != last_stagenames:
-            last_stagenames = current_stagenames
-            _print_stagenames(last_stagenames)
-
-    return 1 if any_errors else 0
-
-
-def _get_current_stagenames(executor):
-    # we use the task name is also the stagename
-    return {
-        t.task_id
-        for t in executor.get_active_tasks()
-        if t.task_id is not None
-    }
-
-
-def _print_stagenames(stagenames):
-    if stagenames:
-        stagenames_str = ", ".join(stagenames)
-        print(f"Executing stage: {stagenames_str}")
-
-
-def _create_task_cache(args, project):
-    cache_dir = fs_utils.join(
-        project.work_dir, ".task-progress", project.study_id
-    )
-    return FileTaskCache(force=args.force, cache_dir=cache_dir)
+    return TaskGraphCli.run(task_graph, executor, keep_going=False)

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -1,6 +1,8 @@
 import argparse
 import sys
 import traceback
+from typing import Union
+
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.import_tools.import_tools import ImportProject
 from dae.task_graph.cache import CacheRecordType, FileTaskCache
@@ -41,6 +43,7 @@ def main(argv=None):
 
 def _cmd_run(args, project, task_cache):
     ids_to_run = args.task_ids or []
+    executor: Union[SequentialExecutor, DaskExecutor]
     if args.jobs == 1:
         executor = SequentialExecutor(task_cache=task_cache)
         return run_with_project(

--- a/dae/dae/task_graph/__init__.py
+++ b/dae/dae/task_graph/__init__.py
@@ -1,1 +1,3 @@
 from .cli_tools import TaskGraphCli
+from .graph import TaskGraph
+from .graph import Task

--- a/dae/dae/task_graph/__init__.py
+++ b/dae/dae/task_graph/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from .cli_tools import TaskGraphCli
 from .graph import TaskGraph
 from .graph import Task

--- a/dae/dae/task_graph/__init__.py
+++ b/dae/dae/task_graph/__init__.py
@@ -1,0 +1,1 @@
+from .cli_tools import TaskGraphCli

--- a/dae/dae/task_graph/__init__.py
+++ b/dae/dae/task_graph/__init__.py
@@ -1,4 +1,3 @@
 # flake8: noqa: F401
-from .cli_tools import TaskGraphCli
-from .graph import TaskGraph
-from .graph import Task
+from dae.task_graph.cli_tools import TaskGraphCli
+from dae.task_graph.graph import TaskGraph, Task

--- a/dae/dae/task_graph/cache.py
+++ b/dae/dae/task_graph/cache.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
 from abc import abstractmethod
 from copy import copy
 from dataclasses import dataclass
 import logging
 from enum import Enum
 import pickle
-from typing import Any, cast
+from typing import Any, cast, Optional
 import fsspec
 
 from dae.task_graph.graph import TaskGraph, Task
@@ -52,6 +53,17 @@ class TaskCache:
     @abstractmethod
     def cache(self, task_node: Task, is_error: bool, result: Any):
         """Cache the result or exception of a task."""
+
+    @staticmethod
+    def create(
+            force: Optional[bool] = None,
+            cache_dir: Optional[str] = None) -> TaskCache:
+        """Create the appropriate task cache."""
+        if force is None:
+            # the force_mode is set to 'always'
+            return NoTaskCache()
+
+        return FileTaskCache(force=force, cache_dir=cache_dir)
 
 
 class NoTaskCache(dict, TaskCache):

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -2,6 +2,8 @@ import sys
 import argparse
 import textwrap
 import traceback
+from typing import Optional
+
 import yaml
 from box import Box
 from dae.task_graph.cache import CacheRecordType, TaskCache
@@ -75,64 +77,6 @@ class TaskGraphCli:
             assert force_mode == "always"
 
     @staticmethod
-    def process_graph(task_graph: TaskGraph, **kwargs) -> bool:
-        """Process task_graph in according with the arguments in args."""
-        args = Box(kwargs)
-
-        task_cache = TaskCache.create(args.force, args.task_status_dir)
-        if args.task_ids:
-            task_graph = task_graph.prune(ids_to_keep=args.task_ids)
-
-        executor = TaskGraphCli.create_executor(**kwargs)
-        if args.command is None or args.command == "run":
-            return TaskGraphCli.run(task_graph, executor, args.keep_going)
-
-        if args.command == "list":
-            id_col_len = max(len(t.task_id) for t in task_graph.tasks)
-            id_col_len = min(120, max(50, id_col_len))
-            columns = ["TaskID", "Status"]
-            print(f"{columns[0]:{id_col_len}s} {columns[1]}")
-            task_cache = getattr(executor, "_task_cache")
-            for task in task_graph.tasks:
-                record = task_cache.get_record(task)
-                status = record.type.name
-                msg = f"{task.task_id:{id_col_len}s} {status}"
-                is_error = record.type == CacheRecordType.ERROR
-                if is_error and not args.verbose:
-                    msg += " (-v to see exception)"
-                print(msg)
-                if is_error and args.verbose:
-                    traceback.print_exception(
-                        etype=None, value=record.error,
-                        tb=record.error.__traceback__,
-                        file=sys.stdout
-                    )
-            return True
-
-        raise Exception("Unknown command")
-
-    @staticmethod
-    def run(
-        task_graph: TaskGraph, executor: TaskGraphExecutor, keep_going: bool
-    ) -> bool:
-        """Execute (runs) the task_graph with the given executor."""
-        tasks_iter = executor.execute(task_graph)
-        no_errors = True
-        for task, result_or_error in tasks_iter:
-            if isinstance(result_or_error, Exception):
-                if keep_going:
-                    print(f"Task {task.task_id} failed with:",
-                          file=sys.stderr)
-                    traceback.print_exception(
-                        etype=None, value=result_or_error,
-                        tb=result_or_error.__traceback__
-                    )
-                    no_errors = False
-                else:
-                    raise result_or_error
-        return no_errors
-
-    @staticmethod
     def create_executor(**kwargs) -> TaskGraphExecutor:
         """Create a task graph executor according to the args specified."""
         args = Box(kwargs)
@@ -162,3 +106,68 @@ class TaskGraphCli:
                                      number_of_threads=args.jobs)
         print("Working with client:", client)
         return DaskExecutor(client, task_cache=task_cache)
+
+    @staticmethod
+    def process_graph(task_graph: TaskGraph, **kwargs) -> bool:
+        """Process task_graph in according with the arguments in args."""
+        args = Box(kwargs)
+
+        if args.task_ids:
+            task_graph = task_graph.prune(ids_to_keep=args.task_ids)
+
+        executor = TaskGraphCli.create_executor(**kwargs)
+        if args.command is None or args.command == "run":
+            return TaskGraphCli.run(task_graph, executor, args.keep_going)
+
+        if args.command == "list":
+            return TaskGraphCli.list(
+                task_graph, executor, args.verbose)
+
+        raise Exception("Unknown command")
+
+    @staticmethod
+    def list(
+            task_graph: TaskGraph, executor: TaskGraphExecutor,
+            verbose: Optional[int]) -> bool:
+        """Show the status of each task from the task graph."""
+        id_col_len = max(len(t.task_id) for t in task_graph.tasks)
+        id_col_len = min(120, max(50, id_col_len))
+        columns = ["TaskID", "Status"]
+        print(f"{columns[0]:{id_col_len}s} {columns[1]}")
+        task_cache = getattr(executor, "_task_cache")
+        for task in task_graph.tasks:
+            record = task_cache.get_record(task)
+            status = record.type.name
+            msg = f"{task.task_id:{id_col_len}s} {status}"
+            is_error = record.type == CacheRecordType.ERROR
+            if is_error and not verbose:
+                msg += " (-v to see exception)"
+            print(msg)
+            if is_error and verbose:
+                traceback.print_exception(
+                    etype=None, value=record.error,
+                    tb=record.error.__traceback__,
+                    file=sys.stdout
+                )
+        return True
+
+    @staticmethod
+    def run(
+        task_graph: TaskGraph, executor: TaskGraphExecutor, keep_going: bool
+    ) -> bool:
+        """Execute (runs) the task_graph with the given executor."""
+        tasks_iter = executor.execute(task_graph)
+        no_errors = True
+        for task, result_or_error in tasks_iter:
+            if isinstance(result_or_error, Exception):
+                if keep_going:
+                    print(f"Task {task.task_id} failed with:",
+                          file=sys.stderr)
+                    traceback.print_exception(
+                        etype=None, value=result_or_error,
+                        tb=result_or_error.__traceback__
+                    )
+                    no_errors = False
+                else:
+                    raise result_or_error
+        return no_errors

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -30,11 +30,15 @@ class TaskGraphCli:
             "of processors on the machine")
 
         executor_group.add_argument(
-            "-dcn", "--dask_cluster_name", type=str, default=None,
+            "-N", "--dask-cluster-name", "--dcn",
+            dest="dask_cluster_name",
+            type=str, default=None,
             help="The named of the named dask cluster"
         )
         executor_group.add_argument(
-            "-dccf", "--dask_cluster_config_file", type=str, default=None,
+            "-c", "--dccf", "--dask-cluster-config-file",
+            dest="dask_cluster_config_file",
+            type=str, default=None,
             help="dask cluster config file"
         )
 
@@ -52,7 +56,7 @@ class TaskGraphCli:
                 """),
                                           )
         execution_mode_group.add_argument(
-            "--task-id", dest="task_ids", type=str, nargs="+")
+            "-t", "--task-ids", dest="task_ids", type=str, nargs="+")
         execution_mode_group.add_argument(
             "--keep-going", default=False, action="store_true",
             help="Whether or not to keep executing in case of an error"
@@ -63,14 +67,15 @@ class TaskGraphCli:
                 help="Ignore precomputed state and always rerun all tasks."
             )
             execution_mode_group.add_argument(
-                "-tsd", "--task-status-dir", default=default_task_status_dir,
+                "-d", "--task-status-dir", "--tsd",
+                default=default_task_status_dir,
                 type=str, help="Directory to store the task progress."
             )
         else:
             assert force_mode == "always"
 
     @staticmethod
-    def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
+    def process_graph(task_graph: TaskGraph, args: argparse.Namespace) -> bool:
         """Process task_graph in according with the arguments in args."""
         task_cache: TaskCache
         if "force" not in vars(args):

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -116,7 +116,7 @@ class TaskGraphCli:
         if args.command is None or args.command == "run":
             return task_graph_run(task_graph, executor, args.keep_going)
 
-        if args.command == "list" or args.command == "status":
+        if args.command in {"list", "status"}:
             return task_graph_status(
                 task_graph, executor, args.verbose)
 

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -3,7 +3,8 @@ import argparse
 import textwrap
 import traceback
 import yaml
-from dae.task_graph.cache import CacheRecordType, FileTaskCache, NoTaskCache
+from dae.task_graph.cache import CacheRecordType, TaskCache, \
+    FileTaskCache, NoTaskCache
 from dae.task_graph.executor import DaskExecutor
 from dae.task_graph.executor import SequentialExecutor
 
@@ -68,6 +69,7 @@ class TaskGraphCli:
 
     @staticmethod
     def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
+        task_cache: TaskCache
         if "force" not in vars(args):
             # if the force_mode is set no 'always'
             task_cache = NoTaskCache()

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -2,93 +2,121 @@ import sys
 import argparse
 import textwrap
 import traceback
+import yaml
 from dae.task_graph.cache import CacheRecordType, FileTaskCache
 from dae.task_graph.executor import DaskExecutor
 from dae.task_graph.executor import SequentialExecutor
 
 from dae.task_graph.graph import TaskGraph
 from dae.dask.named_cluster import setup_client
+from dae.dask.named_cluster import setup_client_from_config
 
 
-def add_arguments(parser: argparse.ArgumentParser):
-    executor_group = parser.add_argument_group(title="Task Graph Executor")
-    # cluster_name
-    # cluster_config_file
-    executor_group.add_argument(
+class TaskGraphCli:
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser, defualt_cache=None):
+        executor_group = parser.add_argument_group(title="Task Graph Executor")
+        # cluster_name
+        # cluster_config_file
+        executor_group.add_argument(
             "-j", "--jobs", type=int, default=None,
             help="Number of jobs to run in parallel. Defaults to the number "
             "of processors on the machine")
-    
-    # task_cache
-    execution_mode_group = parser.add_argument_group(title="Execution Mode")
-    execution_mode_group.add_argument("command",
-                        choices=["run", "list", "status"],
-                        default="run", nargs="?",
-                        help=textwrap.dedent("""\
-                Command to execute on the import configuration.
-                run - runs the import process
-                list - lists the tasks to be executed but doesn't run them
-                status - synonym for list
-            """),
-                        )
-    execution_mode_group.add_argument("--task-id", dest="task_ids", type=str, nargs="+")
-    execution_mode_group.add_argument(
-        "--force", "-f", default=False, action="store_true",
-        help="Ignore precomputed state and always rerun the entire import"
-    )
-    execution_mode_group.add_argument(
-        "--keep-going", default=False, action="store_true",
-        help="Whether or not to keep executing in case of an error"
-    )
 
+        executor_group.add_argument(
+            "-dcn", "--dask_cluster_name", type=str, default=None,
+            help="The named of the named dask cluster"
+        )
+        executor_group.add_argument(
+            "-dccf", "--dask_cluster_config_file", type=str, default=None,
+            help="dask cluster config file"
+        )
 
-def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
-    task_cache = FileTaskCache(force=args.force, cache_dir=".")
+        # task_cache
+        execution_mode_group = parser.add_argument_group(title="Execution Mode")
+        execution_mode_group.add_argument("command",
+                                        choices=["run", "list", "status"],
+                                        default="run", nargs="?",
+                                        help=textwrap.dedent("""\
+                    Command to execute on the import configuration.
+                    run - runs the import process
+                    list - lists the tasks to be executed but doesn't run them
+                    status - synonym for list
+                """),
+                                        )
+        execution_mode_group.add_argument(
+            "--task-id", dest="task_ids", type=str, nargs="+")
+        execution_mode_group.add_argument(
+            "--force", "-f", default=False, action="store_true",
+            help="Ignore precomputed state and always rerun the entire import"
+        )
+        execution_mode_group.add_argument(
+            "--keep-going", default=False, action="store_true",
+            help="Whether or not to keep executing in case of an error"
+        )
 
-    if args.task_ids:
-        task_graph = task_graph.prune(ids_to_keep=args.task_ids)
+    @staticmethod
+    def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
+        task_cache = FileTaskCache(force=args.force, cache_dir=".")
 
-    if args.command is None or args.command == "run":
-        if args.jobs == 1:
-            executor = SequentialExecutor(task_cache=task_cache)
-        else:
-            client, _  = setup_client(number_of_threads=args.jobs)
-            print("Working with client:", client)
-            executor = DaskExecutor(client, task_cache=task_cache)
+        if args.task_ids:
+            task_graph = task_graph.prune(ids_to_keep=args.task_ids)
 
-        no_errors = True
-        tasks_iter = executor.execute(task_graph)
-        for task, result_or_error in tasks_iter:
-            if isinstance(result_or_error, Exception):
-                if args.keep_going:
-                    print(f"Task {task.task_id} failed with:", file=sys.stderr)
-                    no_errors = False
+        if args.command is None or args.command == "run":
+            if args.jobs == 1:
+                assert args.dask_cluster_name is None
+                assert args.dask_cluster_config_file is None
+                executor = SequentialExecutor(task_cache=task_cache)
+            else:
+                assert args.dask_cluster_name is None or \
+                    args.dask_cluster_config_file is None
+                if args.dask_cluster_config_file is not None:
+                    with open(args.dask_cluster_config_file) as F:
+                        dask_cluster_config = yaml.safe_load(F)
+                    print("THE CLUSTER CONFIG IS:", dask_cluster_config,
+                        "loaded from", args.dask_cluster_config_file)
+                    client, _ = setup_client_from_config(
+                        dask_cluster_config,
+                        number_of_threads=args.jobs)
                 else:
-                    raise result_or_error
-        return no_errors
-    elif args.command == "list":
-        task_cache.set_task_graph(task_graph)
-        id_col_len = max(len(t.task_id) for t in task_graph.tasks)
-        id_col_len = min(120, max(50, id_col_len))
-        columns = ["TaskID", "Status"]
-        print(f"{columns[0]:{id_col_len}s} {columns[1]}")
-        for task in task_graph.tasks:
-            record = task_cache.get_record(task)
-            status = record.type.name
-            msg = f"{task.task_id:{id_col_len}s} {status}"
-            is_error = record.type == CacheRecordType.ERROR
-            if is_error and not args.verbose:
-                msg += " (-v to see exception)"
-            print(msg)
-            if is_error and args.verbose:
-                traceback.print_exception(
-                    etype=None, value=record.error,
-                    tb=record.error.__traceback__,
-                    file=sys.stdout
-                )
-    else:
-        raise Exception("Unknown command")
+                    client, _ = setup_client(args.dask_cluster_name,
+                                            number_of_threads=args.jobs)
+                print("Working with client:", client)
+                executor = DaskExecutor(client, task_cache=task_cache)
 
-    # if args.command in {"list", "status"}:
-    #     return _cmd_list(args, project, task_cache)
-    # return 0
+            no_errors = True
+            tasks_iter = executor.execute(task_graph)
+            for task, result_or_error in tasks_iter:
+                if isinstance(result_or_error, Exception):
+                    if args.keep_going:
+                        print(f"Task {task.task_id} failed with:", file=sys.stderr)
+                        no_errors = False
+                    else:
+                        raise result_or_error
+            return no_errors
+        elif args.command == "list":
+            task_cache.set_task_graph(task_graph)
+            id_col_len = max(len(t.task_id) for t in task_graph.tasks)
+            id_col_len = min(120, max(50, id_col_len))
+            columns = ["TaskID", "Status"]
+            print(f"{columns[0]:{id_col_len}s} {columns[1]}")
+            for task in task_graph.tasks:
+                record = task_cache.get_record(task)
+                status = record.type.name
+                msg = f"{task.task_id:{id_col_len}s} {status}"
+                is_error = record.type == CacheRecordType.ERROR
+                if is_error and not args.verbose:
+                    msg += " (-v to see exception)"
+                print(msg)
+                if is_error and args.verbose:
+                    traceback.print_exception(
+                        etype=None, value=record.error,
+                        tb=record.error.__traceback__,
+                        file=sys.stdout
+                    )
+        else:
+            raise Exception("Unknown command")
+
+        # if args.command in {"list", "status"}:
+        #     return _cmd_list(args, project, task_cache)
+        # return 0

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -21,7 +21,6 @@ class TaskGraphCli:
                       force_mode="optional",
                       default_task_status_dir="."):
         """Add arguments needed to execute a task graph."""
-
         executor_group = parser.add_argument_group(title="Task Graph Executor")
         # cluster_name
         # cluster_config_file

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -5,8 +5,8 @@ import traceback
 import yaml
 from dae.task_graph.cache import CacheRecordType, TaskCache, \
     FileTaskCache, NoTaskCache
-from dae.task_graph.executor import DaskExecutor
-from dae.task_graph.executor import SequentialExecutor
+from dae.task_graph.executor import DaskExecutor, TaskGraphExecutor, \
+    SequentialExecutor
 
 from dae.task_graph.graph import TaskGraph
 from dae.dask.named_cluster import setup_client
@@ -14,10 +14,13 @@ from dae.dask.named_cluster import setup_client_from_config
 
 
 class TaskGraphCli:
+    """Takes care of creating a task graph executor and executing a graph."""
+
     @staticmethod
     def add_arguments(parser: argparse.ArgumentParser,
                       force_mode="optional",
                       default_task_status_dir="."):
+        """Add arguments needed to execute a task graph."""
 
         executor_group = parser.add_argument_group(title="Task Graph Executor")
         # cluster_name
@@ -69,6 +72,7 @@ class TaskGraphCli:
 
     @staticmethod
     def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
+        """Process task_graph in according with the arguments in args."""
         task_cache: TaskCache
         if "force" not in vars(args):
             # if the force_mode is set no 'always'
@@ -80,45 +84,16 @@ class TaskGraphCli:
         if args.task_ids:
             task_graph = task_graph.prune(ids_to_keep=args.task_ids)
 
+        executor = TaskGraphCli.create_executor(args)
         if args.command is None or args.command == "run":
-            if args.jobs == 1:
-                assert args.dask_cluster_name is None
-                assert args.dask_cluster_config_file is None
-                executor = SequentialExecutor(task_cache=task_cache)
-            else:
-                assert args.dask_cluster_name is None or \
-                    args.dask_cluster_config_file is None
-                if args.dask_cluster_config_file is not None:
-                    with open(args.dask_cluster_config_file) as F:
-                        dask_cluster_config = yaml.safe_load(F)
-                    print("THE CLUSTER CONFIG IS:", dask_cluster_config,
-                          "loaded from", args.dask_cluster_config_file)
-                    client, _ = setup_client_from_config(
-                        dask_cluster_config,
-                        number_of_threads=args.jobs)
-                else:
-                    client, _ = setup_client(args.dask_cluster_name,
-                                             number_of_threads=args.jobs)
-                print("Working with client:", client)
-                executor = DaskExecutor(client, task_cache=task_cache)
+            return TaskGraphCli.run(task_graph, executor, args.keep_going)
 
-            no_errors = True
-            tasks_iter = executor.execute(task_graph)
-            for task, result_or_error in tasks_iter:
-                if isinstance(result_or_error, Exception):
-                    if args.keep_going:
-                        print(f"Task {task.task_id} failed with:",
-                              file=sys.stderr)
-                        no_errors = False
-                    else:
-                        raise result_or_error
-            return no_errors
-        elif args.command == "list":
-            task_cache.set_task_graph(task_graph)
+        if args.command == "list":
             id_col_len = max(len(t.task_id) for t in task_graph.tasks)
             id_col_len = min(120, max(50, id_col_len))
             columns = ["TaskID", "Status"]
             print(f"{columns[0]:{id_col_len}s} {columns[1]}")
+            task_cache = getattr(executor, "_task_cache")
             for task in task_graph.tasks:
                 record = task_cache.get_record(task)
                 status = record.type.name
@@ -134,9 +109,54 @@ class TaskGraphCli:
                         file=sys.stdout
                     )
             return True
-        else:
-            raise Exception("Unknown command")
 
-        # if args.command in {"list", "status"}:
-        #     return _cmd_list(args, project, task_cache)
-        # return 0
+        raise Exception("Unknown command")
+
+    @staticmethod
+    def run(
+        task_graph: TaskGraph, executor: TaskGraphExecutor, keep_going: bool
+    ) -> bool:
+        """Execute (runs) the task_graph with the given executor."""
+        tasks_iter = executor.execute(task_graph)
+        no_errors = True
+        for task, result_or_error in tasks_iter:
+            if isinstance(result_or_error, Exception):
+                if keep_going:
+                    print(f"Task {task.task_id} failed with:",
+                          file=sys.stderr)
+                    traceback.print_exception(
+                        etype=None, value=result_or_error,
+                        tb=result_or_error.__traceback__
+                    )
+                    no_errors = False
+                else:
+                    raise result_or_error
+        return no_errors
+
+    @staticmethod
+    def create_executor(args) -> TaskGraphExecutor:
+        """Create a task graph executor according to the args specified."""
+        task_cache = FileTaskCache(force=args.force,
+                                   cache_dir=args.task_status_dir)
+
+        if args.jobs == 1:
+            assert args.dask_cluster_name is None
+            assert args.dask_cluster_config_file is None
+            return SequentialExecutor(task_cache=task_cache)
+
+        assert args.dask_cluster_name is None or \
+            args.dask_cluster_config_file is None
+        if args.dask_cluster_config_file is not None:
+            with open(args.dask_cluster_config_file) as conf_file:
+                dask_cluster_config = yaml.safe_load(conf_file)
+            print("THE CLUSTER CONFIG IS:", dask_cluster_config,
+                  "loaded from", args.dask_cluster_config_file)
+            client, _ = setup_client_from_config(
+                dask_cluster_config,
+                number_of_threads_param=args.jobs
+            )
+        else:
+            client, _ = setup_client(args.dask_cluster_name,
+                                     number_of_threads=args.jobs)
+        print("Working with client:", client)
+        return DaskExecutor(client, task_cache=task_cache)

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -1,0 +1,90 @@
+import sys
+import argparse
+import textwrap
+import traceback
+from dae.task_graph.cache import CacheRecordType, FileTaskCache
+from dae.task_graph.executor import DaskExecutor
+from dae.task_graph.executor import SequentialExecutor
+
+from dae.task_graph.graph import TaskGraph
+from dae.dask.named_cluster import setup_client
+
+
+def add_arguments(parser: argparse.ArgumentParser):
+    executor_group = parser.add_argument_group(title="Task Graph Executor")
+    executor_group.add_argument(
+            "-j", "--jobs", type=int, default=None,
+            help="Number of jobs to run in parallel. Defaults to the number "
+            "of processors on the machine")
+    
+    execution_mode_group = parser.add_argument_group(title="Execution Mode")
+    execution_mode_group.add_argument("command",
+                        choices=["run", "list", "status"],
+                        default="run", nargs="?",
+                        help=textwrap.dedent("""\
+                Command to execute on the import configuration.
+                run - runs the import process
+                list - lists the tasks to be executed but doesn't run them
+                status - synonym for list
+            """),
+                        )
+    execution_mode_group.add_argument("--task-id", dest="task_ids", type=str, nargs="+")
+    execution_mode_group.add_argument(
+        "--force", "-f", default=False, action="store_true",
+        help="Ignore precomputed state and always rerun the entire import"
+    )
+    execution_mode_group.add_argument(
+        "--keep-going", default=False, action="store_true",
+        help="Whether or not to keep executing in case of an error"
+    )
+
+
+def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
+    task_cache = FileTaskCache(force=args.force, cache_dir=".")
+
+    if args.task_ids:
+        task_graph = task_graph.prune(ids_to_keep=args.task_ids)
+
+    if args.command is None or args.command == "run":
+        if args.jobs == 1:
+            executor = SequentialExecutor(task_cache=task_cache)
+        else:
+            client, _, _ = setup_client(number_of_threads=args.jobs)
+            executor = DaskExecutor(client, task_cache=task_cache)
+
+        no_errors = True
+        tasks_iter = executor.execute(task_graph)
+        for task, result_or_error in tasks_iter:
+            if isinstance(result_or_error, Exception):
+                if args.keep_going:
+                    print(f"Task {task.task_id} failed with:", file=sys.stderr)
+                    no_errors = False
+                else:
+                    raise result_or_error
+        return no_errors
+    elif args.command == "list":
+        task_cache.set_task_graph(task_graph)
+        id_col_len = max(len(t.task_id) for t in task_graph.tasks)
+        id_col_len = min(120, max(50, id_col_len))
+        columns = ["TaskID", "Status"]
+        print(f"{columns[0]:{id_col_len}s} {columns[1]}")
+        for task in task_graph.tasks:
+            record = task_cache.get_record(task)
+            status = record.type.name
+            msg = f"{task.task_id:{id_col_len}s} {status}"
+            is_error = record.type == CacheRecordType.ERROR
+            if is_error and not args.verbose:
+                msg += " (-v to see exception)"
+            print(msg)
+            if is_error and args.verbose:
+                traceback.print_exception(
+                    etype=None, value=record.error,
+                    tb=record.error.__traceback__,
+                    file=sys.stdout
+                )
+    else:
+        raise Exception("Unknown command")
+
+    # if args.command in {"list", "status"}:
+    #     return _cmd_list(args, project, task_cache)
+    # return 0

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -12,11 +12,14 @@ from dae.dask.named_cluster import setup_client
 
 def add_arguments(parser: argparse.ArgumentParser):
     executor_group = parser.add_argument_group(title="Task Graph Executor")
+    # cluster_name
+    # cluster_config_file
     executor_group.add_argument(
             "-j", "--jobs", type=int, default=None,
             help="Number of jobs to run in parallel. Defaults to the number "
             "of processors on the machine")
     
+    # task_cache
     execution_mode_group = parser.add_argument_group(title="Execution Mode")
     execution_mode_group.add_argument("command",
                         choices=["run", "list", "status"],
@@ -49,7 +52,8 @@ def process_graph(args: argparse.Namespace, task_graph: TaskGraph) -> bool:
         if args.jobs == 1:
             executor = SequentialExecutor(task_cache=task_cache)
         else:
-            client, _, _ = setup_client(number_of_threads=args.jobs)
+            client, _  = setup_client(number_of_threads=args.jobs)
+            print("Working with client:", client)
             executor = DaskExecutor(client, task_cache=task_cache)
 
         no_errors = True

--- a/dae/dae/task_graph/demo_graphs_cli.py
+++ b/dae/dae/task_graph/demo_graphs_cli.py
@@ -47,4 +47,4 @@ def main(argv=None):
     args = parser.parse_args(argv or sys.argv[1:])
 
     empty_graph = build_demo_graph(args.graph, args.graph_params)
-    TaskGraphCli.process_graph(empty_graph, args)
+    TaskGraphCli.process_graph(empty_graph, **vars(args))

--- a/dae/dae/task_graph/demo_graphs_cli.py
+++ b/dae/dae/task_graph/demo_graphs_cli.py
@@ -11,10 +11,11 @@ from dae.task_graph.graph import TaskGraph
 
 def build_demo_graph(graph_type: str,
                      graph_params: Optional[List[str]]) -> TaskGraph:
+    """Build a demo graph."""
     task_graph = TaskGraph()
 
     if graph_type == "A":
-        NP, SP, SS = 10, 1, 1
+        NP, SP, SS = 10, 1, 1  # pylint: disable=invalid-name
 
         if graph_params:
             if len(graph_params) != 3:
@@ -22,10 +23,10 @@ def build_demo_graph(graph_type: str,
                 raise Exception("The graph A needs three parameters: "
                                 "<number of parts>, <seconds for parts>, "
                                 "<seconds for summary>")
-            NP, SP, SS = map(int, graph_params)  
+            NP, SP, SS = map(int, graph_params)  # pylint: disable=invalid-name
         print(f"Bulding graph A with {NP} parts, {SP} seconds for "
               f"each parts, and {SS} secoconds for the summary")
-          
+
         parts = [task_graph.create_task(
             f"part {p}", lambda: time.sleep(SP), [], []) for p in range(NP)]
         task_graph.create_task("summary", lambda: time.sleep(SS), [], parts)
@@ -36,6 +37,7 @@ def build_demo_graph(graph_type: str,
 
 
 def main(argv=None):
+    """Entry point for the demo script."""
     parser = argparse.ArgumentParser(description="test_basic")
 
     parser.add_argument("graph", type=str, help="Demo graph",

--- a/dae/dae/task_graph/demo_graphs_cli.py
+++ b/dae/dae/task_graph/demo_graphs_cli.py
@@ -4,8 +4,6 @@ import time
 from typing import Optional, List
 
 from dae.task_graph import TaskGraphCli
-# TaskGraphCli.add_arumgetts
-# TaksGraphClie.process_graph
 from dae.task_graph.graph import TaskGraph
 
 
@@ -49,4 +47,4 @@ def main(argv=None):
     args = parser.parse_args(argv or sys.argv[1:])
 
     empty_graph = build_demo_graph(args.graph, args.graph_params)
-    TaskGraphCli.process_graph(args, empty_graph)
+    TaskGraphCli.process_graph(empty_graph, args)

--- a/dae/dae/task_graph/demo_graphs_cli.py
+++ b/dae/dae/task_graph/demo_graphs_cli.py
@@ -1,0 +1,49 @@
+import argparse
+import sys
+import time
+from typing import Optional, List
+
+from dae.task_graph.cli_tools import add_arguments
+from dae.task_graph.cli_tools import process_graph
+from dae.task_graph.graph import TaskGraph
+
+
+def build_demo_graph(graph_type: str,
+                     graph_params: Optional[List[str]]) -> TaskGraph:
+    task_graph = TaskGraph()
+
+    if graph_type == "A":
+        NP, SP, SS = 10, 1, 1
+
+        if graph_params:
+            if len(graph_params) != 3:
+
+                raise Exception("The graph A needs three parameters: "
+                                "<number of parts>, <seconds for parts>, "
+                                "<seconds for summary>")
+            NP, SP, SS = map(int, graph_params)  
+        print(f"Bulding graph A with {NP} parts, {SP} seconds for "
+              f"each parts, and {SS} secoconds for the summary")
+          
+        parts = [task_graph.create_task(
+            f"part {p}", lambda: time.sleep(SP), [], []) for p in range(NP)]
+        task_graph.create_task("summary", lambda: time.sleep(SS), [], parts)
+    else:
+        raise Exception("Unknown graph")
+
+    return task_graph
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="test_basic")
+
+    parser.add_argument("graph", type=str, help="Demo graph",
+                        default="A", nargs="?")
+    parser.add_argument("--graph_params", "-gp", type=str, nargs="+")
+
+    add_arguments(parser)
+
+    args = parser.parse_args(argv or sys.argv[1:])
+
+    empty_graph = build_demo_graph(args.graph, args.graph_params)
+    process_graph(args, empty_graph)

--- a/dae/dae/task_graph/demo_graphs_cli.py
+++ b/dae/dae/task_graph/demo_graphs_cli.py
@@ -3,8 +3,9 @@ import sys
 import time
 from typing import Optional, List
 
-from dae.task_graph.cli_tools import add_arguments
-from dae.task_graph.cli_tools import process_graph
+from dae.task_graph import TaskGraphCli
+# TaskGraphCli.add_arumgetts
+# TaksGraphClie.process_graph
 from dae.task_graph.graph import TaskGraph
 
 
@@ -41,9 +42,9 @@ def main(argv=None):
                         default="A", nargs="?")
     parser.add_argument("--graph_params", "-gp", type=str, nargs="+")
 
-    add_arguments(parser)
+    TaskGraphCli.add_arguments(parser)
 
     args = parser.parse_args(argv or sys.argv[1:])
 
     empty_graph = build_demo_graph(args.graph, args.graph_params)
-    process_graph(args, empty_graph)
+    TaskGraphCli.process_graph(args, empty_graph)

--- a/dae/dae/task_graph/executor.py
+++ b/dae/dae/task_graph/executor.py
@@ -1,7 +1,10 @@
+import sys
+import logging
+import traceback
 from abc import abstractmethod
 from copy import copy
 from typing import Any, Iterator
-import logging
+from typing import Optional
 
 from dae.task_graph.graph import TaskGraph, Task
 from dae.task_graph.cache import TaskCache, NoTaskCache, CacheRecordType
@@ -237,3 +240,50 @@ class DaskExecutor(AbstractTaskGraphExecutor):
     @staticmethod
     def _exec(task_func, args, _deps):
         return task_func(*args)
+
+
+def task_graph_status(
+        task_graph: TaskGraph, executor: TaskGraphExecutor,
+        verbose: Optional[int]) -> bool:
+    """Show the status of each task from the task graph."""
+    id_col_len = max(len(t.task_id) for t in task_graph.tasks)
+    id_col_len = min(120, max(50, id_col_len))
+    columns = ["TaskID", "Status"]
+    print(f"{columns[0]:{id_col_len}s} {columns[1]}")
+    task_cache = getattr(executor, "_task_cache")
+    for task in task_graph.tasks:
+        record = task_cache.get_record(task)
+        status = record.type.name
+        msg = f"{task.task_id:{id_col_len}s} {status}"
+        is_error = record.type == CacheRecordType.ERROR
+        if is_error and not verbose:
+            msg += " (-v to see exception)"
+        print(msg)
+        if is_error and verbose:
+            traceback.print_exception(
+                etype=None, value=record.error,
+                tb=record.error.__traceback__,
+                file=sys.stdout
+            )
+    return True
+
+
+def task_graph_run(
+    task_graph: TaskGraph, executor: TaskGraphExecutor, keep_going: bool
+) -> bool:
+    """Execute (runs) the task_graph with the given executor."""
+    tasks_iter = executor.execute(task_graph)
+    no_errors = True
+    for task, result_or_error in tasks_iter:
+        if isinstance(result_or_error, Exception):
+            if keep_going:
+                print(f"Task {task.task_id} failed with:",
+                      file=sys.stderr)
+                traceback.print_exception(
+                    etype=None, value=result_or_error,
+                    tb=result_or_error.__traceback__
+                )
+                no_errors = False
+            else:
+                raise result_or_error
+    return no_errors

--- a/dae/dae/task_graph/executor.py
+++ b/dae/dae/task_graph/executor.py
@@ -74,7 +74,7 @@ class AbstractTaskGraphExecutor(TaskGraphExecutor):
         """Set a precomputed result for a task."""
 
     def _in_exec_order(self, task_graph):
-        visited = set()
+        visited: set[Task] = set()
         for node in task_graph.tasks:
             yield from self._node_in_exec_order(node, visited)
 
@@ -87,8 +87,8 @@ class AbstractTaskGraphExecutor(TaskGraphExecutor):
         yield node
 
     def _check_for_cyclic_deps(self, task_graph):
-        visited = set()
-        stack = []
+        visited: set[Task] = set()
+        stack: list[Task] = []
         for node in task_graph.tasks:
             if node not in visited:
                 cycle = self._find_cycle(node, visited, stack)

--- a/dae/dae/task_graph/tests/test_cli_arguments.py
+++ b/dae/dae/task_graph/tests/test_cli_arguments.py
@@ -1,0 +1,122 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines
+import argparse
+
+import pytest
+
+from dae.task_graph import TaskGraphCli
+
+
+@pytest.mark.parametrize("argv,jobs", [
+    (["-j", "1"], 1),
+    ([], None),
+    (["-j", "100"], 100),
+    (["--jobs", "1"], 1),
+    (["--jobs", "100"], 100)
+])
+def test_cli_args_jobs(argv, jobs):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    assert args.jobs == jobs
+
+
+@pytest.mark.parametrize("argv,command", [
+    ([], "run"),
+    (["run"], "run"),
+    (["list"], "list"),
+    (["status"], "status")
+])
+def test_cli_args_command(argv, command):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    assert args.command == command
+
+
+@pytest.mark.parametrize("argv,name", [
+    ([], None),
+    (["-N", "abc"], "abc"),
+    (["--dcn", "abc"], "abc"),
+    (["--dask-cluster-name", "abc"], "abc")
+])
+def test_cli_args_dask_cluster_name(argv, name):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    assert args.dask_cluster_name == name
+
+
+@pytest.mark.parametrize("argv,filename", [
+    ([], None),
+    (["-c", "abc.yaml"], "abc.yaml"),
+    (["--dccf", "abc.yaml"], "abc.yaml"),
+    (["--dask-cluster-config-file", "abc.yaml"], "abc.yaml")
+])
+def test_cli_args_dask_cluster_config_file(argv, filename):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    assert args.dask_cluster_config_file == filename
+
+
+@pytest.mark.parametrize("argv,task_ids", [
+    ([], None),
+    (["--task-ids", "a"], ["a"]),
+    (["--task-ids", "a", "b"], ["a", "b"]),
+    (["--task-ids", "a", "b", "c"], ["a", "b", "c"]),
+    (["-t", "a"], ["a"]),
+    (["-t", "a", "b"], ["a", "b"]),
+    (["-t", "a", "b", "c"], ["a", "b", "c"]),
+])
+def test_cli_args_task_ids(argv, task_ids):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    assert args.task_ids == task_ids
+
+
+@pytest.mark.parametrize("argv,keep_going", [
+    ([], False),
+    (["--keep-going"], True),
+])
+def test_cli_args_keep_going(argv, keep_going):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    assert args.keep_going == keep_going
+
+
+@pytest.mark.parametrize("force_mode,argv,force", [
+    ("optional", [], False),
+    ("optional", ["--force"], True),
+    ("always", [], None),
+])
+def test_cli_args_force(force_mode, argv, force):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser, force_mode=force_mode)
+    args = vars(parser.parse_args(argv))
+
+    assert args.get("force") == force
+
+
+@pytest.mark.parametrize("default_task_status_dir, argv,task_status_dir", [
+    (".", [], "."),
+    ("/a/b/c", [], "/a/b/c"),
+    (".", ["-d", ".status"], ".status"),
+    (".", ["--tsd", ".status"], ".status"),
+    (".", ["--task-status-dir", ".status"], ".status"),
+])
+def test_cli_args_task_status_dir(
+        default_task_status_dir, argv, task_status_dir):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(
+        parser, default_task_status_dir=default_task_status_dir)
+    args = parser.parse_args(argv)
+
+    assert args.task_status_dir == task_status_dir

--- a/dae/dae/task_graph/tests/test_cli_executor.py
+++ b/dae/dae/task_graph/tests/test_cli_executor.py
@@ -1,0 +1,83 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines,no-member
+import argparse
+import pytest
+
+import dask.distributed
+import dask_jobqueue
+
+from dae.task_graph import TaskGraphCli
+
+
+@pytest.mark.parametrize("argv", [
+    [],
+    ["-N", "local"],
+    ["--dcn", "local"],
+    ["--dask-cluster-name", "local"],
+])
+def test_cli_named_cluster_local(mocker, argv):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+    mocker.patch(
+        "dask.distributed.LocalCluster",
+        autospec=True)
+
+    TaskGraphCli.create_executor(**vars(args))
+    dask.distributed\
+        .LocalCluster.assert_called_once_with()  # type: ignore
+
+
+@pytest.mark.parametrize("argv", [
+    ["-N", "sge_small"],
+    ["--dcn", "sge_small"],
+    ["--dask-cluster-name", "sge_small"],
+])
+def test_cli_named_cluster_sge_small(mocker, argv):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+    mocker.patch(
+        "dask_jobqueue.SGECluster",
+        autospec=True)
+
+    TaskGraphCli.create_executor(**vars(args))
+    dask_jobqueue\
+        .SGECluster.assert_called_once_with(
+            scheduler_options={"dashboard_address": ":8898"},
+            cores=1, memory="1GB", log_directory="./sge_worker_logs"
+        )  # type: ignore
+
+
+@pytest.mark.parametrize("argv", [
+    ["-N", "sge_large"],
+    ["--dcn", "sge_large"],
+    ["--dask-cluster-name", "sge_large"],
+])
+def test_cli_named_cluster_sge_large(mocker, argv):
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    args = parser.parse_args(argv)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+    mocker.patch(
+        "dask_jobqueue.SGECluster",
+        autospec=True)
+
+    TaskGraphCli.create_executor(**vars(args))
+    dask_jobqueue\
+        .SGECluster.assert_called_once_with(
+            scheduler_options={"dashboard_address": ":8898"},
+            cores=1, memory="10GB", log_directory="./sge_worker_logs"
+        )  # type: ignore
+    # dask_jobqueue\
+    #     .SGECluster.adapt.assert_called_once_with()

--- a/dae/dae/task_graph/tests/test_cli_executor.py
+++ b/dae/dae/task_graph/tests/test_cli_executor.py
@@ -1,11 +1,14 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines,no-member
 import argparse
+import textwrap
+
 import pytest
 
 import dask.distributed
 import dask_jobqueue
 
 import dae.dask.named_cluster
+from dae.testing import setup_directories
 from dae.task_graph import TaskGraphCli
 
 
@@ -112,3 +115,45 @@ def test_cli_named_cluster_slurm(mocker, argv):
     cluster_mock = dae.dask.named_cluster\
         .Client.call_args.args[0]  # type: ignore
     cluster_mock.scale.assert_called_once_with(n=10)
+
+
+@pytest.mark.parametrize("argv", [
+    ["-c"],
+    ["--dccf"],
+    ["--dask-cluster-config-file"],
+])
+def test_cli_cluster_with_config_file(mocker, argv, tmp_path):
+    setup_directories(
+        tmp_path / "cluster.yaml", textwrap.dedent("""
+        name: special
+        type: local
+        number_of_threads: 20
+        params:
+            cores: 1
+            memory: 2GB
+            scheduler_options:
+                dashboard_address: :8898
+        """)
+    )
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser)
+    argv.append(str(tmp_path / "cluster.yaml"))
+
+    args = parser.parse_args(argv)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+    mocker.patch(
+        "dask.distributed.LocalCluster",
+        autospec=True)
+
+    TaskGraphCli.create_executor(**vars(args))
+
+    dask.distributed\
+        .LocalCluster.assert_called_once_with(  # type: ignore
+            scheduler_options={"dashboard_address": ":8898"},
+            cores=1, memory="2GB")
+    cluster_mock = dae.dask.named_cluster\
+        .Client.call_args.args[0]  # type: ignore
+    cluster_mock.scale.assert_called_once_with(n=20)

--- a/dae/dae/task_graph/tests/test_cli_tools.py
+++ b/dae/dae/task_graph/tests/test_cli_tools.py
@@ -1,25 +1,51 @@
 import argparse
 
-from dae.task_graph.cli_tools import add_arguments
-from dae.task_graph.cli_tools import process_graph
-from dae.task_graph.graph import TaskGraph
+
+from dae.task_graph import TaskGraph
+from dae.task_graph import TaskGraphCli
 
 
 def test_basic_defalt_executor():
     parser = argparse.ArgumentParser(description="test_basic")
-    add_arguments(parser)
+    TaskGraphCli.add_arguments(parser)
     args = parser.parse_args([])
 
     empty_graph = TaskGraph()
-    process_graph(args, empty_graph)
+    TaskGraphCli.process_graph(args, empty_graph)
 
 
 def test_basic_sequential_executor():
     parser = argparse.ArgumentParser(description="test_basic")
-    add_arguments(parser)
+    TaskGraphCli.add_arguments(parser)
     args = parser.parse_args(["-j", "1"])
 
     empty_graph = TaskGraph()
-    process_graph(args, empty_graph)
+    TaskGraphCli.process_graph(args, empty_graph)
 
+
+def test_force_alwasy():
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser, force_mode="always")
+    args = parser.parse_args([])
+
+    assert "force" not in vars(args)
+    assert "task_status_dir" not in vars(args)
+
+
+def test_force_optional():
+    parser = argparse.ArgumentParser(description="test_basic")
+    TaskGraphCli.add_arguments(parser, force_mode="optional",
+                               default_task_status_dir="gosho")
+
+    args = parser.parse_args([])
+    assert args.force == False
+    assert args.task_status_dir == "gosho"
+
+    args = parser.parse_args(["-tsd", "pesho"])
+    assert args.force == False
+    assert args.task_status_dir == "pesho"
+
+    args = parser.parse_args(["-f"])
+    assert args.force == True
+    assert args.task_status_dir == "gosho"
 

--- a/dae/dae/task_graph/tests/test_cli_tools.py
+++ b/dae/dae/task_graph/tests/test_cli_tools.py
@@ -1,0 +1,25 @@
+import argparse
+
+from dae.task_graph.cli_tools import add_arguments
+from dae.task_graph.cli_tools import process_graph
+from dae.task_graph.graph import TaskGraph
+
+
+def test_basic_defalt_executor():
+    parser = argparse.ArgumentParser(description="test_basic")
+    add_arguments(parser)
+    args = parser.parse_args([])
+
+    empty_graph = TaskGraph()
+    process_graph(args, empty_graph)
+
+
+def test_basic_sequential_executor():
+    parser = argparse.ArgumentParser(description="test_basic")
+    add_arguments(parser)
+    args = parser.parse_args(["-j", "1"])
+
+    empty_graph = TaskGraph()
+    process_graph(args, empty_graph)
+
+

--- a/dae/dae/task_graph/tests/test_cli_tools.py
+++ b/dae/dae/task_graph/tests/test_cli_tools.py
@@ -12,7 +12,7 @@ def test_basic_defalt_executor():
     args = parser.parse_args([])
 
     empty_graph = TaskGraph()
-    TaskGraphCli.process_graph(empty_graph, args)
+    TaskGraphCli.process_graph(empty_graph, **vars(args))
 
 
 def test_basic_sequential_executor():
@@ -21,7 +21,7 @@ def test_basic_sequential_executor():
     args = parser.parse_args(["-j", "1"])
 
     empty_graph = TaskGraph()
-    TaskGraphCli.process_graph(empty_graph, args)
+    TaskGraphCli.process_graph(empty_graph, **vars(args))
 
 
 def test_force_alwasy():
@@ -42,7 +42,7 @@ def test_force_optional():
     assert not args.force
     assert args.task_status_dir == "gosho"
 
-    args = parser.parse_args(["-tsd", "pesho"])
+    args = parser.parse_args(["-d", "pesho"])
     assert not args.force
     assert args.task_status_dir == "pesho"
 

--- a/dae/dae/task_graph/tests/test_cli_tools.py
+++ b/dae/dae/task_graph/tests/test_cli_tools.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines
 import argparse
 
 
@@ -38,14 +39,13 @@ def test_force_optional():
                                default_task_status_dir="gosho")
 
     args = parser.parse_args([])
-    assert args.force == False
+    assert not args.force
     assert args.task_status_dir == "gosho"
 
     args = parser.parse_args(["-tsd", "pesho"])
-    assert args.force == False
+    assert not args.force
     assert args.task_status_dir == "pesho"
 
     args = parser.parse_args(["-f"])
-    assert args.force == True
+    assert args.force
     assert args.task_status_dir == "gosho"
-

--- a/dae/dae/task_graph/tests/test_cli_tools.py
+++ b/dae/dae/task_graph/tests/test_cli_tools.py
@@ -12,7 +12,7 @@ def test_basic_defalt_executor():
     args = parser.parse_args([])
 
     empty_graph = TaskGraph()
-    TaskGraphCli.process_graph(args, empty_graph)
+    TaskGraphCli.process_graph(empty_graph, args)
 
 
 def test_basic_sequential_executor():
@@ -21,7 +21,7 @@ def test_basic_sequential_executor():
     args = parser.parse_args(["-j", "1"])
 
     empty_graph = TaskGraph()
-    TaskGraphCli.process_graph(args, empty_graph)
+    TaskGraphCli.process_graph(empty_graph, args)
 
 
 def test_force_alwasy():

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -96,6 +96,7 @@ setuptools.setup(
     stats_liftover=dae.tools.stats_liftover:main
 
     import_tools=dae.import_tools.cli:main
+    task_graph_demo=dae.task_graph.demo_graphs_cli:main
     """,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -96,7 +96,6 @@ setuptools.setup(
     stats_liftover=dae.tools.stats_liftover:main
 
     import_tools=dae.import_tools.cli:main
-    task_graph_demo=dae.task_graph.demo_graphs_cli:main
     """,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,6 @@ dependencies:
   - djangorestframework=3.13.1
   - django-oauth-toolkit=2.2.0
   - openjdk=8.0.312
-  - hadoop=3.1.2
   - deprecation=2.1.0
   - toml=0.10.2
   - cerberus=1.3.4
@@ -52,3 +51,5 @@ dependencies:
   - dask-kubernetes=2022.12.0
   - tqdm=4.64.0
   - markdown2=2.4.0
+  # comment when on mac
+  - hadoop=3.1.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,10 +32,16 @@ ignore_missing_imports = True
 [mypy-dask.distributed.*]
 ignore_missing_imports = True
 
+[mypy-dask_kubernetes.*]
+ignore_missing_imports = True
+
 [mypy-dask.*]
 ignore_missing_imports = True
 
 [mypy-dask_sql.*]
+ignore_missing_imports = True
+
+[mypy-dask_jobqueue.*]
 ignore_missing_imports = True
 
 [mypy-rest_framework]


### PR DESCRIPTION
## Background

We have a task graph abstraction and executors that execute tasks from these task graphs. We want to use these abstractions in various command line tools - import tools, GRR manage, etc.

We need a common infrastructure for executing tasks from task graphs. 

This work was started by @iossifov and was integrated by @svetlin-mladenov.

## Aim

To have a set of helper functions that allow embedding task graph execution in command line tools.

## Implementation

There is a `cli_tools.TaskGraphCli` class that can:
- add parameters to existing `argparse` argument parser
- create an executor from the parameters collected from the argument parser
- process a task graph in accordance with the parameters collected from the argument parser

Helper functions to execute `run` and `status` commands are added to `dae.task_graph.executor` module.

**Why it's implemented the way it is? What alternative implementations have you
considered and why you chose this one?**

The `dae.dask.client_factory` module is deprecated and should be removed soon.
