### PR TITLE
Dummy task for all parquet generation

### DIFF
--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -183,10 +183,15 @@ class ImpalaSchema1ImportStorage(ImportStorage):
             )
             bucket_tasks.append(task)
 
+        # dummy task used for running the parquet generation w/o impala import
+        all_parquet_task = graph.create_task(
+            "Parquet Tasks", lambda: None, [], bucket_tasks
+        )
+
         if project.has_genotype_storage():
             hdfs_task = graph.create_task(
                 "Copying to HDFS", self._do_load_in_hdfs,
-                [project], [pedigree_task] + bucket_tasks)
+                [project], [pedigree_task, all_parquet_task])
 
             impala_task = graph.create_task(
                 "Importing into Impala", self._do_load_in_impala,

--- a/dae/dae/impala_storage/schema2/schema2_import_storage.py
+++ b/dae/dae/impala_storage/schema2/schema2_import_storage.py
@@ -148,10 +148,15 @@ class Schema2ImportStorage(ImportStorage):
             )
             bucket_tasks.append(task)
 
+        # dummy task used for running the parquet generation w/o impala import
+        all_parquet_task = graph.create_task(
+            "Parquet Tasks", lambda: None, [], bucket_tasks
+        )
+
         if project.has_genotype_storage():
             hdfs_task = graph.create_task(
                 "Copying to HDFS", self._do_load_in_hdfs,
-                [project], [pedigree_task] + bucket_tasks)
+                [project], [pedigree_task, all_parquet_task])
 
             impala_task = graph.create_task(
                 "Importing into Impala", self._do_load_in_impala,

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -33,7 +33,9 @@ def main(argv=None):
     task_graph = storage.generate_import_task_graph(project)
     task_graph.input_files.extend(project.config_filenames)
 
-    return TaskGraphCli.process_graph(task_graph, **vars(args))
+    if TaskGraphCli.process_graph(task_graph, **vars(args)):
+        return 0
+    return 1
 
 
 def run_with_project(project, executor=SequentialExecutor()):

--- a/dae/dae/import_tools/tests/test_cli.py
+++ b/dae/dae/import_tools/tests/test_cli.py
@@ -39,12 +39,13 @@ def simple_study_dir(tmpdir, gpf_instance, mocker, resources_dir):
 
 
 def test_run(simple_study_dir):
-    assert cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
+    import_config_fn = str(simple_study_dir / "import_config.yaml")
+    assert cli.main([import_config_fn, "-j", "1"]) == 0
 
 
 def test_list(simple_study_dir):
-    assert cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
-    assert cli.main([str(simple_study_dir / "import_config.yaml"), "-j", "1"])
-    assert cli.main([str(simple_study_dir / "import_config.yaml"), "list"])
-    assert cli.main([str(simple_study_dir / "import_config.yaml"), "list",
-                     "--verbose"])
+    import_config_fn = str(simple_study_dir / "import_config.yaml")
+    assert cli.main([import_config_fn, "list"]) == 0
+    assert cli.main([import_config_fn, "-j", "1"]) == 0
+    assert cli.main([import_config_fn, "list"]) == 0
+    assert cli.main([import_config_fn, "list", "--verbose"]) == 0

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -111,7 +111,11 @@ class TaskGraphCli:
     @staticmethod
     def process_graph(
             task_graph: TaskGraph, force_mode="optional", **kwargs) -> bool:
-        """Process task_graph in according with the arguments in args."""
+        """
+        Process task_graph in according with the arguments in args.
+
+        Return true if the graph get's successfully processed.
+        """
         args = Box(kwargs)
 
         if args.task_ids:

--- a/gcp_genotype_storage/gcp_genotype_storage/gcp_import_storage.py
+++ b/gcp_genotype_storage/gcp_genotype_storage/gcp_import_storage.py
@@ -141,10 +141,15 @@ class GcpImportStorage(ImportStorage):
             )
             bucket_tasks.append(task)
 
+        # dummy task used for running the parquet generation w/o impala import
+        all_parquet_task = graph.create_task(
+            "Parquet Tasks", lambda: None, [], bucket_tasks
+        )
+
         import_task = graph.create_task(
             "Import Dataset into GCP genotype storage",
             self._do_import_dataset,
-            [project], [pedigree_task, *bucket_tasks])
+            [project], [pedigree_task, all_parquet_task])
 
         graph.create_task(
             "Create study config",


### PR DESCRIPTION
## Background

A tiny PR containing:

 * A dummy task in schema1, 2 and gcp import task graph that is used for running just the parquet generation without the actual import into a DB
 * Fix for the exit codes of import tools.

## Implementation

Do a simple if to determine the correct exit code.

## Related issues

https://github.com/iossifovlab/gpf/issues/395
