### PR TITLE
Utilise TaskGraph in annotate_vcf tool

### DIFF
--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -20,7 +20,7 @@ from dae.task_graph.graph import TaskGraph
 logger = logging.getLogger("annotate_vcf")
 
 
-PART_FILENAME = "{in_file}_annotation_{chrom}_{pos_beg}_{pos_end}.vcf"
+PART_FILENAME = "{in_file}_annotation_{chrom}_{pos_beg}_{pos_end}.vcf.gz"
 
 
 def configure_argument_parser() -> argparse.ArgumentParser:

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -130,9 +130,11 @@ def produce_partfile_paths(input_file_path, regions, work_dir):
     """Produce a list of file paths for output region part files."""
     filenames = []
     for region in regions:
+        pos_beg = region[1] if len(region) > 1 else "?"
+        pos_end = region[2] if len(region) > 2 else "?"
         filenames.append(os.path.join(work_dir, PART_FILENAME.format(
             in_file=os.path.basename(input_file_path),
-            chrom=region[0], pos_beg=region[1], pos_end=region[2]
+            chrom=region[0], pos_beg=pos_beg, pos_end=pos_end
         )))
     return filenames
 

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -5,12 +5,14 @@ import argparse
 import logging
 from typing import List, Optional
 
-from pysam import VariantFile  # pylint: disable=no-name-in-module
+from pysam import VariantFile, TabixFile  # pylint: disable=no-name-in-module
 
 from dae.annotation.context import CLIAnnotationContext
 from dae.annotation.annotatable import VCFAllele
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.genomic_resources.genomic_context import get_genomic_context
+from dae.task_graph import TaskGraphCli
+from dae.task_graph.graph import TaskGraph
 
 logger = logging.getLogger("annotate_vcf")
 
@@ -29,10 +31,54 @@ def configure_argument_parser() -> argparse.ArgumentParser:
                         "from the configured gpf instance will be used.")
     parser.add_argument("output", default="-", nargs="?",
                         help="the output column file")
+    parser.add_argument("region_size", default=500,
+                        type=int, help="region size to parallelize by")
 
     CLIAnnotationContext.add_context_arguments(parser)
+    TaskGraphCli.add_arguments(parser)
     VerbosityConfiguration.set_argumnets(parser)
     return parser
+
+
+def annotate(input_file, region):
+    # once again open the VCF file
+    # query variants from it for given region
+    # annotate them and yield them how?
+    # handling the variants
+    context = get_genomic_context()
+    in_file = VariantFile(input_file)
+    pipeline = CLIAnnotationContext.get_pipeline(context)
+    annotation_attributes = pipeline.annotation_schema.names
+    res = list()
+    with pipeline.open() as pipeline:
+        for vcf_var in in_file.fetch(*region):
+            # pylint: disable=use-list-literal
+            buffers: List[List] = [list() for _ in annotation_attributes]
+
+            if vcf_var.alts is None:
+                logger.info("vcf variant without alternatives: %s", vcf_var)
+                continue
+
+            for alt in vcf_var.alts:
+                annotabale = VCFAllele(
+                    vcf_var.chrom, vcf_var.pos, vcf_var.ref, alt)
+                annotation = pipeline.annotate(annotabale)
+                for buff, attribute in zip(buffers, annotation_attributes):
+                    buff.append(str(annotation[attribute]))
+
+            for attribute, buff in zip(annotation_attributes, buffers):
+                vcf_var.info[attribute] = ",".join(buff)
+            res.append(str(vcf_var))
+    return res
+
+
+def combine(*results):
+    # collect all annotation results
+    # merge into single vcf file
+    # output
+    for result in results:
+        print(result)
+        # print(result, file=out_file, end="")
 
 
 def cli(raw_args: Optional[list[str]] = None) -> None:
@@ -72,30 +118,54 @@ def cli(raw_args: Optional[list[str]] = None) -> None:
         header.info.add(
             attribute, "A", "String",
             description)
+    in_file.close()
 
     print(str(header), file=out_file, end="")
 
-    # handling the variants
-    with pipeline.open() as pipeline:
-        for vcf_var in in_file:
-            buffers: List[List] = [list([]) for _ in annotation_attributes]
+    # get region size from args
+    region_size = args.region_size
+    # get contigs in file
+    pysam_file = TabixFile(args.input)
+    contigs = list(map(str, pysam_file.contigs))
+    pysam_file.close()
+    # get lengths for each contig
+    ref_genome = context.get_reference_genome()
+    assert ref_genome is not None
+    contig_lengths = {}
+    for contig in contigs:
+        try:
+            contig_lengths[contig] = ref_genome.get_chrom_length(contig)
+        except ValueError as exc:
+            # TODO Handle missing chromosomes by queueing them as an
+            # entire region by themselves
+            print(str(exc))
+    # produce regions from all info above
 
-            if vcf_var.alts is None:
-                logger.info("vcf variant without alternatives: %s", vcf_var)
-                continue
 
-            for alt in vcf_var.alts:
-                annotabale = VCFAllele(
-                    vcf_var.chrom, vcf_var.pos, vcf_var.ref, alt)
-                annotation = pipeline.annotate(annotabale)
-                for buff, attribute in zip(buffers, annotation_attributes):
-                    buff.append(str(annotation[attribute]))
 
-            for attribute, buff in zip(annotation_attributes, buffers):
-                vcf_var.info[attribute] = ",".join(buff)
-            print(str(vcf_var), file=out_file, end="")
-
-    in_file.close()
+    # TODO Use utils/regions and create func for building regions.
+    # genomic resources - genomic_scores.py _split_into_regions
+    # make it cover both use cases and extract as util
+    regions = [
+        (contig, start, start + region_size)
+        for contig, length in contig_lengths.items()
+        for start in range(1, length, region_size)
+    ]
+    # create taskgraph
+    print(regions)
+    task_graph = TaskGraph()
+    # spawn a task for each region, passing what is needed to annotate
+    parts = [
+        task_graph.create_task(
+            f"part {region}", annotate, [args.input, region], []
+        )
+        for region in regions
+    ]
+    print(parts)
+    print(len(parts))
+    # spawn a task that has all annotation task results as input
+    task_graph.create_task("combine", combine, parts, [])
+    TaskGraphCli.process_graph(task_graph, **vars(args))
 
     if args.output != "-":
         out_file.close()

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -176,7 +176,7 @@ def cli(raw_args: Optional[list[str]] = None) -> None:
             "combine",
             combine,
             [args.input, pipeline, file_paths, output],
-            [region_tasks]
+            region_tasks
         )
         TaskGraphCli.process_graph(task_graph, **vars(args))
 

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -19,9 +19,6 @@ from dae.task_graph.graph import TaskGraph
 logger = logging.getLogger("annotate_vcf")
 
 
-# TODO Make unit test for multiallelic vcf input
-
-
 PART_FILENAME = "{in_file}_annotation_{chrom}_{pos_beg}_{pos_end}.vcf"
 COMBINED_FILENAME = "combined.vcf"
 
@@ -84,7 +81,7 @@ def annotate(input_file, region, pipeline, out_filepath):
                     buff.append(str(annotation.get(attribute, "-")))
 
             for attribute, buff in zip(annotation_attributes, buffers):
-                vcf_var.info[attribute] = ",".join(buff)
+                vcf_var.info[attribute] = buff
             out_file.write(vcf_var)
     out_file.close()
     in_file.close()

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -41,7 +41,7 @@ def configure_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("-r", "--region-size", default=300_000_000,
                         type=int, help="region size to parallelize by")
     parser.add_argument("-o", "--work-dir",
-                        help="Directory to store output files in",
+                        help="Directory to store intermediate output files in",
                         default="output")
     CLIAnnotationContext.add_context_arguments(parser)
     TaskGraphCli.add_arguments(parser)

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -7,7 +7,8 @@ import logging
 from contextlib import closing
 from typing import List, Optional
 
-from pysam import VariantFile, TabixFile  # pylint: disable=no-name-in-module
+from pysam import VariantFile, TabixFile, \
+    tabix_index  # pylint: disable=no-name-in-module
 
 from dae.annotation.context import CLIAnnotationContext
 from dae.annotation.annotatable import VCFAllele
@@ -103,6 +104,7 @@ def combine(input_file_path, pipeline, partfile_paths, output_file_path):
                 partfile = VariantFile(partfile_path)
                 for rec in partfile.fetch():
                     output_file.write(rec)
+        tabix_index(output_file_path, preset="vcf")
 
 
 def produce_regions(context, contigs, region_size):

--- a/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
@@ -148,18 +148,19 @@ def test_basic_setup_vcf(tmp_path, annotate_directory_fixture):
     })
 
     in_file = tmp_path / "in.vcf"
-    out_file = tmp_path / "out.vcf"
+    workdir = f"{tmp_path}/output"
     annotation_file = tmp_path / "annotation.yaml"
     grr_file = tmp_path / "grr.yaml"
 
     cli_vcf([
         str(a) for a in [
-            in_file, annotation_file, out_file, "--grr", grr_file
+            in_file, annotation_file, "-o", workdir, "--grr", grr_file
         ]
     ])
 
     result = []
-    with pysam.VariantFile(out_file) as vcf_file:  # pylint: disable=no-member
+    # pylint: disable=no-member
+    with pysam.VariantFile(f"{workdir}/combined.vcf") as vcf_file:
         for vcf in vcf_file.fetch():
             result.append(vcf.info["score"][0])
     assert result == ["0.01", "0.2"]

--- a/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
@@ -170,19 +170,21 @@ def test_basic_setup_vcf(tmp_path, annotate_directory_fixture):
     })
 
     in_file = tmp_path / "in.vcf"
-    workdir = f"{tmp_path}/output"
+    out_file = tmp_path / "out.vcf"
+    workdir = tmp_path / "output"
     annotation_file = tmp_path / "annotation.yaml"
     grr_file = tmp_path / "grr.yaml"
 
     cli_vcf([
         str(a) for a in [
-            in_file, annotation_file, "-o", workdir, "--grr", grr_file
+            in_file, annotation_file, "-o", workdir, "--grr", grr_file,
+            "-o", out_file
         ]
     ])
 
     result = []
     # pylint: disable=no-member
-    with pysam.VariantFile(f"{workdir}/combined.vcf") as vcf_file:
+    with pysam.VariantFile(out_file) as vcf_file:
         for vcf in vcf_file.fetch():
             result.append(vcf.info["score"][0])
     assert result == ["0.01", "0.2"]
@@ -202,19 +204,21 @@ def test_multiallelic_setup_vcf(tmp_path, annotate_directory_fixture):
     })
 
     in_file = tmp_path / "in.vcf"
-    workdir = f"{tmp_path}/output"
+    out_file = tmp_path / "out.vcf"
+    workdir = tmp_path / "output"
     annotation_file = tmp_path / "annotation_multiallelic.yaml"
     grr_file = tmp_path / "grr.yaml"
 
     cli_vcf([
         str(a) for a in [
-            in_file, annotation_file, "-o", workdir, "--grr", grr_file
+            in_file, annotation_file, "-w", workdir, "--grr", grr_file,
+            "-o", out_file
         ]
     ])
 
     result = []
     # pylint: disable=no-member
-    with pysam.VariantFile(f"{workdir}/combined.vcf") as vcf_file:
+    with pysam.VariantFile(out_file) as vcf_file:
         for vcf in vcf_file.fetch():
             result.append(vcf.info["score"])
     assert result == [("0.1", "0.2"), ("0.3", "0.4")]

--- a/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
@@ -8,7 +8,7 @@ from dae.annotation.annotate_columns import build_record_to_annotatable
 from dae.annotation.annotatable import Position, VCFAllele, Region
 from dae.testing import setup_directories, setup_vcf, setup_denovo
 from dae.annotation.annotate_columns import cli as cli_columns
-from dae.annotation.annotate_vcf import cli as cli_vcf
+from dae.annotation.annotate_vcf import cli as cli_vcf, produce_partfile_paths
 
 
 @pytest.mark.parametrize(
@@ -63,22 +63,26 @@ def get_file_content_as_string(file):
 
 @pytest.fixture
 def annotate_directory_fixture(tmp_path):
-    setup_directories(tmp_path, {
-        "annotation.yaml": """
-            - position_score: one
+    setup_directories(
+        tmp_path,
+        {
+            "annotation.yaml": """
+                - position_score: one
             """,
-        "annotation_multiallelic.yaml": """
-            - allele_score: two
+            "annotation_multiallelic.yaml": """
+                - allele_score: two
             """,
-        "grr.yaml": """
-            id: mm
-            type: embedded
-            content:
-                one:
-                    genomic_resource.yaml: |
+            "grr.yaml": f"""
+                id: mm
+                type: dir
+                directory: "{tmp_path}/grr"
+            """,
+            "grr": {
+                "one": {
+                    "genomic_resource.yaml": """
                         type: position_score
                         table:
-                            filename: data.mem
+                            filename: data.txt
                         scores:
                         - id: score
                           type: float
@@ -86,15 +90,13 @@ def annotate_directory_fixture(tmp_path):
                                 The phastCons computed over the tree of 100
                                 verterbarte species
                           name: s1
-                    data.mem: |
-                        chrom  pos_begin  s1
-                        chr1   23         0.01
-                        chr1   24         0.2
-                two:
-                    genomic_resource.yaml: |
+                    """
+                },
+                "two": {
+                    "genomic_resource.yaml": """
                         type: allele_score
                         table:
-                            filename: data.mem
+                            filename: data.txt
                             reference:
                               name: reference
                             alternative:
@@ -103,15 +105,29 @@ def annotate_directory_fixture(tmp_path):
                         - id: score
                           type: float
                           name: s1
-                    data.mem: |
-                        chrom  pos_begin  reference  alternative  s1
-                        chr1   23         C          T            0.1
-                        chr1   23         C          A            0.2
-                        chr1   24         C          A            0.3
-                        chr1   24         C          G            0.4
-
-            """
-    })
+                    """
+                }
+            }
+        }
+    )
+    one_content = textwrap.dedent("""
+        chrom  pos_begin  s1
+        chr1   23         0.1
+        chr1   24         0.2
+        chr2   33         0.3
+        chr2   34         0.4
+        chr3   43         0.5
+        chr3   44         0.6
+    """)
+    two_content = textwrap.dedent("""
+        chrom  pos_begin  reference  alternative  s1
+        chr1   23         C          T            0.1
+        chr1   23         C          A            0.2
+        chr1   24         C          A            0.3
+        chr1   24         C          G            0.4
+    """)
+    setup_denovo(tmp_path / "grr" / "one" / "data.txt", one_content)
+    setup_denovo(tmp_path / "grr" / "two" / "data.txt", two_content)
 
 
 def test_basic_setup(tmp_path, annotate_directory_fixture):
@@ -122,16 +138,16 @@ def test_basic_setup(tmp_path, annotate_directory_fixture):
     """)
     out_expected_content = (
         "chrom\tpos\tscore\n"
-        "chr1\t23\t0.01\n"
+        "chr1\t23\t0.1\n"
         "chr1\t24\t0.2\n"
     )
-
-    setup_denovo(tmp_path / "in.txt", in_content)
 
     in_file = tmp_path / "in.txt"
     out_file = tmp_path / "out.txt"
     annotation_file = tmp_path / "annotation.yaml"
     grr_file = tmp_path / "grr.yaml"
+
+    setup_denovo(in_file, in_content)
 
     cli_columns([
         str(a) for a in [
@@ -153,17 +169,17 @@ def test_basic_vcf(tmp_path, annotate_directory_fixture):
         chr1   24  .  C   A   .    .      .    GT     0/0 0/1 0/0
     """)
 
-    setup_vcf(tmp_path / "in.vcf", in_content)
-
     in_file = tmp_path / "in.vcf"
     out_file = tmp_path / "out.vcf"
     workdir = tmp_path / "output"
     annotation_file = tmp_path / "annotation.yaml"
     grr_file = tmp_path / "grr.yaml"
 
+    setup_vcf(in_file, in_content)
+
     cli_vcf([
         str(a) for a in [
-            in_file, annotation_file, "-o", workdir, "--grr", grr_file,
+            in_file, annotation_file, "-w", workdir, "--grr", grr_file,
             "-o", out_file
         ]
     ])
@@ -173,7 +189,7 @@ def test_basic_vcf(tmp_path, annotate_directory_fixture):
     with pysam.VariantFile(out_file) as vcf_file:
         for vcf in vcf_file.fetch():
             result.append(vcf.info["score"][0])
-    assert result == ["0.01", "0.2"]
+    assert result == ["0.1", "0.2"]
 
 
 def test_multiallelic_vcf(tmp_path, annotate_directory_fixture):
@@ -185,13 +201,13 @@ def test_multiallelic_vcf(tmp_path, annotate_directory_fixture):
         chr1   24  .  C   A,G   .    .      .
     """)
 
-    setup_vcf(tmp_path / "in.vcf", in_content)
-
     in_file = tmp_path / "in.vcf"
     out_file = tmp_path / "out.vcf"
     workdir = tmp_path / "output"
     annotation_file = tmp_path / "annotation_multiallelic.yaml"
     grr_file = tmp_path / "grr.yaml"
+
+    setup_vcf(in_file, in_content)
 
     cli_vcf([
         str(a) for a in [
@@ -206,3 +222,66 @@ def test_multiallelic_vcf(tmp_path, annotate_directory_fixture):
         for vcf in vcf_file.fetch():
             result.append(vcf.info["score"])
     assert result == [("0.1", "0.2"), ("0.3", "0.4")]
+
+
+def test_vcf_multiple_chroms(tmp_path, annotate_directory_fixture):
+    in_content = textwrap.dedent("""
+        ##fileformat=VCFv4.2
+        ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+        ##contig=<ID=chr1>
+        ##contig=<ID=chr2>
+        ##contig=<ID=chr3>
+        #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT m1  d1  c1
+        chr1   23  .  C   T   .    .      .    GT     0/1 0/0 0/0
+        chr1   24  .  C   A   .    .      .    GT     0/0 0/1 0/0
+        chr2   33  .  C   T   .    .      .    GT     0/1 0/0 0/0
+        chr2   34  .  C   A   .    .      .    GT     0/0 0/1 0/0
+        chr3   43  .  C   T   .    .      .    GT     0/1 0/0 0/0
+        chr3   44  .  C   A   .    .      .    GT     0/0 0/1 0/0
+    """)
+
+    in_file = tmp_path / "in.vcf.gz"
+    out_file = tmp_path / "out.vcf"
+    workdir = tmp_path / "output"
+    annotation_file = tmp_path / "annotation.yaml"
+    grr_file = tmp_path / "grr.yaml"
+
+    tasks_log_dir = tmp_path / "tld"
+    tasks_status_dir = tmp_path / "tsd"
+
+    setup_vcf(in_file, in_content)
+
+    cli_vcf([
+        str(a) for a in [
+            in_file, annotation_file, "-w", workdir, "--grr", grr_file,
+            "-o", out_file, "-j 1",
+            "--tasks-log-dir", tasks_log_dir,
+            "-d", tasks_status_dir
+        ]
+    ])
+
+    result = []
+    # pylint: disable=no-member
+    with pysam.VariantFile(out_file) as vcf_file:
+        for vcf in vcf_file.fetch():
+            result.append(vcf.info["score"][0])
+    assert result == ["0.1", "0.2",
+                      "0.3", "0.4",
+                      "0.5", "0.6"]
+
+
+def test_produce_partfile_paths():
+    regions = [("chr1", 0, 1000), ("chr1", 1000, 2000), ("chr1", 2000, 3000)]
+    expected_output = [
+        "work_dir/output/input.vcf_annotation_chr1_0_1000.vcf",
+        "work_dir/output/input.vcf_annotation_chr1_1000_2000.vcf",
+        "work_dir/output/input.vcf_annotation_chr1_2000_3000.vcf",
+    ]
+    # relative input file path
+    assert produce_partfile_paths(
+        "src/input.vcf", regions, "work_dir/output"
+    ) == expected_output
+    # absolute input file path
+    assert produce_partfile_paths(
+        "/home/user/src/input.vcf", regions, "work_dir/output"
+    ) == expected_output

--- a/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
@@ -1,4 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
 import textwrap
 
 import pytest
@@ -241,7 +242,8 @@ def test_vcf_multiple_chroms(tmp_path, annotate_directory_fixture):
     """)
 
     in_file = tmp_path / "in.vcf.gz"
-    out_file = tmp_path / "out.vcf"
+    out_file = tmp_path / "out.vcf.gz"
+    out_file_tbi = tmp_path / "out.vcf.gz.tbi"
     workdir = tmp_path / "output"
     annotation_file = tmp_path / "annotation.yaml"
     grr_file = tmp_path / "grr.yaml"
@@ -268,6 +270,7 @@ def test_vcf_multiple_chroms(tmp_path, annotate_directory_fixture):
     assert result == ["0.1", "0.2",
                       "0.3", "0.4",
                       "0.5", "0.6"]
+    assert os.path.exists(out_file_tbi)
 
 
 def test_produce_partfile_paths():

--- a/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_and_vcf.py
@@ -273,9 +273,9 @@ def test_vcf_multiple_chroms(tmp_path, annotate_directory_fixture):
 def test_produce_partfile_paths():
     regions = [("chr1", 0, 1000), ("chr1", 1000, 2000), ("chr1", 2000, 3000)]
     expected_output = [
-        "work_dir/output/input.vcf_annotation_chr1_0_1000.vcf",
-        "work_dir/output/input.vcf_annotation_chr1_1000_2000.vcf",
-        "work_dir/output/input.vcf_annotation_chr1_2000_3000.vcf",
+        "work_dir/output/input.vcf_annotation_chr1_0_1000.vcf.gz",
+        "work_dir/output/input.vcf_annotation_chr1_1000_2000.vcf.gz",
+        "work_dir/output/input.vcf_annotation_chr1_2000_3000.vcf.gz",
     ]
     # relative input file path
     assert produce_partfile_paths(

--- a/dae/dae/genomic_resources/reference_genome.py
+++ b/dae/dae/genomic_resources/reference_genome.py
@@ -149,7 +149,7 @@ class ReferenceGenome(
         """Return the length of a specified chromosome."""
         chrom_data = self._index.get(chrom)
         if chrom_data is None:
-            raise ValueError(f"can't fined chromosome {chrom}")
+            raise ValueError(f"can't find chromosome {chrom}")
         return cast(int, chrom_data["length"])
 
     def get_all_chrom_lengths(self):

--- a/dae/dae/task_graph/graph.py
+++ b/dae/dae/task_graph/graph.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Iterable, Optional
 
 @dataclass(eq=False, frozen=True)
 class Task:
-    """Represent one node in a TaskGraph together with its dependancies."""
+    """Represent one node in a TaskGraph together with its dependencies."""
 
     task_id: str
     func: Callable


### PR DESCRIPTION
## Background

We wish to be able to annotate VCF files using TaskGraph's parallelization.

## Aim

Utilize TaskGraph when annotating VCF files with the annotate_vcf tool.

## Implementation

Split the VCF file into regions, then create a task for each region. A "combine" task is also created, which assembles all separate region annotations into a single output file.
