### PR TITLE
Problems while deploying schema2 study on seqclust

### DIFF
--- a/dae/dae/inmemory_storage/raw_variants.py
+++ b/dae/dae/inmemory_storage/raw_variants.py
@@ -324,10 +324,15 @@ class RawFamilyVariants(abc.ABC):
             ] = variant_type_query.transform_tree_to_matcher(parsed)
 
         return_reference = kwargs.get("return_reference", False)
+        seen = kwargs.get("seen", set())
 
         def filter_func(sv):
             if sv is None:
                 return None
+            if sv.svuid in seen:
+                return None
+            seen.add(sv.svuid)
+
             if not cls.filter_summary_variant(sv, **kwargs):
                 return None
 
@@ -428,11 +433,14 @@ class RawFamilyVariants(abc.ABC):
 
         return_reference = kwargs.get("return_reference", False)
         return_unknown = kwargs.get("return_unknown", False)
+        seen = kwargs.get("seen", set())
 
         def filter_func(v):
             try:
-                if v is None:
+                if v is None or v.fvuid in seen:
                     return None
+                seen.add(v.fvuid)
+
                 if v.is_unknown() and not return_unknown:
                     return None
 

--- a/dae/dae/query_variants/sql/schema2/base_variants.py
+++ b/dae/dae/query_variants/sql/schema2/base_variants.py
@@ -163,7 +163,8 @@ class SqlSchema2Variants(abc.ABC):
             frequency_filter=frequency_filter,
             return_reference=return_reference,
             return_unknown=return_unknown,
-            limit=limit)
+            limit=limit,
+            seen=set())
 
         runner.adapt(filter_func)
 
@@ -248,7 +249,8 @@ class SqlSchema2Variants(abc.ABC):
             frequency_filter=frequency_filter,
             return_reference=return_reference,
             return_unknown=return_unknown,
-            limit=limit)
+            limit=limit,
+            seen=set())
 
         runner.adapt(filter_func)
 

--- a/dae/dae/tools/gpf_instance_adjustments.py
+++ b/dae/dae/tools/gpf_instance_adjustments.py
@@ -86,8 +86,13 @@ class AdjustImpalaStorageCommand(AdjustmentsCommand):
         self.impala_hosts = impala_hosts
 
     def execute(self):
-        storages = self.config["storage"]
-        storage = storages.get(self.storage_id)
+        storages = self.config["genotype_storage"]["storages"]
+        storage = None
+        for current in storages:
+            if current["id"] == self.storage_id:
+                storage = current
+                break
+
         if storage is None:
             logger.error(
                 "unable to find storage (%s) in instance at %s",

--- a/dae/dae/tools/gpf_instance_adjustments.py
+++ b/dae/dae/tools/gpf_instance_adjustments.py
@@ -209,11 +209,18 @@ class EnableDisableStudies(StudyConfigsAdjustmentCommand):
         if gpfjs is not None:
             selected_genotype_data = gpfjs.get("selected_genotype_data")
             if selected_genotype_data:
-                result = []
-                for study_id in selected_genotype_data:
-                    if study_id in self.study_ids:
-                        continue
-                    result.append(study_id)
+                if self.enabled:
+                    result = selected_genotype_data
+                    for study_id in self.study_ids:
+                        if study_id not in result:
+                            result.append(study_id)
+                else:
+                    result = []
+                    for study_id in selected_genotype_data:
+                        if study_id in self.study_ids:
+                            continue
+                        result.append(study_id)
+
                 gpfjs["selected_genotype_data"] = result
 
     def adjust_study(self, study_id, study_config):


### PR DESCRIPTION
## Background

While deploying `SFARI_SPARK_WES_1_schema2` on `seqclust` I encountered some issues that I wanted to address.

There were two types of problems:
- `gpf_instance_adjustment` command was broken for updating impala genotype storage and for study enable.
- The GPF genotype browser queries were extremely slow.

## Implementation

I have updated the `gpf_instance_adjustment` to properly handle the impala genotype storage and fixed the enable study subcommand.

I have changed the query builder to stop using `SELECT DISTINCT` and to use just `SELECT` when searching for variants. I had to make sure that the repeating variants are filtered out by `RawVariants` helpers.
