### PR TITLE
Add named_cluster.yaml to dae setup.py

### DIFF
--- a/dae/setup.py
+++ b/dae/setup.py
@@ -17,9 +17,10 @@ setuptools.setup(
     packages=setuptools.find_packages(
         where=".", exclude=["dae.docs", "dae.tests", "*.tests.*", "*.tests", ],
     ),
-    # include_package_data=True,
+    include_package_data=True,
     package_data={
         "dae": ["py.typed"],
+        "dae.dask": ["named_cluster.yaml"],
     },
     scripts=[
         "dae/tools/impala_parquet_loader.py",


### PR DESCRIPTION
## Background

The GPF E2E build began failing 3 days ago due to not being able to find `dae/dask/named_cluster.yaml` in the conda package.

## Aim

Add the yaml to the conda package.

## Implementation

Added to `dae/setup.py` as package data
