### PR TITLE
Handling for chromosome only region queries #707

### DIFF
--- a/dae/dae/inmemory_storage/raw_variants.py
+++ b/dae/dae/inmemory_storage/raw_variants.py
@@ -121,6 +121,8 @@ class RawFamilyVariants(abc.ABC):
             end_position = v.end_position
 
         for reg in regions:
+            if reg.start is None and reg.stop is None:
+                return reg.chrom == v.chromosome
             if (
                 reg.chrom == v.chromosome
                 and (

--- a/dae/dae/query_variants/sql/schema1/tests/test_query_builders.py
+++ b/dae/dae/query_variants/sql/schema1/tests/test_query_builders.py
@@ -1,0 +1,24 @@
+import pytest
+from dae.query_variants.sql.schema1.base_query_builder import BaseQueryBuilder
+from dae.utils.regions import Region
+
+
+@pytest.fixture()
+def query_builder():
+    return BaseQueryBuilder
+
+
+def test_regions(query_builder):
+    query = query_builder._build_regions_where(
+        query_builder, [Region("X", 5, 15)]
+    )
+    assert ("(`chromosome` = 'X' AND ((`position` >= 5 AND `position` <= 15)"
+            + " OR (COALESCE(end_position, -1) >= 5"
+            + " AND COALESCE(end_position, -1) <= 15)"
+            + " OR (5 >= `position` AND 15 <= COALESCE(end_position, -1))))"
+            ) in query
+
+    query = query_builder._build_regions_where(query_builder, [
+        Region('13')
+    ])
+    assert "(`chromosome` = '13')" in query

--- a/dae/dae/query_variants/sql/schema1/tests/test_query_builders.py
+++ b/dae/dae/query_variants/sql/schema1/tests/test_query_builders.py
@@ -19,6 +19,6 @@ def test_regions(query_builder):
             ) in query
 
     query = query_builder._build_regions_where(query_builder, [
-        Region('13')
+        Region("13")
     ])
     assert "(`chromosome` = '13')" in query

--- a/dae/dae/query_variants/sql/schema2/tests/test_query_builders.py
+++ b/dae/dae/query_variants/sql/schema2/tests/test_query_builders.py
@@ -155,6 +155,6 @@ def test_regions(query_builder):
     assert "15 >= COALESCE(`end_position`, `position`)" in query
 
     query = query_builder._build_regions_where([
-        Region('13')
+        Region("13")
     ])
     assert "(`chromosome` = '13')" in query

--- a/dae/dae/query_variants/sql/schema2/tests/test_query_builders.py
+++ b/dae/dae/query_variants/sql/schema2/tests/test_query_builders.py
@@ -149,7 +149,12 @@ def test_limit(query_builder):
 
 
 def test_regions(query_builder):
-    query = query_builder.build_query(regions=[Region("X", 5, 15)])
+    query = query_builder._build_regions_where(regions=[Region("X", 5, 15)])
     assert "`chromosome` = 'X'" in query
     assert "5 <= `position`" in query
     assert "15 >= COALESCE(`end_position`, `position`)" in query
+
+    query = query_builder._build_regions_where([
+        Region('13')
+    ])
+    assert "(`chromosome` = '13')" in query

--- a/wdae/wdae/studies/tests/test_study_wrapper_queries.py
+++ b/wdae/wdae/studies/tests/test_study_wrapper_queries.py
@@ -387,6 +387,27 @@ def test_query_family_filters(iossifov_2014_wrappers, wrapper_type):
     assert len(variants) == 15
 
 
+@pytest.mark.parametrize("wrapper_type", ["local", "remote"])
+def test_query_study_filters(iossifov_2014_wrappers, wrapper_type):
+    study_wrapper = iossifov_2014_wrappers[wrapper_type]
+    query = {
+        "studyFilters": ["iossifov_2014"],
+        "regions": ["12"]
+    }
+
+    variants = list(study_wrapper.query_variants_wdae(
+        query, [{"source": "location"}])
+    )
+
+    assert len(variants) == 2
+
+    variants = list(study_wrapper.query_variants_wdae(
+        {"studyFilters": ["iossifov_2014"]}, [{"source": "location"}])
+    )
+
+    assert len(variants) == 16
+
+
 @pytest.mark.parametrize(
     "wrapper_type",
     [


### PR DESCRIPTION
## Background

Currently, the region filter requires positions in order to get the variants between them. There is no support for region filtering on a whole chromosome.

## Aim

Provide support for handling chromosome filtering in region filter.

## Implementation

Linked with front-end issue #707