### PR TITLE
Fix GRR caching bug

### DIFF
--- a/dae/dae/genomic_resources/fsspec_protocol.py
+++ b/dae/dae/genomic_resources/fsspec_protocol.py
@@ -249,11 +249,12 @@ class FsspecReadWriteProtocol(
             if not self.filesystem.exists(os.path.dirname(path)):
                 self.filesystem.makedirs(
                     os.path.dirname(path), exist_ok=True)
+            # pylint: disable=consider-using-with
             lockfile = open(path, "wt", encoding="utf8")
             lockfile.write(str(datetime.datetime.now()) + "\n")
             fcntl.flock(lockfile, fcntl.LOCK_EX)
-            lock.__enter__ = lockfile.__enter__
-            lock.__exit__ = lockfile.__exit__
+            lock.__enter__ = lockfile.__enter__  # type: ignore
+            lock.__exit__ = lockfile.__exit__  # type: ignore
 
         return lock
 
@@ -544,7 +545,7 @@ class FsspecReadWriteProtocol(
         result = {}
         for res in self.get_all_resources():
             res_size = convert_size(
-                sum([f for _, f in res.get_manifest().get_files()])
+                sum(f for _, f in res.get_manifest().get_files())
             )
             result[res.resource_id] = {
                 **res.config,

--- a/dae/dae/genomic_resources/repository.py
+++ b/dae/dae/genomic_resources/repository.py
@@ -360,7 +360,7 @@ class ReadOnlyRepositoryProtocol(abc.ABC):
     def __init__(self, proto_id: str):
         self.proto_id = proto_id
 
-    def mode(self):  # pylint: disable=no-self-use
+    def mode(self):
         """Return repository protocol mode - READONLY or READWRITE."""
         return Mode.READONLY
 
@@ -495,6 +495,8 @@ class ReadOnlyRepositoryProtocol(abc.ABC):
 class ReadWriteRepositoryProtocol(ReadOnlyRepositoryProtocol):
     """Defines read write genomic resources repository protocol."""
 
+    # pylint: disable=too-many-public-methods
+
     def mode(self):
         return Mode.READWRITE
 
@@ -508,6 +510,8 @@ class ReadWriteRepositoryProtocol(ReadOnlyRepositoryProtocol):
 
     def _update_manifest_entry_and_state(
             self, resource, entry, prebuild_entries):
+        pre_state = self.load_resource_file_state(resource, entry.name)
+
         size = None
         md5 = None
         if entry.name in prebuild_entries:
@@ -516,7 +520,8 @@ class ReadWriteRepositoryProtocol(ReadOnlyRepositoryProtocol):
             md5 = ready_entry.md5
         state = self.build_resource_file_state(
             resource, entry.name, size=size, md5=md5)
-        self.save_resource_file_state(resource, state)
+        if state != pre_state:
+            self.save_resource_file_state(resource, state)
         entry.md5 = state.md5
         entry.size = state.size
 

--- a/dae/dae/genomic_resources/tests/test_fsspec_protocol.py
+++ b/dae/dae/genomic_resources/tests/test_fsspec_protocol.py
@@ -361,3 +361,20 @@ def test_update_resource_specific_file(
     dst_res = proto.get_resource("sample")
     assert proto.file_exists(dst_res, "prim.txt")
     assert not proto.file_exists(dst_res, "second.txt")
+
+
+def test_build_manifest_should_not_update_existing_resource_state(
+    rw_fsspec_proto: ReadWriteRepositoryProtocol, mocker
+):
+    # Given
+    proto = rw_fsspec_proto
+    res = proto.get_resource("one")
+    proto.build_manifest(res)
+
+    mocker.patch.object(proto, "save_resource_file_state")
+
+    # When
+    proto.build_manifest(res)
+
+    # Then
+    assert not proto.save_resource_file_state.called  # type: ignore


### PR DESCRIPTION
## Background

While debugging a GRR caching issue, we have found that the `build_manifest` method of the `ReadWriteRepositoryProtocol` class recreates the GRR state of the resource files even when it is not needed.

## Aim

Change the code to skip updating the GRR state files when unnecessary.

## Implementation

We changed the `_update_manifest_entry_and_state` to check the existing GRR state instead of recreating it.