### PR TITLE
Merge small parquets

### DIFF
--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -67,6 +67,24 @@ class ImpalaSchema1ImportStorage(ImportStorage):
         project.stats[("elapsed", f"variants {bucket}")] = elapsed
 
     @classmethod
+    def _variant_partitions(cls, project):
+        part_desc = cls._get_partition_description(project)
+        chromosome_lengths = dict(
+            project.get_gpf_instance().reference_genome.get_all_chrom_lengths()
+        )
+        _, fam_parts = \
+            part_desc.get_variant_partitions(chromosome_lengths)
+        for part in fam_parts:
+            yield part_desc.partition_directory("", part), part
+
+    @classmethod
+    def _merge_parquets(cls, project, out_dir, partitions):
+        full_out_dir = fs_utils.join(cls._variants_dir(project), out_dir)
+        ParquetWriter.merge_parquets(
+            cls._get_partition_description(project), full_out_dir, partitions
+        )
+
+    @classmethod
     def _do_load_in_hdfs(cls, project):
         start = time.time()
         genotype_storage = project.get_genotype_storage()
@@ -183,9 +201,20 @@ class ImpalaSchema1ImportStorage(ImportStorage):
             )
             bucket_tasks.append(task)
 
+        # merge small parquet files into larger ones
+        bucket_sync = graph.create_task(
+            "Sync Parquet Generation", lambda: None, [], bucket_tasks
+        )
+        output_dir_tasks = []
+        for output_dir, partitions in self._variant_partitions(project):
+            output_dir_tasks.append(graph.create_task(
+                f"Merging {output_dir}", self._merge_parquets,
+                [project, output_dir, partitions], [bucket_sync]
+            ))
+
         # dummy task used for running the parquet generation w/o impala import
         all_parquet_task = graph.create_task(
-            "Parquet Tasks", lambda: None, [], bucket_tasks
+            "Parquet Tasks", lambda: None, [], output_dir_tasks + [bucket_sync]
         )
 
         if project.has_genotype_storage():

--- a/dae/dae/import_tools/tests/test_custom_region_length.py
+++ b/dae/dae/import_tools/tests/test_custom_region_length.py
@@ -45,32 +45,43 @@ def test_import_task_bin_size(gpf_instance_2019, tmpdir, mocker,
     out_dir = join(
         variants_dir,
         "summary/region_bin=1_0/frequency_bin=0")
-    parquet_files = [f"{fn}.parquet" for fn in [
-        "summary_region_bin_1_0_frequency_bin_0_bucket_index_000000",
-        "summary_region_bin_1_0_frequency_bin_0_bucket_index_000001",
-        "summary_region_bin_1_0_frequency_bin_0_bucket_index_000003",
-    ]]
+    parquet_files = [
+        "merged_region_bin_1_0_frequency_bin_0.parquet",
+    ]
     assert set(os.listdir(out_dir)) == set(parquet_files)
-    _assert_variants(join(out_dir, parquet_files[0]), bucket_index=0,
-                     positions=[123, 123, 150, 150, 30000000, 30000000])
-    _assert_variants(join(out_dir, parquet_files[1]), bucket_index=1,
-                     positions=[30000001, 30000001, 40000000, 40000000])
-    _assert_variants(join(out_dir, parquet_files[2]), bucket_index=3,
-                     positions=[99999999, 99999999])
+    _assert_variants(
+        join(out_dir, parquet_files[0]),
+        bucket_index=[
+            0, 0, 0, 0, 0, 0,
+            1, 1, 1, 1,
+            3, 3,
+        ],
+        positions=[
+            123, 123, 150, 150, 30000000, 30000000,
+            30000001, 30000001, 40000000, 40000000,
+            99999999, 99999999
+        ]
+    )
 
     # Same for the second directory
     out_dir = join(
         variants_dir,
         "summary/region_bin=1_1/frequency_bin=0")
-    parquet_files = [f"{fn}.parquet" for fn in [
-        "summary_region_bin_1_1_frequency_bin_0_bucket_index_000003",
-        "summary_region_bin_1_1_frequency_bin_0_bucket_index_000004",
-    ]]
+    parquet_files = [
+        "merged_region_bin_1_1_frequency_bin_0.parquet",
+    ]
     assert set(os.listdir(out_dir)) == set(parquet_files)
-    _assert_variants(join(out_dir, parquet_files[0]), bucket_index=3,
-                     positions=[100000000, 100000000, 120000000, 120000000])
-    _assert_variants(join(out_dir, parquet_files[1]), bucket_index=4,
-                     positions=[120000001, 120000001])
+    _assert_variants(
+        join(out_dir, parquet_files[0]),
+        bucket_index=[
+            3, 3, 3, 3,
+            4, 4,
+        ],
+        positions=[
+            100000000, 100000000, 120000000, 120000000,
+            120000001, 120000001,
+        ]
+    )
 
 
 def _assert_variants(parquet_fn, bucket_index, positions):

--- a/dae/dae/parquet/helpers.py
+++ b/dae/dae/parquet/helpers.py
@@ -1,7 +1,8 @@
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 from fsspec.core import url_to_fs
 import pyarrow as pa
+import pyarrow.parquet as pq
 
 
 def url_to_pyarrow_fs(filename: str, filesystem: Any = None):
@@ -31,3 +32,43 @@ def url_to_pyarrow_fs(filename: str, filesystem: Any = None):
 
     pa_fs = pa.fs.PyFileSystem(pa.fs.FSSpecHandler(filesystem))
     return pa_fs, filename
+
+
+def merge_parquets(in_files: list[str], out_file: str, delete_in_files=True):
+    """Merge `in_files` into one large file called `out_file`."""
+    try:
+        _try_merge_parquets(in_files, out_file, delete_in_files)
+    except Exception:  # pylint: disable=broad-except
+        # unsuccessfull conversion. Remove the partially generated file.
+        fs, path = url_to_fs(out_file)
+        if fs.exists(path):
+            fs.rm_file(path)
+        raise
+
+
+def _try_merge_parquets(in_files, out_file, delete_in_files):
+    assert len(in_files) > 0
+    out_parquet = None
+
+    for in_file in in_files:
+        in_fs, in_fn = url_to_pyarrow_fs(in_file)
+        if in_fs is None:
+            in_fs = pa.fs.LocalFileSystem()
+        with in_fs.open_input_file(in_fn) as parquet_native_file:
+            parq_file = pq.ParquetFile(parquet_native_file)
+            if out_parquet is None:
+                out_filesystem, out_filename = url_to_pyarrow_fs(out_file)
+                out_parquet = pq.ParquetWriter(
+                    out_filename, parq_file.schema_arrow,
+                    filesystem=out_filesystem
+                )
+
+            for batch in parq_file.iter_batches():
+                out_parquet.write_batch(batch)
+
+    cast(pq.ParquetWriter, out_parquet).close()
+
+    if delete_in_files:
+        for in_file in in_files:
+            fs, path = url_to_fs(in_file)
+            fs.rm_file(path)

--- a/dae/dae/parquet/partition_descriptor.py
+++ b/dae/dae/parquet/partition_descriptor.py
@@ -378,7 +378,7 @@ class PartitionDescriptor:
     @staticmethod
     def partition_filename(
             prefix: str, partition: List[Tuple[str, str]],
-            bucket_index: int) -> str:
+            bucket_index: Optional[int]) -> str:
         """Construct a partition dataset base filename.
 
         Given a partition in the format returned by `summary_parition` or

--- a/dae/dae/parquet/tests/test_parquet_helpers.py
+++ b/dae/dae/parquet/tests/test_parquet_helpers.py
@@ -1,5 +1,10 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
+import pytest
 import pyarrow as pa
-from dae.parquet.helpers import url_to_pyarrow_fs
+import pyarrow.parquet as pq
+import pandas as pd
+from dae.parquet.helpers import url_to_pyarrow_fs, merge_parquets
 
 
 def test_url_to_pyarrow_fs():
@@ -14,3 +19,82 @@ def test_url_to_pyarrow_fs_s3_url():
     fs, path = url_to_pyarrow_fs(filename)
     assert isinstance(fs, pa.fs.PyFileSystem)
     assert path == "bucket/file.txt"
+
+
+def test_merge_parquets(tmpdir):
+    full_data = pd.DataFrame({
+        "n_legs": [2, 2, 4, 4, 5, 100],
+        "animal": [
+            "Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"
+        ]
+    })
+
+    in_files = []
+    for i in range(0, len(full_data), 2):
+        table = pa.table(full_data.iloc[i:i + 2])
+        in_files.append(str(tmpdir / f"p{i}.parquet"))
+        writer = pq.ParquetWriter(in_files[-1], table.schema)
+        writer.write_table(table)
+        writer.close()
+
+    out_file = str(tmpdir / "merged.parquet")
+    merge_parquets(in_files, out_file)
+
+    merged = pq.ParquetFile(out_file)
+    assert merged.schema_arrow == table.schema
+    data = merged.read().to_pandas()
+    assert (data == full_data).all().all()
+
+    # assert input files get deleted
+    for in_file in in_files:
+        assert not os.path.exists(in_file)
+
+
+def test_merge_parquets_single_file(tmpdir):
+    table = pa.table({
+        "n_legs": [2, 2, 4, 4, 5, 100],
+        "animal": [
+            "Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"
+        ]
+    })
+    in_file = str(tmpdir / "in.parquet")
+    writer = pq.ParquetWriter(in_file, table.schema)
+    writer.write_table(table)
+    writer.close()
+
+    out_file = str(tmpdir / "out.parquet")
+    merge_parquets([in_file], out_file)
+
+    merged = pq.ParquetFile(out_file)
+    assert merged.schema_arrow == table.schema
+    data = merged.read().to_pandas()
+    assert (data == table.to_pandas()).all().all()
+
+
+def test_merge_parquets_no_files():
+    with pytest.raises(Exception):
+        merge_parquets([], "out.parquet")
+    assert not os.path.exists("out.parquet")
+
+
+def test_merge_parquets_broken_input_file(tmpdir):
+    table = pa.table({
+        "n_legs": [2, 2, 4, 4, 5, 100],
+        "animal": [
+            "Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"
+        ]
+    })
+    writer = pq.ParquetWriter(str(tmpdir / "p1.parquet"), table.schema)
+    writer.write_table(table)
+    writer.close()
+
+    with open(str(tmpdir / "p2.parquet"), "wt") as file:
+        file.write("This is not a parquet file.")
+
+    in_files = [str(tmpdir / "p1.parquet"), str(tmpdir / "p2.parquet")]
+    out_file = str(tmpdir / "merged.parquet")
+    with pytest.raises(Exception):
+        merge_parquets(in_files, out_file)
+
+    # assert no partial output file is left behind in case of error
+    assert not os.path.exists(out_file)

--- a/dae/dae/parquet/tests/test_parquet_writer.py
+++ b/dae/dae/parquet/tests/test_parquet_writer.py
@@ -1,0 +1,58 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
+import textwrap
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from dae.parquet.partition_descriptor import PartitionDescriptor
+from dae.parquet.parquet_writer import ParquetWriter
+
+
+def test_merge_parquets(tmpdir):
+    pd_content = textwrap.dedent("""
+        region_bin:
+            chromosomes: foo,bar
+            region_length: 8
+        family_bin:
+            family_bin_size: 2
+    """)
+    part_desc = PartitionDescriptor.parse_string(pd_content, "yaml")
+
+    def write_parquets():
+        pq.write_table(
+            pa.table({
+                "index": [1, 2, 3],
+                "prop": ["a", "b", "c"]
+            }),
+            str(tmpdir / "p1.parquet")
+        )
+        pq.write_table(
+            pa.table({
+                "index": [4, 5, 6],
+                "prop": ["d", "e", "f"]
+            }),
+            str(tmpdir / "p2.parquet")
+        )
+
+    # run and assert files are merged
+    write_parquets()
+    ParquetWriter.merge_parquets(
+        part_desc, str(tmpdir), [("region_bin", "foo_0"), ("family_bin", "1")]
+    )
+    out_files = os.listdir(str(tmpdir))
+    assert len(out_files) == 1
+
+    # run again and assert dir is unchanged
+    ParquetWriter.merge_parquets(
+        part_desc, str(tmpdir), [("region_bin", "foo_0"), ("family_bin", "1")]
+    )
+    out_files = os.listdir(str(tmpdir))
+    assert len(out_files) == 1
+
+    # generate files and run again
+    write_parquets()
+    ParquetWriter.merge_parquets(
+        part_desc, str(tmpdir), [("region_bin", "foo_0"), ("family_bin", "1")]
+    )
+    out_files = os.listdir(str(tmpdir))
+    assert len(out_files) == 1

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -94,6 +94,18 @@ def tabix_index_filename(tabix_filename: str) -> Optional[str]:
     return None
 
 
+def glob(path: str) -> list[str]:
+    """Find files by glob-matching."""
+    fs, relative_path = url_to_fs(path)
+    return cast(list[str], fs.glob(relative_path))
+
+
+def rm_file(path: str):
+    """Remove a file."""
+    fs, relative_path = url_to_fs(path)
+    return fs.rm_file(relative_path)
+
+
 def _handle_env_variables(envdict=None):
     """Handle filesystem-related environment variables.
 


### PR DESCRIPTION
## Background

When generating parquet files multiple output parquet files could end up in the same output bucket. Impala and BigQuery don't like working with so many files, they prefer a single large one.

## Aim

The goal of this PR is to merge multiple smaller parquet files in a single output dir into a single large file.

## Implementation

In the import task-graph after parquet-generation merge tasks are created for each output bucket. These tasks list the parquet files in the output dir and if there are more then 1 file the files get merged into a single one. The resulting file has the same name as the output bucket but without `bucket_index` (because it could contain variants from multiple bucket indices) and with the prefix `merged`.
