### PR TITLE
Reorganization of `wdae.default_settings`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,6 +111,18 @@ function main() {
     }
   }
 
+  # run MailHog
+  build_stage "Run MailHog"
+  {
+      local -A ctx_mailhog
+      build_run_ctx_init ctx:ctx_mailhog "persistent" "container" "mailhog/mailhog" \
+          "cmd-from-image" "no-def-mounts" \
+          ports:1025,8025 --hostname mailhog --network "${ctx_network["network_id"]}"
+
+      defer_ret build_run_ctx_reset ctx:ctx_mailhog
+      build_run_ctx_persist ctx:ctx_mailhog
+  }
+
   # prepare gpf data
   build_stage "Prepare GPF data"
   {
@@ -130,7 +142,8 @@ EOT
       --env DAE_DB_DIR="/wd/data/data-hg19-local/" \
       --env GRR_DEFINITION_FILE="/wd/cache/grr_definition.yaml" \
       --env DAE_HDFS_HOST="impala" \
-      --env DAE_IMPALA_HOST="impala"
+      --env DAE_IMPALA_HOST="impala" \
+      --env WDAE_EMAIL_HOST="mailhog"
     defer_ret build_run_ctx_reset
 
 
@@ -148,7 +161,8 @@ EOT
       --env DAE_DB_DIR="/wd/data/data-hg19-remote/" \
       --env GRR_DEFINITION_FILE="/wd/cache/grr_definition.yaml" \
       --env DAE_HDFS_HOST="impala" \
-      --env DAE_IMPALA_HOST="impala"
+      --env DAE_IMPALA_HOST="impala" \
+      --env WDAE_EMAIL_HOST="mailhog"
     defer_ret build_run_ctx_reset ctx:ctx_gpf_remote
 
     build_run_container_detached ctx:ctx_gpf_remote /wd/integration/remote/entrypoint.sh
@@ -256,7 +270,8 @@ EOT
       --env GRR_DEFINITION_FILE="/wd/cache/grr_definition.yaml" \
       --env TEST_REMOTE_HOST="gpfremote" \
       --env DAE_HDFS_HOST="impala" \
-      --env DAE_IMPALA_HOST="impala"
+      --env DAE_IMPALA_HOST="impala" \
+      --env WDAE_EMAIL_HOST="mailhog"
 
     defer_ret build_run_ctx_reset
 
@@ -288,7 +303,8 @@ EOT
       --env GRR_DEFINITION_FILE="/wd/cache/grr_definition.yaml" \
       --env TEST_REMOTE_HOST="gpfremote" \
       --env DAE_HDFS_HOST="impala" \
-      --env DAE_IMPALA_HOST="impala"
+      --env DAE_IMPALA_HOST="impala" \
+      --env WDAE_EMAIL_HOST="mailhog"
 
     defer_ret build_run_ctx_reset
 
@@ -326,7 +342,8 @@ EOT
       --env GRR_DEFINITION_FILE="/wd/cache/grr_definition.yaml" \
       --env TEST_REMOTE_HOST="gpfremote" \
       --env DAE_HDFS_HOST="impala" \
-      --env DAE_IMPALA_HOST="impala"
+      --env DAE_IMPALA_HOST="impala" \
+      --env WDAE_EMAIL_HOST="mailhog"
 
     defer_ret build_run_ctx_reset
 
@@ -363,7 +380,8 @@ EOT
       --env GRR_DEFINITION_FILE="/wd/cache/grr_definition.yaml" \
       --env TEST_REMOTE_HOST="gpfremote" \
       --env DAE_HDFS_HOST="impala" \
-      --env DAE_IMPALA_HOST="impala"
+      --env DAE_IMPALA_HOST="impala" \
+      --env WDAE_EMAIL_HOST="mailhog"
 
     defer_ret build_run_ctx_reset
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,6 +10,7 @@ channels:
 dependencies:
   - dask-jobqueue=0.8.1
   - dask-kubernetes=2022.12.0
+  - raven=6.10.0
   - bump2version=1.0.1
   - sphinx=5.3.0
   - sphinx_rtd_theme=1.1.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,13 @@ services:
       - "21050:21050"
       - "8020:8020"
 
+  mail:
+    image: mailhog/mailhog
+    hostname: mail
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
   setup:
     build:
       context: .

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,3 +73,6 @@ ignore_missing_imports = True
 
 [mypy-toolz.*]
 ignore_missing_imports = True
+
+[mypy-raven.*]
+ignore_missing_imports = True

--- a/wdae/wdae/users_api/tests/conftest.py
+++ b/wdae/wdae/users_api/tests/conftest.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-
+import uuid
 from datetime import timedelta
 import pytest
 
@@ -114,6 +114,17 @@ def researcher(db):
 def researcher_without_password(db):
     res = WdaeUser.objects.create_user(email="fake@fake.com")
     res.name = "fname"
+    res.save()
+
+    return res
+
+
+@pytest.fixture()
+def unique_test_user(db):
+    uid = uuid.uuid1()
+    res = WdaeUser.objects.create_user(email=f"fake{uid}@unique.com")
+    res.name = f"fname{uid}"
+    res.set_password("alabala")
     res.save()
 
     return res

--- a/wdae/wdae/users_api/tests/test_users_api.py
+++ b/wdae/wdae/users_api/tests/test_users_api.py
@@ -27,7 +27,6 @@ def test_invalid_reset_code(client, researcher):
 def test_reset_pass(client, researcher):
     url = "/api/v3/users/forgotten_password"
     data = {"email": researcher.email}
-    pprint(data)
 
     response = client.post(
         url, json.dumps(data), content_type="application/json", format="json"

--- a/wdae/wdae/users_api/tests/test_users_emails_integration.py
+++ b/wdae/wdae/users_api/tests/test_users_emails_integration.py
@@ -1,0 +1,26 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import json
+import requests
+from rest_framework import status
+
+
+def test_reset_pass_message_search(client, unique_test_user, settings):
+    settings.EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    url = "/api/v3/users/forgotten_password"
+    data = {"email": unique_test_user.email}
+
+    response = client.post(
+        url, json.dumps(data), content_type="application/json", format="json"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response = requests.get(
+        f"http://{settings.EMAIL_HOST}:8025/api/v2/search",
+        params={"kind": "to", "query": unique_test_user.email}, timeout=2.0)
+
+    assert response.ok
+
+    data = response.json()
+    assert data["count"] == 1
+    to_email = data["items"][0]["Content"]["Headers"]["To"]
+    assert to_email == [unique_test_user.email]

--- a/wdae/wdae/users_api/utils.py
+++ b/wdae/wdae/users_api/utils.py
@@ -25,7 +25,7 @@ def get_default_application():
 
 def send_verif_email(user, verif_path):
     email = _create_verif_email(
-        settings.EMAIL_VERIFICATION_HOST,
+        settings.EMAIL_VERIFICATION_ENDPOINT,
         settings.EMAIL_VERIFICATION_SET_PATH,
         str(verif_path.path),
     )
@@ -63,7 +63,7 @@ def send_reset_inactive_acc_email(user):
 def send_reset_email(user, verif_path, by_admin=False):
     """Return dict with subject and message of the email."""
     email = _create_reset_mail(
-        settings.EMAIL_VERIFICATION_HOST,
+        settings.EMAIL_VERIFICATION_ENDPOINT,
         settings.EMAIL_VERIFICATION_RESET_PATH,
         str(verif_path.path),
         by_admin,
@@ -72,7 +72,7 @@ def send_reset_email(user, verif_path, by_admin=False):
     user.email_user(email["subject"], email["message"])
 
 
-def _create_verif_email(host, path, verification_path):
+def _create_verif_email(endpoint, path, verification_path):
     message = (
         "Welcome to GPF: Genotype and Phenotype in Families! "
         "Follow the link below to validate your new account "
@@ -82,7 +82,7 @@ def _create_verif_email(host, path, verification_path):
     email_settings = {
         "subject": "GPF: Registration validation",
         "initial_message": message,
-        "host": host,
+        "endpoint": endpoint,
         "path": path,
         "verification_path": verification_path,
     }
@@ -90,7 +90,7 @@ def _create_verif_email(host, path, verification_path):
     return _build_email_template(email_settings)
 
 
-def _create_reset_mail(host, path, verification_path, by_admin=False):
+def _create_reset_mail(endpoint, path, verification_path, by_admin=False):
     message = (
         "Hello. You have requested to reset your password for "
         "your GPF account. To do so, please follow the link below:\n {link}\n"
@@ -107,7 +107,7 @@ def _create_reset_mail(host, path, verification_path, by_admin=False):
     email_settings = {
         "subject": "GPF: Password reset request",
         "initial_message": message,
-        "host": host,
+        "endpoint": endpoint,
         "path": path,
         "verification_path": verification_path,
     }
@@ -120,6 +120,6 @@ def _build_email_template(email_settings):
     message = email_settings["initial_message"]
     path = email_settings["path"].format(email_settings["verification_path"])
 
-    message = message.format(link=f"{email_settings['host']}{path}")
+    message = message.format(link=f"{email_settings['endpoint']}{path}")
 
     return {"subject": subject, "message": message}

--- a/wdae/wdae/users_api/utils.py
+++ b/wdae/wdae/users_api/utils.py
@@ -25,14 +25,15 @@ def get_default_application():
 
 def send_verif_email(user, verif_path):
     email = _create_verif_email(
-        settings.EMAIL_HOST,
-        settings.EMAIL_SET_PATH,
+        settings.EMAIL_VERIFICATION_HOST,
+        settings.EMAIL_VERIFICATION_SET_PATH,
         str(verif_path.path),
     )
     user.email_user(email["subject"], email["message"])
 
 
 def send_already_existing_email(user):
+    """Send an email to already existing user."""
     subject = "GPF: Attempted registration with email in use"
     message = (
         "Hello. Someone has attempted to create an account in GPF "
@@ -46,6 +47,7 @@ def send_already_existing_email(user):
 
 
 def send_reset_inactive_acc_email(user):
+    """Send an email to an inactive user."""
     subject = "GPF: Password reset for inactive account"
     message = (
         "Hello. You've requested a password reset for an inactive account. "
@@ -61,8 +63,8 @@ def send_reset_inactive_acc_email(user):
 def send_reset_email(user, verif_path, by_admin=False):
     """Return dict with subject and message of the email."""
     email = _create_reset_mail(
-        settings.EMAIL_HOST,
-        settings.EMAIL_RESET_PATH,
+        settings.EMAIL_VERIFICATION_HOST,
+        settings.EMAIL_VERIFICATION_RESET_PATH,
         str(verif_path.path),
         by_admin,
     )
@@ -77,7 +79,7 @@ def _create_verif_email(host, path, verification_path):
         "and set your password:\n {link}"
     )
 
-    settings = {
+    email_settings = {
         "subject": "GPF: Registration validation",
         "initial_message": message,
         "host": host,
@@ -85,7 +87,7 @@ def _create_verif_email(host, path, verification_path):
         "verification_path": verification_path,
     }
 
-    return _build_email_template(settings)
+    return _build_email_template(email_settings)
 
 
 def _create_reset_mail(host, path, verification_path, by_admin=False):
@@ -102,7 +104,7 @@ def _create_reset_mail(host, path, verification_path, by_admin=False):
             "GPF: Genotype and Phenotype in Families "
             "please follow the link below:\n {link}"
         )
-    settings = {
+    email_settings = {
         "subject": "GPF: Password reset request",
         "initial_message": message,
         "host": host,
@@ -110,14 +112,14 @@ def _create_reset_mail(host, path, verification_path, by_admin=False):
         "verification_path": verification_path,
     }
 
-    return _build_email_template(settings)
+    return _build_email_template(email_settings)
 
 
-def _build_email_template(settings):
-    subject = settings["subject"]
-    message = settings["initial_message"]
-    path = settings["path"].format(settings["verification_path"])
+def _build_email_template(email_settings):
+    subject = email_settings["subject"]
+    message = email_settings["initial_message"]
+    path = email_settings["path"].format(email_settings["verification_path"])
 
-    message = message.format(link="{0}{1}".format(settings["host"], path))
+    message = message.format(link=f"{email_settings['host']}{path}")
 
     return {"subject": subject, "message": message}

--- a/wdae/wdae/wdae/default_settings.py
+++ b/wdae/wdae/wdae/default_settings.py
@@ -47,7 +47,7 @@ else:
     FORCE_SCRIPT_NAME = "/"
 
 EMAIL_HOST = os.environ.get("WDAE_EMAIL_HOST", "localhost")
-EMAIL_USET_TLS = os.environ.get("WDAE_EMAIL_USET_TLS", False)
+EMAIL_USE_TLS = os.environ.get("WDAE_EMAIL_USE_TLS", False)
 EMAIL_HOST_USER = os.environ.get("WDAE_EMAIL_HOST_USER", None)
 EMAIL_HOST_PASSWORD = os.environ.get("WDAE_EMAIL_HOST_PASSWORD", None)
 

--- a/wdae/wdae/wdae/default_settings.py
+++ b/wdae/wdae/wdae/default_settings.py
@@ -28,25 +28,30 @@ AUTHENTICATION_BACKENDS = (
 
 MANAGERS = ADMINS
 
-EMAIL_HOST = "http://localhost:8000"
-EMAIL_SET_PATH = "/api/v3/users/set_password?code={}"
-EMAIL_RESET_PATH = "/api/v3/users/reset_password?code={}"
-
 RESET_PASSWORD_TIMEOUT_HOURS = 24
 
 DEFAULT_OAUTH_APPLICATION_CLIENT = "gpfjs"
 
+EMAIL_VERIFICATION_HOST = "http://localhost:8000"
+EMAIL_VERIFICATION_SET_PATH = "/api/v3/users/set_password?code={}"
+EMAIL_VERIFICATION_RESET_PATH = "/api/v3/users/reset_password?code={}"
 
-""" Set these for production"""
-# EMAIL_USE_TLS = True
-# EMAIL_HOST =
-# EMAIL_PORT =
-# EMAIL_HOST_USER
-# EMAIL_HOST_PASSWORD
+EMAIL_HOST = os.environ.get("WDAE_EMAIL_HOST", "localhost")
+EMAIL_USET_TLS = os.environ.get("WDAE_EMAIL_USET_TLS", False)
+EMAIL_HOST_USER = os.environ.get("WDAE_EMAIL_HOST_USER", None)
+EMAIL_HOST_PASSWORD = os.environ.get("WDAE_EMAIL_HOST_PASSWORD", None)
 
-DEFAULT_FROM_EMAIL = "no-reply@iossifovlab.com"
+EMAIL_PORT = os.environ.get("WDAE_EMAIL_PORT", 1025)
+if EMAIL_PORT is not None:
+    EMAIL_PORT = int(EMAIL_PORT)
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+EMAIL_SUBJECT_PREFIX = "[GPF] "
+
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "WDAE_DEFAULT_FROM_EMAIL", "no-reply@iossifovlab.com")
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+# EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 

--- a/wdae/wdae/wdae/settings.py
+++ b/wdae/wdae/wdae/settings.py
@@ -8,6 +8,8 @@ from gpf_instance.gpf_instance import get_wgpf_instance_path
 
 from .default_settings import *
 
+DEBUG = True
+
 ALLOWED_HOSTS += ["localhost"]
 
 CORS_ORIGIN_WHITELIST = [


### PR DESCRIPTION
## Background

Currently, the `wdae` application has too many different `wdae.settings` that could come from different places. 

## Aim

We want to collect all important configuration variables for the project in `wdae.default_settings` and make them configurable through environment variables. The `wdae.settings` in `iossifovlab-gpf-containers/iossifovlab-gpf-full` should become trivial and should not contain important overrides.

## Implementation

We moved most of the configuration parameters in `wdae.default_settings` and made them configurable through environment variables. In the setup, we run `MailHog` to make possible integration testing for sending mails. Example reset password test is added.

