### PR TITLE
Resource labels

### DIFF
--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -343,7 +343,7 @@ class GeneScoreCollection(
                 "histograms": config["histograms"]
             },
             "score_file": manifest[score_filename].md5
-        }, sort_keys=True).encode()
+        }, sort_keys=True, indent=2).encode()
 
     def add_statistics_build_tasks(self, task_graph, **kwargs) -> List[Task]:
         save_tasks = []

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -34,9 +34,9 @@ class GeneScore:
 
     Gene Score resource configuration format:
     type: gene_score
+    filename: (filename to gene score)
     gene_scores:
       - id: (gene score id)
-        filename: (filename to gene score)
         desc: (gene score description)
     histograms:
       - score: (gene score id)
@@ -336,11 +336,15 @@ class GeneScoreCollection(
 
     def calc_statistics_hash(self) -> bytes:
         manifest = self.resource.get_manifest()
-        score_filename = self.get_config()["filename"]
-        return hashlib.md5(json.dumps({
-            "config": manifest["genomic_resource.yaml"].md5,
+        config = self.get_config()
+        score_filename = config["filename"]
+        return json.dumps({
+            "config": {
+                "gene_scores": config["gene_scores"],
+                "histograms": config["histograms"]
+            },
             "score_file": manifest[score_filename].md5
-        }, sort_keys=True).encode()).digest()
+        }, sort_keys=True).encode()
 
     def add_statistics_build_tasks(self, task_graph, **kwargs) -> List[Task]:
         save_tasks = []

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -3,7 +3,6 @@ import copy
 import itertools
 import logging
 import textwrap
-import hashlib
 import json
 from typing import Optional, List
 

--- a/dae/dae/gene/gene_sets_db.py
+++ b/dae/dae/gene/gene_sets_db.py
@@ -188,7 +188,7 @@ class GeneSetCollection(
     def _get_template_data(self):
         info = copy.deepcopy(self.config)
         if "meta" in info:
-            info["meta"] = markdown(info["meta"])
+            info["meta"] = markdown(str(info["meta"]))
         return info
 
     @staticmethod
@@ -309,7 +309,7 @@ class SqliteGeneSetCollectionDB(
     def _get_template_data(self):
         info = copy.deepcopy(self.config)
         if "meta" in info:
-            info["meta"] = markdown(info["meta"])
+            info["meta"] = markdown(str(info["meta"]))
         return info
 
     @property

--- a/dae/dae/gene/tests/test_genomic_scores.py
+++ b/dae/dae/gene/tests/test_genomic_scores.py
@@ -45,7 +45,9 @@ def scores_repo(tmp_path):
                     - source: phastCons100
                       destination: phastcons100
                 meta:
-                  test_help
+                  description:
+                    test_help
+                  labels: ~
             """),
             "histograms": {
                 "phastCons100.csv": textwrap.dedent("""

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -55,7 +55,7 @@ def _add_repository_resource_parameters_group(parser, use_resource=True):
         "directory. If found the directory is assumed for root repository "
         "directory; otherwise error is reported.")
     group.add_argument(
-        "--definition", type=str,
+        "--definition", "--grr", "-g", type=str,
         default=None,
         help="Path to an extra GRR definition file. This GRR will be loaded"
         "in a group alongside the local one.")

--- a/dae/dae/genomic_resources/gene_models.py
+++ b/dae/dae/genomic_resources/gene_models.py
@@ -1468,7 +1468,7 @@ class GeneModels(
     def _get_template_data(self):
         info = copy.deepcopy(self.config)
         if "meta" in info:
-            info["meta"] = markdown(info["meta"])
+            info["meta"] = markdown(str(info["meta"]))
         return info
 
     @staticmethod

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -809,7 +809,7 @@ class GenomicScore(
                 "table": config["table"]
             },
             "score_file": manifest[score_filename].md5
-        }, sort_keys=True).encode()
+        }, sort_keys=True, indent=2).encode()
 
 
 class PositionScore(GenomicScore):

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 import textwrap
 import copy
-import hashlib
 import json
 
 from typing import Iterator, Optional, cast, Type, Any, Union

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -567,13 +567,15 @@ class GenomicScore(
         ref_genome_id = self.get_label("reference_genome")
         ref_genome = None
         if ref_genome_id is not None or grr is not None:
-            logger.warning(
-                "Couldn't use reference genome tag for %s",
-                self.resource.resource_id
-            )
             try:
                 ref_genome = build_reference_genome_from_resource(
                     grr.get_resource(ref_genome_id)
+                )
+                logger.info(
+                    "Using reference genome label <%s> "
+                    "for chromosome lengths of <%s>",
+                    ref_genome_id,
+                    self.resource.resource_id
                 )
             except FileNotFoundError:
                 logger.warning(
@@ -770,9 +772,13 @@ class GenomicScore(
     def _split_into_regions(self, region_size, reference_genome):
         chromosomes = self.get_all_chromosomes()
         for chrom in chromosomes:
-            if reference_genome is not None:
+            if reference_genome is not None \
+                    and chrom in reference_genome.chromosomes:
                 chrom_len = reference_genome.get_chrom_length(chrom)
             else:
+                logger.info(
+                    "chromosome %s of %s not found in reference genome %s",
+                    chrom, self.resource_id, reference_genome.resource_id)
                 chrom_len = self.table.get_chromosome_length(chrom)
             logger.debug(
                 "Chromosome '%s' has length %s",

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -768,7 +768,7 @@ class GenomicScore(
             plt.clf()
         return merged_histograms
 
-    def _split_into_regions(self, region_size, reference_genome):
+    def _split_into_regions(self, region_size, reference_genome=None):
         chromosomes = self.get_all_chromosomes()
         for chrom in chromosomes:
             if reference_genome is not None \

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -801,11 +801,16 @@ class GenomicScore(
         recomputed.
         """
         manifest = self.resource.get_manifest()
-        score_filename = self.get_config()["table"]["filename"]
-        return hashlib.md5(json.dumps({
-            "config": manifest["genomic_resource.yaml"].md5,
+        config = self.get_config()
+        score_filename = config["table"]["filename"]
+        return json.dumps({
+            "config": {
+                "scores": config["scores"],
+                "histograms": config["histograms"],
+                "table": config["table"]
+            },
             "score_file": manifest[score_filename].md5
-        }, sort_keys=True).encode()).digest()
+        }, sort_keys=True).encode()
 
 
 class PositionScore(GenomicScore):

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -775,9 +775,17 @@ class GenomicScore(
                     and chrom in reference_genome.chromosomes:
                 chrom_len = reference_genome.get_chrom_length(chrom)
             else:
-                logger.info(
-                    "chromosome %s of %s not found in reference genome %s",
-                    chrom, self.resource_id, reference_genome.resource_id)
+                if reference_genome is not None:
+                    logger.info(
+                        "chromosome %s of %s not found in reference genome %s",
+                        chrom, self.resource.resource_id,
+                        reference_genome.resource_id
+                    )
+                else:
+                    logger.info(
+                        "chromosome %s of %s using table, no reference genome",
+                        chrom, self.resource.resource_id
+                    )
                 chrom_len = self.table.get_chromosome_length(chrom)
             logger.debug(
                 "Chromosome '%s' has length %s",
@@ -805,7 +813,7 @@ class GenomicScore(
         return json.dumps({
             "config": {
                 "scores": config["scores"],
-                "histograms": config["histograms"],
+                "histograms": config.get("histograms", {}),
                 "table": config["table"]
             },
             "score_file": manifest[score_filename].md5

--- a/dae/dae/genomic_resources/liftover_resource.py
+++ b/dae/dae/genomic_resources/liftover_resource.py
@@ -158,7 +158,7 @@ class LiftoverChain(
                     " to variants after performing liftover."
                 )
         if "meta" in info:
-            info["meta"] = markdown(info["meta"])
+            info["meta"] = markdown(str(info["meta"]))
         return info
 
     @staticmethod

--- a/dae/dae/genomic_resources/reference_genome.py
+++ b/dae/dae/genomic_resources/reference_genome.py
@@ -158,6 +158,20 @@ class ReferenceGenome(
             (key, value["length"])
             for key, value in self._index.items()]
 
+    def split_into_regions(self, region_size):
+        chromosome_lengths = self.get_all_chrom_lengths()
+        print(chromosome_lengths)
+        for chrom, chrom_len in chromosome_lengths:
+            print(chrom, chrom_len)
+            logger.debug(
+                "Chromosome '%s' has length %s",
+                chrom, chrom_len)
+            i = 1
+            while i < chrom_len - region_size:
+                yield chrom, i, i + region_size - 1
+                i += region_size
+            yield chrom, i, None
+
     def get_sequence(self, chrom, start, stop):
         """Return sequence of nucleotides from specified chromosome region."""
         if chrom not in self.chromosomes:

--- a/dae/dae/genomic_resources/reference_genome.py
+++ b/dae/dae/genomic_resources/reference_genome.py
@@ -158,19 +158,19 @@ class ReferenceGenome(
             (key, value["length"])
             for key, value in self._index.items()]
 
-    def split_into_regions(self, region_size):
-        chromosome_lengths = self.get_all_chrom_lengths()
-        print(chromosome_lengths)
-        for chrom, chrom_len in chromosome_lengths:
-            print(chrom, chrom_len)
-            logger.debug(
-                "Chromosome '%s' has length %s",
-                chrom, chrom_len)
-            i = 1
-            while i < chrom_len - region_size:
-                yield chrom, i, i + region_size - 1
-                i += region_size
-            yield chrom, i, None
+    # def split_into_regions(self, region_size):
+    #     chromosome_lengths = self.get_all_chrom_lengths()
+    #     print(chromosome_lengths)
+    #     for chrom, chrom_len in chromosome_lengths:
+    #         print(chrom, chrom_len)
+    #         logger.debug(
+    #             "Chromosome '%s' has length %s",
+    #             chrom, chrom_len)
+    #         i = 1
+    #         while i < chrom_len - region_size:
+    #             yield chrom, i, i + region_size - 1
+    #             i += region_size
+    #         yield chrom, i, None
 
     def get_sequence(self, chrom, start, stop):
         """Return sequence of nucleotides from specified chromosome region."""
@@ -246,7 +246,7 @@ class ReferenceGenome(
     def _get_template_data(self):
         info = copy.deepcopy(self.config)
         if "meta" in info:
-            info["meta"] = markdown(info["meta"])
+            info["meta"] = markdown(str(info["meta"]))
         return info
 
     @staticmethod

--- a/dae/dae/genomic_resources/resource_implementation.py
+++ b/dae/dae/genomic_resources/resource_implementation.py
@@ -18,7 +18,7 @@ def get_base_resource_schema():
             "allow_unknown": True,
             "schema": {
                 "description": {"type": "string"},
-                "labels": {"type": "dict"}
+                "labels": {"type": "dict", "required": False}
             }
         }
     }
@@ -38,6 +38,10 @@ class GenomicResourceImplementation(ABC):
     def __init__(self, genomic_resource: GenomicResource):
         self.resource = genomic_resource
         self.config: dict = self.resource.config
+
+    @property
+    def resource_id(self):
+        self.resource.resource_id
 
     def get_config(self) -> dict:
         return self.config

--- a/dae/dae/genomic_resources/resource_implementation.py
+++ b/dae/dae/genomic_resources/resource_implementation.py
@@ -18,7 +18,7 @@ def get_base_resource_schema():
             "allow_unknown": True,
             "schema": {
                 "description": {"type": "string"},
-                "labels": {"type": "dict", "required": False}
+                "labels": {"type": "dict", "nullable": True}
             }
         }
     }

--- a/dae/dae/genomic_resources/resource_implementation.py
+++ b/dae/dae/genomic_resources/resource_implementation.py
@@ -13,7 +13,14 @@ logger = logging.getLogger(__name__)
 def get_base_resource_schema():
     return {
         "type": {"type": "string"},
-        "meta": {"type": "string"}
+        "meta": {
+            "type": "dict",
+            "allow_unknown": True,
+            "schema": {
+                "description": {"type": "string"},
+                "labels": {"type": "dict"}
+            }
+        }
     }
 
 
@@ -64,6 +71,17 @@ class GenomicResourceImplementation(ABC):
     def get_info(self) -> str:
         """Construct the contents of the implementation's HTML info page."""
         raise NotImplementedError()
+
+    def get_label(self, label):
+        metadata = self.config.get("meta")
+        if metadata is None:
+            return None
+
+        labels = metadata.get("labels")
+        if labels is None:
+            return None
+
+        return labels.get(label)
 
 
 class InfoImplementationMixin:

--- a/dae/dae/genomic_resources/tests/test_cli_stats.py
+++ b/dae/dae/genomic_resources/tests/test_cli_stats.py
@@ -473,15 +473,15 @@ def test_reference_genome_usage(tmp_path, mocker):
 
     assert repo is not None
 
-    ref_genome_split_mock = mocker.Mock(return_value=[])
+    ref_genome_length_mock = mocker.Mock(return_value=30)
     mocker.patch(
         "dae.genomic_resources.reference_genome"
-        ".ReferenceGenome.split_into_regions",
-        new=ref_genome_split_mock
+        ".ReferenceGenome.get_chrom_length",
+        new=ref_genome_length_mock
     )
-    assert ref_genome_split_mock.call_count == 0
+    assert ref_genome_length_mock.call_count == 0
     cli_manage(["repo-stats", "-R", str(tmp_path), "-j", "1"])
-    assert ref_genome_split_mock.call_count == 2
+    assert ref_genome_length_mock.call_count == 6
 
     label_mock = mocker.Mock(return_value=None)
     mocker.patch(
@@ -490,18 +490,18 @@ def test_reference_genome_usage(tmp_path, mocker):
         new=label_mock
     )
 
-    genomic_score_split_mock = mocker.Mock(return_value=[])
+    genomic_table_length_mock = mocker.Mock(return_value=30)
     mocker.patch(
-        "dae.genomic_resources.genomic_scores"
-        ".GenomicScore._split_into_regions",
-        new=genomic_score_split_mock
+        "dae.genomic_resources.genomic_position_table.table"
+        ".GenomicPositionTable.get_chromosome_length",
+        new=genomic_table_length_mock
     )
 
     os.remove(os.path.join(tmp_path, "one", "statistics", "stats_hash"))
 
-    assert genomic_score_split_mock.call_count == 0
+    assert genomic_table_length_mock.call_count == 0
 
     cli_manage(["repo-stats", "-R", str(tmp_path), "-j", "1"])
 
-    assert genomic_score_split_mock.call_count == 2
-    assert ref_genome_split_mock.call_count == 2
+    assert genomic_table_length_mock.call_count == 6
+    assert ref_genome_length_mock.call_count == 6

--- a/dae/dae/genomic_resources/tests/test_cli_stats.py
+++ b/dae/dae/genomic_resources/tests/test_cli_stats.py
@@ -407,3 +407,101 @@ def test_minmax(tmp_path):
 
     assert minmax.min == 0
     assert minmax.max == 1
+
+def test_reference_genome_usage(tmp_path, mocker):
+    setup_directories(tmp_path, {
+        "one": {
+            GR_CONF_FILE_NAME: """
+                type: position_score
+                table:
+                    filename: data.mem
+                scores:
+                    - id: phastCons100way
+                      type: float
+                      desc: "The phastCons computed over the tree of 100 \
+                              verterbarte species"
+                      name: s1
+                histograms:
+                    - score: phastCons100way
+                      bins: 100
+                      x_scale: linear
+                      y_scale: linear
+                meta:
+                    labels:
+                        reference_genome: genome
+            """,
+            "data.mem": convert_to_tab_separated("""
+                chrom  pos_begin  pos_end  s1
+                1      10         15       0.0
+                1      17         19       0.03
+                1      22         25       0.46
+                2      5          8        0.01
+                2      10         11       1.0
+                3      5          17       1.0
+                3      18         20       0.01
+            """)
+        },
+        "genome": {
+            GR_CONF_FILE_NAME: """
+                type: genome
+                filename: data.fa
+            """,
+            "data.fa": textwrap.dedent("""
+                >1
+                NACGTNACGT
+                NACGTNACGT
+                NACGTNACGT
+                >2
+                NACGTNACGT
+                NACGTNACGT
+                NACGTNACGT
+                >3
+                NACGTNACGT
+                NACGTNACGT
+                NACGTNACGT
+            """),
+            "data.fa.fai": textwrap.dedent("""\
+                1	30	3	10	11
+                2	30	39	10	11
+                3	30	75	10	11
+            """)
+
+        }
+    })
+
+    repo = build_filesystem_test_repository(tmp_path)
+
+    assert repo is not None
+
+    ref_genome_split_mock = mocker.Mock(return_value=[])
+    mocker.patch(
+        "dae.genomic_resources.reference_genome"
+        ".ReferenceGenome.split_into_regions",
+        new=ref_genome_split_mock
+    )
+    assert ref_genome_split_mock.call_count == 0
+    cli_manage(["repo-stats", "-R", str(tmp_path), "-j", "1"])
+    assert ref_genome_split_mock.call_count == 2
+
+    label_mock = mocker.Mock(return_value=None)
+    mocker.patch(
+        "dae.genomic_resources.resource_implementation."
+        "GenomicResourceImplementation.get_label",
+        new=label_mock
+    )
+
+    genomic_score_split_mock = mocker.Mock(return_value=[])
+    mocker.patch(
+        "dae.genomic_resources.genomic_scores"
+        ".GenomicScore._split_into_regions",
+        new=genomic_score_split_mock
+    )
+
+    os.remove(os.path.join(tmp_path, "one", "statistics", "stats_hash"))
+
+    assert genomic_score_split_mock.call_count == 0
+
+    cli_manage(["repo-stats", "-R", str(tmp_path), "-j", "1"])
+
+    assert genomic_score_split_mock.call_count == 2
+    assert ref_genome_split_mock.call_count == 2

--- a/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg19/GATK_ResourceBundle_5777_b37_phiX174_short/gene_models/refGene_201309/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg19/GATK_ResourceBundle_5777_b37_phiX174_short/gene_models/refGene_201309/genomic_resource.yaml
@@ -5,7 +5,9 @@ filename: refGene201309.txt
 format: "default"
 
 
-meta: |
-  ## refGene gene models from 2013-09
+meta:
+  description: |
+    ## refGene gene models from 2013-09
 
-  Old gene models used by GPF up to 2019-02.
+    Old gene models used by GPF up to 2019-02.
+  labels: ~

--- a/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg19/GATK_ResourceBundle_5777_b37_phiX174_short/genome/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg19/GATK_ResourceBundle_5777_b37_phiX174_short/genome/genomic_resource.yaml
@@ -12,7 +12,9 @@ PARS:
     - "Y:10001-2649520"
     - "Y:59034050-59363566"
 
-meta: |
-  ## HG19 Reference Genome Fragment
+meta: 
+  description: |
+    ## HG19 Reference Genome Fragment
 
-  Default HG19 reference genome used by GPF
+    Default HG19 reference genome used by GPF
+  labels: ~

--- a/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg38/GRCh38-hg38/gene_models/refSeq_20200330/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg38/GRCh38-hg38/gene_models/refSeq_20200330/genomic_resource.yaml
@@ -5,7 +5,9 @@ filename: refSeq_20200330.txt
 format: "refseq"
 
 
-meta: |
-  ## refSeq gene models for HG38 from 2020-03
+meta:
+  description: |
+    ## refSeq gene models for HG38 from 2020-03
 
-  Default gene models used by GPF for HG38.
+    Default gene models used by GPF for HG38.
+  labels: ~

--- a/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg38/GRCh38-hg38/genome/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/genomic_resources/hg38/GRCh38-hg38/genome/genomic_resource.yaml
@@ -13,7 +13,9 @@ PARS:
     - "chrY:56887902-57217415"
 
 
-meta: |
-  ## HG38 Reference Genome 
+meta:
+  description: |
+    ## HG38 Reference Genome 
 
-  Default HG38 reference genome used by GPF
+    Default HG38 reference genome used by GPF
+  labels: ~


### PR DESCRIPTION
## Background
We decided to begin using labels in the resource configuration's metadata for more flexible functionality. For a start, genomic scores should use a `reference_genome` label that points to a resource on the repository and use that resource to get the regions instead of iterating through the genomic table.

## Aim
Implement labels and add genomic scores `reference_genome` label functionality.

## Implementation
The new meta section of the configuration is a dictionary containing a `description` and `labels`. Other arbitrary keys can be added. When starting the grr_manage CLI, a repository is now created and sent down to the statistics, where it is passed down as a keyword argument and used in genomic scores with the label. When there is no GRR passed down or there is no reference_genome label, the genomic scores fall back to the old `_split_into_regions`.
This PR also includes a new argument in the GRR manage CLI - `--definition`. When `--definition` is passed, it will open the GRR definition path given, and create a group with the local repo that is found by the tool and said newly created GRR. 