### PR TITLE
Small improvements and fixes

### DIFF
--- a/dae/dae/dask/tests/test_named_cluster.py
+++ b/dae/dae/dask/tests/test_named_cluster.py
@@ -1,22 +1,79 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import pytest
+
 from dask import config
 
 import dae.dask.named_cluster
-
 from dae.dask.named_cluster import setup_client, \
     setup_client_from_config
 
 
-def test_default():
-    client, _ = setup_client(number_of_threads=4)
-    print(client)
-    assert client
+@pytest.fixture
+def named_cluster_config():
+    return {
+        "default": "local",
+        "clusters": [{
+            "name": "local",
+            "type": "local",
+            "params": {
+                "memory_limit": "4GB",
+                "threads_per_worker": 2,
+            }
+        },
+
+        ]
+    }
 
 
-def test_config_access():
-    with config.set({"dask.config.get": None}):
+def test_default(mocker, named_cluster_config):
+    mocked_local = mocker.patch(
+        "dask.distributed.LocalCluster", autospec=True)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+
+    with config.set({"dae_named_cluster": named_cluster_config}):
         client, _ = setup_client()
         assert client
+
+    assert mocked_local.call_count == 1
+    assert mocked_local.call_args.kwargs == {
+        "memory_limit": "4GB",
+        "threads_per_worker": 2,
+    }
+
+
+def test_default_with_number_of_threads(mocker, named_cluster_config):
+    mocked_local = mocker.patch(
+        "dask.distributed.LocalCluster", autospec=True)
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+
+    with config.set({"dae_named_cluster": named_cluster_config}):
+        client, _ = setup_client(number_of_threads=4)
+        assert client
+
+    assert mocked_local.call_count == 1
+    assert mocked_local.call_args.kwargs["n_workers"] == 1
+
+
+def test_config_access(mocker, named_cluster_config):
+    mocked_local = mocker.patch(
+        "dask.distributed.LocalCluster", autospec=True)
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+    with config.set({"dae_named_cluster": named_cluster_config}):
+        client, _ = setup_client()
+        assert client
+
+    assert mocked_local.call_count == 1
+    assert mocked_local.call_args.kwargs == {
+        "memory_limit": "4GB",
+        "threads_per_worker": 2,
+    }
 
 
 def test_setup_cluster_from_config_simple(mocker):
@@ -38,4 +95,37 @@ def test_setup_cluster_from_config_simple(mocker):
     # pylint: disable=no-member
     dae.dask.named_cluster\
         .set_up_local_cluster.assert_called_once_with({  # type: ignore
+            "number_of_workers": 2
         })
+
+
+def test_setup_sge_cluster(mocker):
+    mocked_sge = mocker.patch(
+        "dask_jobqueue.SGECluster", autospec=True)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+
+    setup_client_from_config({
+        "type": "sge",
+    }, number_of_threads_param=2)
+
+    assert mocked_sge.call_count == 1
+    assert "number_of_workers" not in mocked_sge.call_args.kwargs
+
+
+def test_setup_slurm_cluster(mocker):
+    mocked_slurm = mocker.patch(
+        "dask_jobqueue.SLURMCluster", autospec=True)
+
+    mocker.patch(
+        "dae.dask.named_cluster.Client",
+        autospec=True)
+
+    setup_client_from_config({
+        "type": "slurm",
+    }, number_of_threads_param=2)
+
+    assert mocked_slurm.call_count == 1
+    assert "number_of_workers" not in mocked_slurm.call_args.kwargs

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -483,7 +483,7 @@ def _run_repo_stats_command(repo, proto, **kwargs):
         elif dry_run and needs_rebuild:
             logger.info("Statistics of <%s> need update", res.resource_id)
 
-    if not dry_run:
+    if not dry_run and len(graph.tasks) > 0:
         modified_kwargs = copy.copy(kwargs)
         modified_kwargs["command"] = "run"
         TaskGraphCli.process_graph(
@@ -514,21 +514,23 @@ def _run_resource_stats_command(repo, proto, repo_url, **kwargs):
         logger.error("unable to find resource...")
         return
 
-    graph = TaskGraph()
-
     impl = build_resource_implementation(res)
 
     needs_rebuild = _stats_need_rebuild(proto, impl)
 
+    if dry_run and needs_rebuild:
+        logger.info("Statistics of <%s> need update", res.resource_id)
+        return
+
     if (force or needs_rebuild) and not dry_run:
+        graph = TaskGraph()
         _collect_impl_stats_tasks(
             graph, proto, impl, repo, dry_run, force, use_dvc, region_size)
-    elif dry_run and needs_rebuild:
-        logger.info("Statistics of <%s> need update", res.resource_id)
-
-    modified_kwargs = copy.copy(kwargs)
-    modified_kwargs["command"] = "run"
-    TaskGraphCli.process_graph(graph, force_mode="always", **modified_kwargs)
+        if len(graph.tasks) == 0:
+            return
+        modified_kwargs = copy.copy(kwargs)
+        modified_kwargs["command"] = "run"
+        TaskGraphCli.process_graph(graph, force_mode="always", **modified_kwargs)
 
 
 def _run_repo_repair_command(repo, proto, **kwargs):

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -105,10 +105,11 @@ def _add_dvc_parameters_group(parser):
 
 
 def _add_hist_parameters_group(parser):
-    group = parser.add_argument_group(title="Histograms")
+    group = parser.add_argument_group(title="Statistics")
     group.add_argument(
-        "--region-size", type=int, default=3_000_000,
-        help="Number of records to process in parallel")
+        "--region-size", type=int, default=300_000_000,
+        help="Region size to use for splitting statistics calculation into "
+        "tasks")
 
 
 def _configure_list_subparser(subparsers):

--- a/dae/dae/genomic_resources/genomic_position_table/line.py
+++ b/dae/dae/genomic_resources/genomic_position_table/line.py
@@ -22,10 +22,10 @@ class Line:
         pos_end_key: Key = 2,
         ref_key: Optional[Key] = None,
         alt_key: Optional[Key] = None,
-        header: tuple[str, ...] = tuple(),
+        header: Optional[tuple[str, ...]] = None,
     ):
         self.data: tuple = raw_line
-        self.header: tuple[str, ...] = header
+        self.header: Optional[tuple[str, ...]] = header
         self.chrom: str = self.get(chrom_key)
         self.pos_begin: int = int(self.get(pos_begin_key))
         self.pos_end: int = int(self.get(pos_end_key))
@@ -35,7 +35,11 @@ class Line:
             self.get(alt_key) if alt_key is not None else None
 
     def get(self, key: Key):
-        idx = key if isinstance(key, int) else self.header.index(key)
+        if isinstance(key, int):
+            return self.data[key]
+
+        assert self.header is not None
+        idx = self.header.index(key)
         return self.data[idx]
 
 

--- a/dae/dae/genomic_resources/genomic_position_table/table.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table.py
@@ -24,9 +24,9 @@ class GenomicPositionTable(abc.ABC):
         self.chrom_order: Optional[List[str]] = None
         self.rev_chrom_map: Optional[Dict[str, str]] = None
 
-        self.chrom_key = None
-        self.pos_begin_key = None
-        self.pos_end_key = None
+        self.chrom_key: Optional[int] = None
+        self.pos_begin_key: Optional[int] = None
+        self.pos_end_key: Optional[int] = None
         self.ref_key = None
         self.alt_key = None
 
@@ -108,16 +108,16 @@ class GenomicPositionTable(abc.ABC):
     def _set_core_column_keys(self):
         self.chrom_key = self._get_column_key(self.CHROM)
         if self.chrom_key is None:
-            self.chrom_key = self.CHROM
+            self.chrom_key = self.CHROM  # type: ignore
 
         self.pos_begin_key = self._get_column_key(self.POS_BEGIN)
         if self.pos_begin_key is None:
-            self.pos_begin_key = self.POS_BEGIN
+            self.pos_begin_key = self.POS_BEGIN  # type: ignore
 
         self.pos_end_key = self._get_column_key(self.POS_END)
         if self.pos_end_key is None:
             if self.header and self.POS_END in self.header:
-                self.pos_end_key = self.POS_END
+                self.pos_end_key = self.POS_END  # type: ignore
             else:
                 self.pos_end_key = self.pos_begin_key
 
@@ -166,19 +166,18 @@ class GenomicPositionTable(abc.ABC):
         the chromomes in the file in the order determinted by the file.
         """
 
-    def get_chromosome_length(self, chrom, step=1_000_000):
+    def get_chromosome_length(self, chrom, step=100_000_000):
         """Return the length of a chromosome (or contig).
 
-        The returned value is
-        the index of the last record for the chromosome + 1.
+        Returned value is guarnteed to be larget than the actual contig length.
         """
         def any_records(riter):
             try:
                 next(riter)
             except StopIteration:
                 return False
-            else:
-                return True
+
+            return True
 
         # First we find any region that includes the last record i.e.
         # the length of the chromosome
@@ -191,10 +190,9 @@ class GenomicPositionTable(abc.ABC):
             else:
                 right = pos
                 pos = pos // 2
-
         # Second we use binary search to narrow the region until we find the
         # index of the last element (in left) and the length (in right)
-        while (right - left) > 1:
+        while (right - left) > 5_000_000:
             pos = (left + right) // 2
             if any_records(self.get_records_in_region(chrom, pos, None)):
                 left = pos

--- a/dae/dae/genomic_resources/genomic_position_table/table_inmemory.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table_inmemory.py
@@ -26,6 +26,8 @@ class InmemoryGenomicPositionTable(GenomicPositionTable):
 
     def _make_line(self, data) -> Line:
         assert self.chrom_key is not None
+        assert self.pos_begin_key is not None
+        assert self.pos_end_key is not None
         return Line(
             data,
             self.chrom_key,

--- a/dae/dae/genomic_resources/genomic_position_table/table_tabix.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table_tabix.py
@@ -88,6 +88,8 @@ class TabixGenomicPositionTable(GenomicPositionTable):
 
     def _make_line(self, data) -> Line:
         assert self.chrom_key is not None
+        assert self.pos_begin_key is not None
+        assert self.pos_end_key is not None
         return Line(
             data,
             self.chrom_key,

--- a/dae/dae/genomic_resources/genomic_position_table/utils.py
+++ b/dae/dae/genomic_resources/genomic_position_table/utils.py
@@ -53,7 +53,6 @@ def save_as_tabix_table(
             print(*rec, sep="\t", file=text_file)
     pysam.tabix_compress(tmp_file, full_file_path, force=True)
     os.remove(tmp_file)
-
     pysam.tabix_index(full_file_path, force=True,
                       seq_col=table.chrom_key,
                       start_col=table.pos_begin_key,

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -15,8 +15,6 @@ import yaml
 from jinja2 import Template
 from markdown2 import markdown
 
-import matplotlib.pyplot as plt  # type: ignore
-
 from dae.task_graph.graph import TaskGraph
 from . import GenomicResource
 from .statistic import Statistic
@@ -748,24 +746,12 @@ class GenomicScore(
             ) as outfile:
                 outfile.write(score_histogram.serialize())
 
-            width = score_histogram.bins[1:] - score_histogram.bins[:-1]
-            plt.bar(
-                x=score_histogram.bins[:-1], height=score_histogram.bars,
-                log=score_histogram.y_scale == "log",
-                width=width,
-                align="edge")
-
-            if score_histogram.x_scale == "log":
-                plt.xscale("log")
-            plt.grid(axis="y")
-            plt.grid(axis="x")
             with proto.open_raw_file(
                 resource,
                 f"{GenomicScore.STATISTICS_FOLDER}/histogram_{score_id}.png",
                 mode="wb"
             ) as outfile:
-                plt.savefig(outfile)
-            plt.clf()
+                score_histogram.plot(outfile)
         return merged_histograms
 
     def _split_into_regions(self, region_size, reference_genome=None):

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -812,7 +812,7 @@ class GenomicScore(
         score_filename = config["table"]["filename"]
         return json.dumps({
             "config": {
-                "scores": config["scores"],
+                "scores": config.get("scores", {}),
                 "histograms": config.get("histograms", {}),
                 "table": config["table"]
             },

--- a/dae/dae/genomic_resources/histogram.py
+++ b/dae/dae/genomic_resources/histogram.py
@@ -132,6 +132,29 @@ class Histogram(Statistic):
             }
         ))
 
+    def plot(self, outfile):
+        """Plot histogram and save it into outfile."""
+        # pylint: disable=import-outside-toplevel
+        import matplotlib.pyplot as plt
+        width = self.bins[1:] - self.bins[:-1]
+        plt.bar(
+            x=self.bins[:-1], height=self.bars,
+            log=self.y_scale == "log",
+            width=width,
+            align="edge")
+
+        if self.x_scale == "log":
+            plt.xscale("log")
+
+        plt.xlabel(self.score_id)
+        plt.ylabel("count")
+
+        plt.grid(axis="y")
+        plt.grid(axis="x")
+
+        plt.savefig(outfile)
+        plt.clf()
+
     @staticmethod
     def deserialize(data) -> Histogram:
         res = yaml.load(data, yaml.Loader)

--- a/dae/dae/genomic_resources/tests/test_genomic_position_table.py
+++ b/dae/dae/genomic_resources/tests/test_genomic_position_table.py
@@ -1087,12 +1087,12 @@ def test_contig_length():
             1     12        11    6.13
             2     1         2     0"""})
     with build_genomic_position_table(res, res.config["table"]) as tab:
-        assert tab.get_chromosome_length("1") == 13
-        assert tab.get_chromosome_length("2") == 2
+        assert tab.get_chromosome_length("1") >= 13
+        assert tab.get_chromosome_length("2") >= 2
 
 
 def test_contig_length_tabix_table(tabix_table):
-    assert tabix_table.get_chromosome_length("1") == 13
+    assert tabix_table.get_chromosome_length("1") >= 13
 
 
 def test_vcf_autodetect_format(vcf_res_autodetect_format):

--- a/dae/dae/impala_storage/helpers/hdfs_helpers.py
+++ b/dae/dae/impala_storage/helpers/hdfs_helpers.py
@@ -146,6 +146,6 @@ class HdfsHelpers:
 
         assert self.isdir(hdfs_dirname), hdfs_dirname
 
-        result = []
+        result: list[str] = []
         list_parquet_files_recursive(hdfs_dirname, result)
         return result

--- a/dae/dae/impala_storage/schema2/schema2_genotype_storage.py
+++ b/dae/dae/impala_storage/schema2/schema2_genotype_storage.py
@@ -70,6 +70,9 @@ class Schema2GenotypeStorage(GenotypeStorage):
         # Copy pedigree
         base_dir = self.storage_config["hdfs"]["base_dir"]
         study_path = os.path.join(base_dir, study_id)
+        if self.hdfs_helpers.exists(study_path):
+            self.hdfs_helpers.delete(study_path, recursive=True)
+
         pedigree_hdfs_path = os.path.join(
             study_path, "pedigree", "pedigree.parquet"
         )

--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -111,8 +111,7 @@ class TaskGraphCli:
     @staticmethod
     def process_graph(
             task_graph: TaskGraph, force_mode="optional", **kwargs) -> bool:
-        """
-        Process task_graph in according with the arguments in args.
+        """Process task_graph in according with the arguments in args.
 
         Return true if the graph get's successfully processed.
         """
@@ -136,4 +135,4 @@ class TaskGraphCli:
             res = task_graph_status(task_graph, task_cache, args.verbose)
             return res
 
-        raise Exception("Unknown command")
+        raise ValueError(f"Unknown command {args.command}")

--- a/dae/tests/conftest.py
+++ b/dae/tests/conftest.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-
+from typing import Optional, Any
 from dae.genotype_storage.genotype_storage_registry import \
     GenotypeStorageRegistry
 
@@ -56,7 +56,7 @@ def default_genotype_storage_configs(root_path):
 
 
 GENOTYPE_STORAGE_REGISTRY = GenotypeStorageRegistry()
-GENOTYPE_STORAGES = None
+GENOTYPE_STORAGES: Optional[dict[str, Any]] = None
 
 
 def _select_storages_by_type(storage_types):


### PR DESCRIPTION
## Aim

Fix a number of nuisances in the GPF code base.

- Before uploading parquet files into HDFS, we need to remove the target directory.
- Default value of `--region-size` in `grr_manage` command should become 300_000_000.
- Fix the help message for `--region-size`.
- When creating a local Dask cluster without specifying the number of workers, we should use the default Dask policy for the number of workers.
- `grr_manage` should not create a task executor (Dask cluster) if there are no statistics tasks to compute.
- Add axes labels to the histogram plots.
- Improve performance of `get_chromosome_length` in the genomic position table.
