### PR TITLE
Strip empty value in genomic scores histogram bars and cast them to float

### DIFF
--- a/dae/dae/gene/scores.py
+++ b/dae/dae/gene/scores.py
@@ -82,7 +82,7 @@ class GenomicScoresDb:
                 assert set(df.columns) == set(["bars", "bins"]), \
                     "Incorrect CSV file"
                 bins = df["bins"].values
-                bars = df["bars"].values
+                bars = list(map(float, filter(None, df["bars"].values)))
                 hist.bins = bins
                 hist.bars = bars
 


### PR DESCRIPTION
## Background

The frontend's histogram component would not render the Y scale for the bars correctly. It was discovered that the backend was sending the bars as string values, which was the cause of the error. The root of the problem was the last empty value for the histogram bars, which prevented pandas from casting them to the correct type.

## Aim

Remove the empty value and cast the bars' values to float.

## Implementation

Done directly after loading the pandas dataframe as it is the simplest way.

## Related issues

Closes #384 
