### PR TITLE
Capture logs from tasks executed by task graph Dask executor

### DIFF
--- a/dae/dae/task_graph/cli_tools.py
+++ b/dae/dae/task_graph/cli_tools.py
@@ -41,7 +41,10 @@ class TaskGraphCli:
             type=str, default=None,
             help="dask cluster config file"
         )
-
+        executor_group.add_argument(
+            "--tasks-log-dir", dest="log_dir", type=str, default=None,
+            help="Path to directory where to store tasks' logs"
+        )
         # task_cache
         execution_mode_group = parser.add_argument_group(
             title="Execution Mode")
@@ -106,7 +109,7 @@ class TaskGraphCli:
             client, _ = setup_client(args.dask_cluster_name,
                                      number_of_threads=args.jobs)
         print("Working with client:", client)
-        return DaskExecutor(client, task_cache=task_cache)
+        return DaskExecutor(client, task_cache=task_cache, **kwargs)
 
     @staticmethod
     def process_graph(

--- a/dae/dae/task_graph/executor.py
+++ b/dae/dae/task_graph/executor.py
@@ -239,12 +239,12 @@ class DaskExecutor(AbstractTaskGraphExecutor):
         handler = configure_task_logging(log_dir, task_id, verbose)
         root_logger.addHandler(handler)
 
-        task_logger = logging.getLogger(task_id)
-        task_logger.warning("Starting task: %s", task_id)
+        task_logger = logging.getLogger("task_executor")
+        task_logger.info("task <%s> started", task_id)
         start = time.time()
         result = task_func(*args)
         elapsed = time.time() - start
-        task_logger.warning("Finish task %s in %0.2fsec", task_id, elapsed)
+        task_logger.info("task <%s> finished in %0.2fsec", task_id, elapsed)
 
         root_logger.removeHandler(handler)
         handler.close()

--- a/dae/dae/task_graph/logging.py
+++ b/dae/dae/task_graph/logging.py
@@ -71,7 +71,7 @@ def configure_task_logging(log_dir, task_id, verbosity):
     return handler
 
 
-RE_TASK_ID = re.compile(r"[\. /]")
+RE_TASK_ID = re.compile(r"[\. /,()\-:]")
 
 
 def safe_task_id(task_id):

--- a/dae/dae/task_graph/logging.py
+++ b/dae/dae/task_graph/logging.py
@@ -1,0 +1,78 @@
+import re
+import logging
+
+from dae.utils import fs_utils
+
+
+class FsspecHandler(logging.StreamHandler):
+    """Class to create fsspec based logging handler."""
+
+    def __init__(self, logfile: str):
+        fs, logpath = fs_utils.url_to_fs(logfile)
+        stream = fs.open(logpath, "w")
+        super().__init__(stream=stream)
+
+    def close(self):
+        """Close the stream.
+
+        Copied from logging.FileHandler.close().
+        """
+        self.acquire()
+        try:
+            try:
+                if self.stream:
+                    try:
+                        self.flush()
+                    finally:
+                        stream = self.stream
+                        self.stream = None
+                        stream.close()
+            finally:
+                # Issue #19523: call unconditionally to
+                # prevent a handler leak when delay is set
+                # Also see Issue #42378: we also rely on
+                # self._closed being set to True there
+                logging.StreamHandler.close(self)
+        finally:
+            self.release()
+
+
+def ensure_log_dir(**kwargs):
+    """Ensure logging directory exists."""
+    log_dir = kwargs.get("log_dir")
+    if log_dir is not None:
+        log_dir = fs_utils.abspath(log_dir)
+        if not fs_utils.exists(log_dir):
+            fs, path = fs_utils.url_to_fs(log_dir)
+            fs.mkdir(path, exists_ok=True)
+    return log_dir
+
+
+def configure_task_logging(log_dir, task_id, verbosity):
+    """Configure and return task logging hadnler."""
+    if log_dir is None:
+        return logging.NullHandler()
+
+    if verbosity == 1:
+        loglevel = logging.INFO
+    elif verbosity == 2:
+        loglevel = logging.DEBUG
+    else:
+        loglevel = logging.WARNING
+
+    logfile = fs_utils.join(log_dir, f"log_{task_id}.log")
+
+    handler = FsspecHandler(logfile)
+    formatter = logging.Formatter(
+        f"{task_id}: %(asctime)s %(name)s %(levelname)s %(message)s")
+    handler.setFormatter(formatter)
+    handler.setLevel(loglevel)
+
+    return handler
+
+
+RE_TASK_ID = re.compile(r"[\. /]")
+
+
+def safe_task_id(task_id):
+    return RE_TASK_ID.sub("_", task_id)

--- a/dae/dae/utils/fs_utils.py
+++ b/dae/dae/utils/fs_utils.py
@@ -7,6 +7,13 @@ from typing import Optional, Union, cast
 from fsspec.core import url_to_fs
 
 
+def abspath(filename):
+    url = urlparse(filename)
+    if url.scheme:
+        return filename
+    return os.path.abspath(filename)
+
+
 def exists(filename):
     fs, relative_path = url_to_fs(filename)
     return fs.exists(relative_path)

--- a/dae/dae/utils/tests/test_fs_utils.py
+++ b/dae/dae/utils/tests/test_fs_utils.py
@@ -49,3 +49,20 @@ def test_tabix_index_filename_file_not_found(mocker):
         lambda tf: False)
     with pytest.raises(IOError, match="tabix file 'test' not found"):
         fs_utils.tabix_index_filename("test")
+
+
+@pytest.mark.parametrize("url, expected", [
+    ("/filename", "/filename"),
+    ("/dir/filename", "/dir/filename"),
+    ("file:///dir/filename", "file:///dir/filename"),
+    ("s3://bucket", "s3://bucket"),
+    ("s3://bucket/dir/filename", "s3://bucket/dir/filename"),
+    ("file", "/abs/path/file"),
+    ("./file", "/abs/path/file"),
+    ("/", "/"),
+    ("s3://", "s3://"),
+])
+def test_abspath(url, expected, mocker):
+    mocker.patch("os.getcwd", return_value="/abs/path")
+    res = fs_utils.abspath(url)
+    assert res == expected

--- a/dae/dae/utils/verbosity_configuration.py
+++ b/dae/dae/utils/verbosity_configuration.py
@@ -14,10 +14,23 @@ class VerbosityConfiguration:
     @staticmethod
     def set(args) -> None:
         """Read verbosity settings from parsed arguments and sets logger."""
-        if args.verbose == 1:
+        VerbosityConfiguration.set_verbosity(args.verbose)
+
+    @staticmethod
+    def set_verbosity(verbose):
+        """Set logging level according to the verbosity specified."""
+        if verbose == 1:
+            loglevel = logging.INFO
             logging.basicConfig(level=logging.INFO)
-        elif args.verbose >= 2:
+        elif verbose >= 2:
+            loglevel = logging.DEBUG
             logging.basicConfig(level=logging.DEBUG)
         else:
+            loglevel = logging.WARNING
             logging.basicConfig(level=logging.WARNING)
+
         logging.getLogger("impala").setLevel(logging.WARNING)
+        logging.getLogger("distributed").setLevel(logging.WARNING)
+        logging.getLogger("bokeh").setLevel(logging.ERROR)
+        logging.getLogger("fsspec").setLevel(max(loglevel, logging.INFO))
+        logging.getLogger("matplotlib").setLevel(max(loglevel, logging.INFO))

--- a/dae/dae/utils/verbosity_configuration.py
+++ b/dae/dae/utils/verbosity_configuration.py
@@ -29,6 +29,9 @@ class VerbosityConfiguration:
             loglevel = logging.WARNING
             logging.basicConfig(level=logging.WARNING)
 
+        logging.getLogger("dae.effect_annotation").setLevel(
+            max(loglevel, logging.INFO))
+
         logging.getLogger("impala").setLevel(logging.WARNING)
         logging.getLogger("distributed").setLevel(logging.WARNING)
         logging.getLogger("bokeh").setLevel(logging.ERROR)

--- a/dae/dae/utils/verbosity_configuration.py
+++ b/dae/dae/utils/verbosity_configuration.py
@@ -34,3 +34,5 @@ class VerbosityConfiguration:
         logging.getLogger("bokeh").setLevel(logging.ERROR)
         logging.getLogger("fsspec").setLevel(max(loglevel, logging.INFO))
         logging.getLogger("matplotlib").setLevel(max(loglevel, logging.INFO))
+        logging.getLogger("botocore").setLevel(max(loglevel, logging.INFO))
+        logging.getLogger("s3fs").setLevel(max(loglevel, logging.INFO))


### PR DESCRIPTION
## Background

When tasks are executed using Dask executor running on SGE/Kubernetes/Slurm, the logs of the task are very difficult to find and expect.

## Aim

Provide a way to collect tasks logs in an easy-to-follow way that covers different scenarios of using Dask clusters.

## Implementation

We added a `FsspecHandler` logging handler that is able to store logs in any `fsspec` supported writeable filesystem. For each task we start using `DaskExecutor` we add `FsspecHandler` to store logs from that task in a separate log file.
