### PR TITLE
Import only generate parquets

### DIFF
--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -183,7 +183,7 @@ class ImpalaSchema1ImportStorage(ImportStorage):
             )
             bucket_tasks.append(task)
 
-        if project.has_destination() or project.has_gpf_instance():
+        if project.has_genotype_storage():
             hdfs_task = graph.create_task(
                 "Copying to HDFS", self._do_load_in_hdfs,
                 [project], [pedigree_task] + bucket_tasks)

--- a/dae/dae/impala_storage/schema2/schema2_import_storage.py
+++ b/dae/dae/impala_storage/schema2/schema2_import_storage.py
@@ -148,7 +148,7 @@ class Schema2ImportStorage(ImportStorage):
             )
             bucket_tasks.append(task)
 
-        if project.has_destination():
+        if project.has_genotype_storage():
             hdfs_task = graph.create_task(
                 "Copying to HDFS", self._do_load_in_hdfs,
                 [project], [pedigree_task] + bucket_tasks)

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -313,20 +313,24 @@ class ImportProject():
         # FIXME: this method should check if the input has variants
         return True
 
-    def has_gpf_instance(self):
-        # FIXME: this method should check if project has access to a
-        # GPF instance - configured in the project or through the
-        # environment variable DAE_DB_DIR
-        return True
-
     @property
     def study_id(self):
         return self.import_config["id"]
 
+    def has_genotype_storage(self):
+        """Return if a genotype storage can be created."""
+        if not self._has_destination():
+            return True  # Use default genotype storage
+        if "storage_type" not in self.import_config["destination"]:
+            return True  # External genotype storage
+        if len(self.import_config["destination"]) > 1:
+            return True  # Embedded configuration
+        return False
+
     def get_genotype_storage(self):
         """Find, create and return the correct genotype storage."""
         explicit_config = (
-            self.has_destination()
+            self._has_destination()
             and "storage_id" not in self.import_config["destination"]
         )
         if not explicit_config:
@@ -343,7 +347,7 @@ class ImportProject():
         return registry.register_storage_config(
             self.import_config["destination"])
 
-    def has_destination(self) -> bool:
+    def _has_destination(self) -> bool:
         """Return if there is a *destination* section in the import config."""
         return "destination" in self.import_config
 
@@ -369,7 +373,7 @@ class ImportProject():
         return variants_loader
 
     def _storage_type(self) -> str:
-        if not self.has_destination():
+        if not self._has_destination():
             # get default storage schema from GPF instance
             gpf_instance = self.get_gpf_instance()
             storage: GenotypeStorage = gpf_instance\

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -325,6 +325,8 @@ class ImportProject():
             return True  # External genotype storage
         if len(self.import_config["destination"]) > 1:
             return True  # Embedded configuration
+        # storage_type is the only property in destination
+        # this is a special case and we assume there is no genotype storage
         return False
 
     def get_genotype_storage(self):

--- a/dae/dae/import_tools/tests/resources/cnv_import/import_config.yaml
+++ b/dae/dae/import_tools/tests/resources/cnv_import/import_config.yaml
@@ -22,4 +22,4 @@ partition_description:
     rare_boundary: 5
 
 destination:
-  storage_id: genotype_impala_2
+  storage_type: impala2

--- a/dae/dae/import_tools/tests/resources/denovo_import/import_config.yaml
+++ b/dae/dae/import_tools/tests/resources/denovo_import/import_config.yaml
@@ -27,4 +27,4 @@ partition_description:
 
 
 destination:
-  storage_id: genotype_impala_2
+  storage_type: impala2

--- a/dae/dae/import_tools/tests/resources/import_task_bin_size/import_config.yaml
+++ b/dae/dae/import_tools/tests/resources/import_task_bin_size/import_config.yaml
@@ -29,4 +29,4 @@ partition_description:
     rare_boundary: 5
 
 destination:
-  storage_id: genotype_impala_2
+  storage_type: impala2

--- a/dae/dae/import_tools/tests/resources/vcf_import/import_config.yaml
+++ b/dae/dae/import_tools/tests/resources/vcf_import/import_config.yaml
@@ -20,4 +20,4 @@ partition_description:
     rare_boundary: 5
 
 destination:
-  storage_id: genotype_impala_2
+  storage_type: impala2

--- a/dae/dae/import_tools/tests/resources/vcf_import/import_config_add_chrom_prefix.yaml
+++ b/dae/dae/import_tools/tests/resources/vcf_import/import_config_add_chrom_prefix.yaml
@@ -21,4 +21,4 @@ partition_description:
     rare_boundary: 5
 
 destination:
-  storage_id: genotype_impala_2
+  storage_type: impala2

--- a/dae/dae/import_tools/tests/test_cli.py
+++ b/dae/dae/import_tools/tests/test_cli.py
@@ -16,7 +16,11 @@ def simple_study_dir(tmpdir, gpf_instance_grch38, mocker, resources_dir):
     config_fn = str(tmpdir / "import_config.yaml")
     with open(config_fn, "rt") as file:
         config = yaml.safe_load(file.read())
-    del config["destination"]
+    config["destination"] = {
+        "id": "genotype_inmemory",
+        "storage_type": "inmemory",
+        "dir": str(tmpdir),
+    }  # don't import into impala
     with open(config_fn, "wt") as file:
         yaml.safe_dump(config, file)
 
@@ -28,12 +32,12 @@ def simple_study_dir(tmpdir, gpf_instance_grch38, mocker, resources_dir):
 
 
 def test_run(simple_study_dir):
-    cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
+    assert cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
 
 
 def test_list(simple_study_dir):
-    cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
-    cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
-    cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
-    cli.main([str(simple_study_dir / "import_config.yaml"), "list",
-              "--verbose"])
+    assert cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
+    assert cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
+    assert cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
+    assert cli.main([str(simple_study_dir / "import_config.yaml"), "list",
+                     "--verbose"])

--- a/dae/dae/import_tools/tests/test_cli.py
+++ b/dae/dae/import_tools/tests/test_cli.py
@@ -4,10 +4,17 @@ import shutil
 import yaml
 import pytest
 from dae.import_tools import import_tools, cli
+from dae.testing.alla_import import alla_gpf
 
 
 @pytest.fixture()
-def simple_study_dir(tmpdir, gpf_instance_grch38, mocker, resources_dir):
+def gpf_instance(tmp_path_factory):
+    root_path = tmp_path_factory.mktemp(__name__)
+    return alla_gpf(root_path)
+
+
+@pytest.fixture()
+def simple_study_dir(tmpdir, gpf_instance, mocker, resources_dir):
     shutil.copytree(
         resources_dir / "vcf_import", tmpdir, dirs_exist_ok=True
     )
@@ -25,7 +32,7 @@ def simple_study_dir(tmpdir, gpf_instance_grch38, mocker, resources_dir):
         yaml.safe_dump(config, file)
 
     mocker.patch.object(import_tools.ImportProject, "get_gpf_instance",
-                        return_value=gpf_instance_grch38)
+                        return_value=gpf_instance)
     mocker.patch.object(import_tools.ImportProject, "work_dir",
                         new=str(tmpdir))
     return tmpdir

--- a/dae/dae/import_tools/tests/test_import_configs.py
+++ b/dae/dae/import_tools/tests/test_import_configs.py
@@ -13,9 +13,8 @@ from dae.configuration.gpf_config_parser import GPFConfigParser
 
 @pytest.mark.parametrize("config_dir", ["denovo_import", "vcf_import",
                                         "cnv_import", "dae_import"])
-@pytest.mark.parametrize("schema", ["schema1", "schema2"])
 def test_parquet_files_are_generated(tmpdir, gpf_instance_2019, config_dir,
-                                     mocker, resources_dir, schema):
+                                     mocker, resources_dir):
     input_dir = resources_dir / config_dir
     config_fn = input_dir / "import_config.yaml"
 

--- a/dae/dae/import_tools/tests/test_import_project.py
+++ b/dae/dae/import_tools/tests/test_import_project.py
@@ -87,3 +87,30 @@ def test_tags_on_by_default(resources_dir):
     _, params = project.get_pedigree_params()
     assert "ped_tags" in params
     assert params["ped_tags"] is True
+
+
+@pytest.mark.parametrize("import_config, expected", [
+    ({"input": {}}, True),
+    ({
+        "input": {},
+        "destination": {}
+    }, True),
+    ({
+        "input": {},
+        "destination": {"storage_id": "storage"}
+    }, True),
+    ({
+        "input": {},
+        "destination": {
+            "storage_type": "schema2",
+            "hdfs": {},
+        },
+    }, True),
+    ({
+        "input": {},
+        "destination": {"storage_type": "schema2"}
+    }, False),
+])
+def test_has_genotype_storage(import_config, expected):
+    project = ImportProject.build_from_config(import_config)
+    assert project.has_genotype_storage() == expected


### PR DESCRIPTION
## Background

We want to be able to generate just parquet files without actually importing them into impala. This is useful for actual imports and for optimizing the tests.

## Implementation

The implementation is very simple. if the destination section in the import configuration is configured with just a `storage_type` and no other information then we generate the parquet files but don't import into impala. The copy-to-hdfs and import-into-impala steps are not generated and added to the task graph.
