### PR TITLE
Bump Python version to 3.10.9

### DIFF
--- a/dae/dae/docs/conf.py
+++ b/dae/dae/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#
+# pylint: skip-file
 # type: ignore
 # pheno documentation build configuration file, created by
 # sphinx-quickstart on Fri Nov 11 14:34:13 2016.

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -27,7 +27,7 @@ def find_directory_with_a_file(
     Starts from current working directory or from a directory passed.
     """
     if cwd is None:
-        curr_dir = Path().absolute()
+        curr_dir = Path(os.getcwd()).absolute()
     else:
         curr_dir = Path(cwd).absolute()
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ channels:
   - defaults
   - iossifovlab
 dependencies:
-  - python=3.9.12
+  - python=3.10.9
   - importlib_metadata=4.11.3
   - pysam=0.20.0
   - samtools=1.15.1
@@ -31,7 +31,7 @@ dependencies:
   - python-box=6.0.2
   - setuptools=65.6.3
   - sqlalchemy=1.4.40
-  - sqlite=3.39.2
+  - sqlite=3.40.1
   - django=4.1.7
   - django-cors-headers=3.13.0
   - djangorestframework=3.13.1

--- a/wdae/wdae/docs/conf.py
+++ b/wdae/wdae/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#
+# pylint: skip-file
 # type: ignore
 # wdae documentation build configuration file, created by
 # sphinx-quickstart on Tue Aug 21 14:50:04 2018.
@@ -25,8 +25,8 @@
 import os
 import sys
 import django
-sys.path.insert(0, os.path.abspath('..'))
-os.environ['DJANGO_SETTINGS_MODULE'] = 'wdae.settings'
+sys.path.insert(0, os.path.abspath(".."))
+os.environ["DJANGO_SETTINGS_MODULE"] = "wdae.settings"
 django.setup()
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
## Background

We want to switch to a newer version of Python. 

## Aim

At the moment, `pysam` is the library that limits us to using Python 3.10. The latest currently available version of the Python 3.10 series is 3.10.9.

To use Python 3.10.9 we have to bump `sqlite` version too.