### PR TITLE
Reduce effect_annotation module excessive logging

### DIFF
--- a/dae/dae/effect_annotation/annotation_request.py
+++ b/dae/dae/effect_annotation/annotation_request.py
@@ -38,28 +38,11 @@ class BaseAnnotationRequest:
                 if region.start <= end <= region.stop:
                     return end - start
                 length = region.stop - start + 1
-                self.logger.debug(
-                    "start len %d %d-%d", length, start, region.stop
-                )
             else:
                 length += region.stop - region.start + 1
-                self.logger.debug(
-                    "total %d + len %d %d-%d",
-                    length,
-                    region.stop - region.start + 1,
-                    region.stop,
-                    region.start - 1,
-                )
 
             if region.start <= end <= region.stop:
                 length -= region.stop - end + 1
-                self.logger.debug(
-                    "total %d - len %d %d-%d",
-                    length,
-                    region.stop - end + 1,
-                    region.stop,
-                    end - 1,
-                )
                 break
         return length
 
@@ -75,8 +58,6 @@ class BaseAnnotationRequest:
         return prot_pos // 3 + 1
 
     def _get_sequence(self, start_position, end_position):
-        self.logger.debug("_get_sequence %d-%d", start_position, end_position)
-
         if end_position < start_position:
             return ""
 
@@ -101,9 +82,6 @@ class BaseAnnotationRequest:
 
     def get_coding_right(self, pos, length, index):
         """Construct conding sequence to the right of a position."""
-        self.logger.debug(
-            "get_coding_right pos:%d len:%d index:%d", pos, length, index
-        )
         if length <= 0:
             return ""
 
@@ -132,9 +110,6 @@ class BaseAnnotationRequest:
 
     def get_coding_left(self, pos, length, index):
         """Return coding sequence to the left of a position."""
-        self.logger.debug(
-            "get_coding_left pos:%d len:%d index:%d", pos, length, index
-        )
         if length <= 0:
             return ""
 
@@ -231,10 +206,6 @@ class PositiveStrandAnnotationRequest(BaseAnnotationRequest):
                 length += position - region.start
                 break
             length += region.stop - region.start + 1
-
-        self.logger.debug(
-            "get_coding_nucleotide_position pos=%d len=%d", position, length
-        )
         return length
 
     def get_protein_position(self):
@@ -275,7 +246,6 @@ class PositiveStrandAnnotationRequest(BaseAnnotationRequest):
             return 0
         start_pos = max(self.transcript_model.cds[0], reg.start)
         frame = (pos - start_pos + reg.frame) % 3
-        self.logger.debug("frame %d for pos=%s", frame, pos)
         return frame
 
     def get_codons(self):
@@ -303,10 +273,6 @@ class PositiveStrandAnnotationRequest(BaseAnnotationRequest):
             self.variant.position + len(self.variant.reference),
             length_alt,
             index,
-        )
-
-        self.logger.debug(
-            "ref codons=%s, alt codons=%s", ref_codons, alt_codons
         )
         return ref_codons, alt_codons
 
@@ -344,10 +310,6 @@ class NegativeStrandAnnotationRequest(BaseAnnotationRequest):
                 length += region.stop - position
                 break
             length += region.stop - region.start + 1
-
-        self.logger.debug(
-            "get_coding_nucleotide_position pos=%d len=%d", position, length
-        )
         return length
 
     def get_protein_position(self):
@@ -389,7 +351,6 @@ class NegativeStrandAnnotationRequest(BaseAnnotationRequest):
             return 0
         stop_pos = min(self.transcript_model.cds[1], reg.stop)
         frame = (stop_pos - pos + reg.frame) % 3
-        self.logger.debug("frame %d for pos=%s", frame, pos)
         return frame
 
     def get_codons(self):
@@ -407,25 +368,9 @@ class NegativeStrandAnnotationRequest(BaseAnnotationRequest):
         length = last_position - pos + 1
         length += self.get_nucleotides_count_to_full_codon(length + frame)
 
-        self.logger.debug(
-            "last_position=%d, length=%d index=%d pos=%d cds=%d",
-            last_position,
-            length,
-            index,
-            self.variant.position,
-            self.transcript_model.cds[0],
-        )
-
         coding_before_pos = self.get_coding_left(last_position, length, index)
         coding_after_pos = self.get_coding_right(
             last_position + 1, frame, index
-        )
-
-        self.logger.debug(
-            "coding_before_pos=%s, coding_after_pos=%s frame=%s",
-            coding_before_pos,
-            coding_after_pos,
-            frame,
         )
 
         ref_codons = coding_before_pos + coding_after_pos
@@ -440,21 +385,6 @@ class NegativeStrandAnnotationRequest(BaseAnnotationRequest):
             + alt_codons
         )
 
-        self.logger.debug(
-            "%d-%d %d-%d->%d-%d %d-%d",
-            last_position,
-            last_position - length,
-            last_position + 1,
-            last_position + 1 + frame,
-            pos,
-            pos - length_alt,
-            last_position + 1,
-            last_position + 1 + frame,
-        )
-
-        self.logger.debug(
-            "ref codons=%s, alt codons=%s", ref_codons, alt_codons
-        )
         return ref_codons, alt_codons
 
     @staticmethod
@@ -480,9 +410,6 @@ class NegativeStrandAnnotationRequest(BaseAnnotationRequest):
 
     def cod2aa(self, codon):
         complement_codon = self.complement(codon[::-1])
-        self.logger.debug(
-            "complement codon %s for codon %s", complement_codon, codon
-        )
         return BaseAnnotationRequest.cod2aa(self, complement_codon)
 
     def get_amino_acids(self):

--- a/dae/dae/effect_annotation/effect_checkers/frame_shift.py
+++ b/dae/dae/effect_annotation/effect_checkers/frame_shift.py
@@ -1,11 +1,7 @@
-import logging
 from ..effect import EffectFactory
 
 
 class FrameShiftEffectChecker:
-    def __init__(self):
-        self.logger = logging.getLogger(__name__)
-
     def create_effect(self, request, change_length):
         if change_length > 0:
             if change_length % 3 == 0:
@@ -68,26 +64,5 @@ class FrameShiftEffectChecker:
             if len(request.variant.reference) == 0:
                 stop += 1
 
-            self.logger.debug(
-                "frameshift %d<=%d<=%d cds:%d-%d exon:%d-%d",
-                start,
-                request.variant.position,
-                stop,
-                request.transcript_model.cds[0],
-                request.transcript_model.cds[1],
-                j.start,
-                j.stop,
-            )
-
             if start <= request.variant.position <= stop:
-                self.logger.debug(
-                    "fs detected %d<=%d-%d<=%d cds:%d-%d",
-                    start,
-                    request.variant.position,
-                    request.variant.ref_position_last,
-                    stop,
-                    request.transcript_model.cds[0],
-                    request.transcript_model.cds[1],
-                )
-
                 return self.create_effect(request, length)

--- a/dae/dae/effect_annotation/effect_checkers/intron.py
+++ b/dae/dae/effect_annotation/effect_checkers/intron.py
@@ -1,4 +1,3 @@
-import logging
 from ..effect import EffectFactory
 
 
@@ -7,8 +6,6 @@ class IntronicEffectChecker:
         self.splice_site_length = splice_site_length
 
     def get_effect(self, request):
-        logger = logging.getLogger(__name__)
-
         coding_regions = request.CDS_regions()
         prev = coding_regions[0].stop
 
@@ -16,24 +13,11 @@ class IntronicEffectChecker:
 
         intron_regions_before_coding = 0
         for j in request.transcript_model.exons:
-            logger.debug(
-                "reg %d-%d cds:%d",
-                j.start,
-                j.stop,
-                request.transcript_model.cds[0],
-            )
             if request.transcript_model.cds[0] <= j.stop:
                 break
             intron_regions_before_coding += 1
 
         for i, j in enumerate(coding_regions):
-            logger.debug(
-                "pos: %d-%d checking intronic region %d-%d",
-                request.variant.position,
-                last_position,
-                prev,
-                j.start,
-            )
             if prev < request.variant.position and last_position < j.start:
                 return EffectFactory.create_intronic_effect(
                     "intron",

--- a/dae/dae/effect_annotation/effect_checkers/splice_site.py
+++ b/dae/dae/effect_annotation/effect_checkers/splice_site.py
@@ -1,11 +1,9 @@
-import logging
 from ..effect import EffectFactory
 
 
 class SpliceSiteEffectChecker:
     def __init__(self, splice_site_length=2):
         self.splice_site_length = splice_site_length
-        self.logger = logging.getLogger(__name__)
 
     def get_effect(self, request):
         coding_regions = request.transcript_model.exons
@@ -18,15 +16,6 @@ class SpliceSiteEffectChecker:
             if prev is None:
                 prev = j.stop
                 continue
-
-            self.logger.debug(
-                "pos: %d-%d checking intronic region %d-%d %d",
-                request.variant.position,
-                last_position,
-                prev,
-                j.start,
-                j.stop,
-            )
 
             if (
                 request.variant.position < prev + self.splice_site_length + 1

--- a/dae/dae/effect_annotation/effect_checkers/start_loss.py
+++ b/dae/dae/effect_annotation/effect_checkers/start_loss.py
@@ -1,22 +1,8 @@
-import logging
 from ..effect import EffectFactory
 
 
 class StartLossEffectChecker:
     def get_effect(self, request):
-        logger = logging.getLogger(__name__)
-
-        last_position = request.variant.position + len(
-            request.variant.reference
-        )
-
-        logger.debug(
-            "position check %d <= %d-%d <= %d",
-            request.transcript_model.cds[0],
-            request.variant.position,
-            last_position,
-            request.transcript_model.cds[0] + 2,
-        )
         if request.is_start_codon_affected():
             return EffectFactory.create_effect_with_prot_pos(
                 "noStart", request

--- a/dae/dae/effect_annotation/effect_checkers/stop_loss.py
+++ b/dae/dae/effect_annotation/effect_checkers/stop_loss.py
@@ -1,22 +1,8 @@
-import logging
 from ..effect import EffectFactory
 
 
 class StopLossEffectChecker:
     def get_effect(self, request):
-        logger = logging.getLogger(__name__)
-        last_position = request.variant.position + len(
-            request.variant.reference
-        )
-
-        logger.debug(
-            "position check %d <= %d-%d <= %d",
-            request.transcript_model.cds[1] - 2,
-            request.variant.position,
-            last_position,
-            request.transcript_model.cds[0],
-        )
-
         if request.is_stop_codon_affected():
             try:
                 ref_aa, alt_aa = request.get_amino_acids()
@@ -24,8 +10,6 @@ class StopLossEffectChecker:
                 if len(ref_aa) == len(alt_aa):
                     if alt_aa[ref_aa.index("End")] == "End":
                         return
-
-                logger.debug("ref aa=%s, alt aa=%s", ref_aa, alt_aa)
 
             except IndexError:
                 pass


### PR DESCRIPTION
## Background

The E2E build in Jenkins has a log of over 140MB, causing the browser to lag when inspecting it. Most of the logging bloat originates from the `effect_annotation` module. 

## Aim

Reduce logging bloat so that E2E Jenkins logs are usable.

## Implementation

Delete the most frequently encountered logging lines.

## Related issues

closes https://github.com/iossifovlab/gpf-e2e/issues/27
