### PR TITLE
Import tools should support start from existing parquet files

### DIFF
--- a/dae/dae/common_reports/tests/test_common_report_config.py
+++ b/dae/dae/common_reports/tests/test_common_report_config.py
@@ -1,6 +1,4 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-import textwrap
-
 import pytest
 
 from dae.testing import setup_pedigree, setup_denovo, denovo_study
@@ -43,11 +41,12 @@ def trios2_study(tmp_path_factory):
         root_path,
         "trios2", ped_path, [vcf_path],
         gpf_instance,
-        study_config_update=textwrap.dedent("""
-        id: trios2
-        common_report:
-          enabled: True
-        """))
+        study_config_update={
+            "id": "trios2",
+            "common_report": {
+                "enabled": True
+            }
+        })
     return study
 
 

--- a/dae/dae/configuration/schemas/import_config.py
+++ b/dae/dae/configuration/schemas/import_config.py
@@ -63,7 +63,7 @@ embedded_input_schema = {
     "input_dir": {"type": "string"}
 }
 
-import_config_schema = {
+import_config_schema: dict[str, Any] = {
     "id": {"type": "string"},
     "input": {
         "type": "dict",
@@ -78,6 +78,7 @@ import_config_schema = {
         "type": "dict",
         "schema": {
             "work_dir": {"type": "string"},
+            "parquet_dataset_dir": {"type": "string"},
             "include_reference": {"type": "boolean", "default": False},
             "vcf": _loader_processing_schema,
             "denovo": _loader_processing_schema,

--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -29,6 +29,8 @@ dae_named_cluster:
         cores: 1
         memory: 1GB
         log_directory: ./.sge_worker_logs
+        job_extra_directives:
+        - "-V"
     - name: sge
       type: sge
       number_of_threads: 150

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -268,11 +268,11 @@ class GeneScore:
 
     def min(self):
         """Return minimal score value."""
-        return self.df[self.score_id].min().item()
+        return self.df[self.score_id].min()
 
     def max(self):
         """Return maximal score value."""
-        return self.df[self.score_id].max().item()
+        return self.df[self.score_id].max()
 
     def get_genes(self, score_min=None, score_max=None):
         """

--- a/dae/dae/gene/tests/conftest.py
+++ b/dae/dae/gene/tests/conftest.py
@@ -3,7 +3,6 @@
 import os
 import shutil
 
-import textwrap
 import pytest
 
 from dae.testing import setup_pedigree, setup_denovo, denovo_study
@@ -167,9 +166,10 @@ def trios2_study(tmp_path_factory):
         root_path,
         "trios2", ped_path, [vcf_path],
         gpf_instance,
-        study_config_update=textwrap.dedent("""
-        id: trios2
-        denovo_gene_sets:
-          enabled: True
-        """))
+        study_config_update={
+            "id": "trios2",
+            "denovo_gene_sets": {
+                "enabled": True
+            }
+        })
     return study

--- a/dae/dae/genomic_resources/cached_repository.py
+++ b/dae/dae/genomic_resources/cached_repository.py
@@ -239,9 +239,8 @@ class GenomicResourceCachedRepo(GenomicResourceRepo):
             resource_files = {}
             for resource in resources:
                 remote_manifest = resource.get_manifest()
-                resource_files[resource.get_id()] = set(
-                    remote_manifest.names()
-                )
+                resource_files[resource.get_id()] = \
+                    set(remote_manifest.names()) - {"genomic_resource.yaml"}
 
         for rem_resource in resources:
             files_to_cache = resource_files.get(rem_resource.get_id())
@@ -259,5 +258,6 @@ class GenomicResourceCachedRepo(GenomicResourceRepo):
                         {res_file, }
                     )
                 )
-            for future in as_completed(futures):
-                future.result()
+        for future in as_completed(futures):
+            future.result()
+        executor.shutdown()

--- a/dae/dae/genomic_resources/fsspec_protocol.py
+++ b/dae/dae/genomic_resources/fsspec_protocol.py
@@ -457,7 +457,7 @@ class FsspecReadWriteProtocol(
                     uncompress=False) as outfile:
 
             md5_hash = hashlib.md5()
-            while chunk := infile.read(32768):
+            while chunk := infile.read(self.CHUNK_SIZE):
                 outfile.write(chunk)
                 md5_hash.update(chunk)
 

--- a/dae/dae/genotype_storage/genotype_storage.py
+++ b/dae/dae/genotype_storage/genotype_storage.py
@@ -34,10 +34,11 @@ class GenotypeStorage(abc.ABC):
         """
         if config.get("id") is None:
             raise ValueError(
-                "genotype storage without ID; 'id' is required")
+                f"genotype storage without ID; 'id' is required: {config}")
         if config.get("storage_type") is None:
             raise ValueError(
-                "genotype storage without type; 'storage_type' is required")
+                f"genotype storage without type; 'storage_type' is required: "
+                f"{config}")
         if config["storage_type"] != cls.get_storage_type():
             raise ValueError(
                 f"storage configuration for <{config['storage_type']}> passed "

--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -21,8 +21,10 @@ class ImpalaSchema1ImportStorage(ImportStorage):
     """Import logic for data in the Impala Schema 1 format."""
 
     @staticmethod
-    def _pedigree_dir(project):
-        return fs_utils.join(project.work_dir, f"{project.study_id}_pedigree")
+    def _pedigree_filename(project):
+        return fs_utils.join(
+            project.work_dir, f"{project.study_id}_pedigree",
+            "pedigree.parquet")
 
     @staticmethod
     def _variants_dir(project):
@@ -39,9 +41,9 @@ class ImpalaSchema1ImportStorage(ImportStorage):
     @classmethod
     def _do_write_pedigree(cls, project):
         start = time.time()
-        out_dir = cls._pedigree_dir(project)
+        ped_filename = cls._pedigree_filename(project)
         ParquetWriter.write_pedigree(
-            out_dir, project.get_pedigree(),
+            ped_filename, project.get_pedigree(),
             cls._get_partition_description(project))
         elapsed = time.time() - start
         logger.info("prepare pedigree elapsed %.2f sec", elapsed)
@@ -95,8 +97,7 @@ class ImpalaSchema1ImportStorage(ImportStorage):
 
         partition_description = cls._get_partition_description(project)
 
-        pedigree_file = fs_utils.join(cls._pedigree_dir(project),
-                                      "pedigree.parquet")
+        pedigree_file = cls._pedigree_filename(project)
         genotype_storage.hdfs_upload_dataset(
             project.study_id,
             cls._variants_dir(project),

--- a/dae/dae/impala_storage/schema1/import_commons.py
+++ b/dae/dae/impala_storage/schema1/import_commons.py
@@ -1257,6 +1257,13 @@ class Variants2ParquetTool:
             rows=argv.rows,
         )
 
+        ParquetWriter.write_meta(
+            out_dir,
+            variants_loader,
+            partition_description,
+            S1VariantsWriter,
+        )
+
     @classmethod
     def _build_variants_loader_pipeline(
             cls, gpf_instance, argv, variants_loader):

--- a/dae/dae/impala_storage/schema2/impala2_genotype_storage.py
+++ b/dae/dae/impala_storage/schema2/impala2_genotype_storage.py
@@ -25,7 +25,7 @@ class HdfsStudyLayout:
     meta_file: str
 
 
-class Schema2GenotypeStorage(GenotypeStorage):
+class Impala2GenotypeStorage(GenotypeStorage):
     """A genotype storing implementing the new schema2."""
 
     def __init__(self, storage_config: Dict[str, Any]):

--- a/dae/dae/impala_storage/schema2/impala2_import_storage.py
+++ b/dae/dae/impala_storage/schema2/impala2_import_storage.py
@@ -4,8 +4,8 @@ from typing import cast
 from dae.configuration.study_config_builder import StudyConfigBuilder
 from dae.impala_storage.schema1.import_commons import save_study_config
 from dae.task_graph.graph import TaskGraph
-from dae.impala_storage.schema2.schema2_genotype_storage import \
-    Schema2GenotypeStorage
+from dae.impala_storage.schema2.impala2_genotype_storage import \
+    Impala2GenotypeStorage
 from dae.schema2_storage.schema2_import_storage import Schema2ImportStorage, \
     schema2_dataset_layout
 
@@ -19,18 +19,18 @@ class Impala2ImportStorage(Schema2ImportStorage):
     @classmethod
     def _do_load_in_hdfs(cls, project):
         genotype_storage = project.get_genotype_storage()
-        assert isinstance(genotype_storage, Schema2GenotypeStorage)
+        assert isinstance(genotype_storage, Impala2GenotypeStorage)
         layout = schema2_dataset_layout(project.get_parquet_dataset_dir())
         return genotype_storage.hdfs_upload_dataset(
             project.study_id,
-            layout.study_dir,
+            layout.study,
             layout.pedigree,
             layout.meta)
 
     @classmethod
     def _do_load_in_impala(cls, project, hdfs_study_layout):
         genotype_storage = project.get_genotype_storage()
-        assert isinstance(genotype_storage, Schema2GenotypeStorage)
+        assert isinstance(genotype_storage, Impala2GenotypeStorage)
 
         logger.info("HDFS study layout: %s", hdfs_study_layout)
 
@@ -43,8 +43,8 @@ class Impala2ImportStorage(Schema2ImportStorage):
 
     @classmethod
     def _do_study_config(cls, project):
-        genotype_storage: Schema2GenotypeStorage = \
-            cast(Schema2GenotypeStorage, project.get_genotype_storage())
+        genotype_storage: Impala2GenotypeStorage = \
+            cast(Impala2GenotypeStorage, project.get_genotype_storage())
         # pylint: disable=protected-access
         pedigree_table = genotype_storage\
             ._construct_pedigree_table(project.study_id)

--- a/dae/dae/impala_storage/schema2/schema2_import_storage.py
+++ b/dae/dae/impala_storage/schema2/schema2_import_storage.py
@@ -1,83 +1,26 @@
 import logging
 from typing import cast
 
-from dae.utils import fs_utils
 from dae.configuration.study_config_builder import StudyConfigBuilder
 from dae.impala_storage.schema1.import_commons import save_study_config
-from dae.import_tools.import_tools import ImportStorage
 from dae.task_graph.graph import TaskGraph
 from dae.impala_storage.schema2.schema2_genotype_storage import \
     Schema2GenotypeStorage
-from dae.parquet.parquet_writer import ParquetWriter
-from dae.parquet.schema2.parquet_io import schema2_layout, \
-    VariantsParquetWriter as S2VariantsWriter
-from dae.parquet.partition_descriptor import PartitionDescriptor
+from dae.schema2_storage.schema2_import_storage import Schema2ImportStorage, \
+    schema2_dataset_layout
 
 
 logger = logging.getLogger(__file__)
 
 
-class Schema2ImportStorage(ImportStorage):
+class Impala2ImportStorage(Schema2ImportStorage):
     """Import logic for data in the Impala Schema 1 format."""
-
-    @staticmethod
-    def _get_partition_description(project, out_dir=None):
-        out_dir = out_dir if out_dir else project.work_dir
-        config_dict = project.get_partition_description_dict()
-
-        if config_dict is None:
-            return PartitionDescriptor()
-        return PartitionDescriptor.parse_dict(config_dict)
-
-    @classmethod
-    def _do_write_pedigree(cls, project):
-        study_dir = fs_utils.join(project.work_dir, project.study_id)
-        layout = schema2_layout(study_dir)
-        ParquetWriter.write_pedigree(
-            layout.pedigree, project.get_pedigree(),
-            cls._get_partition_description(project))
-
-    @classmethod
-    def _do_write_variant(cls, project, bucket):
-        study_dir = fs_utils.join(project.work_dir, project.study_id)
-        layout = schema2_layout(study_dir)
-        gpf_instance = project.get_gpf_instance()
-        ParquetWriter.write_variants(
-            layout.study_dir,
-            project.get_variant_loader(
-                bucket, gpf_instance.reference_genome),
-            cls._get_partition_description(project),
-            bucket,
-            project,
-            S2VariantsWriter)
-
-    @classmethod
-    def _variant_partitions(cls, project):
-        part_desc = cls._get_partition_description(project)
-        chromosome_lengths = dict(
-            project.get_gpf_instance().reference_genome.get_all_chrom_lengths()
-        )
-        sum_parts, fam_parts = \
-            part_desc.get_variant_partitions(chromosome_lengths)
-        for part in sum_parts:
-            yield part_desc.partition_directory("summary", part), part
-        for part in fam_parts:
-            yield part_desc.partition_directory("family", part), part
-
-    @classmethod
-    def _merge_parquets(cls, project, out_dir, partitions):
-        study_dir = fs_utils.join(project.work_dir, project.study_id)
-        layout = schema2_layout(study_dir)
-        full_out_dir = fs_utils.join(layout.study_dir, out_dir)
-        ParquetWriter.merge_parquets(
-            cls._get_partition_description(project), full_out_dir, partitions
-        )
 
     @classmethod
     def _do_load_in_hdfs(cls, project):
         genotype_storage = project.get_genotype_storage()
         assert isinstance(genotype_storage, Schema2GenotypeStorage)
-        layout = schema2_layout(project.get_parquet_dataset_dir())
+        layout = schema2_dataset_layout(project.get_parquet_dataset_dir())
         return genotype_storage.hdfs_upload_dataset(
             project.study_id,
             layout.study_dir,
@@ -139,38 +82,6 @@ class Schema2ImportStorage(ImportStorage):
             project.get_gpf_instance().dae_config,
             project.study_id,
             config, force=True)
-
-    def _build_all_parquet_tasks(self, project, graph):
-        pedigree_task = graph.create_task(
-            "Generating Pedigree", self._do_write_pedigree, [project], [],
-            input_files=[project.get_pedigree_filename()]
-        )
-
-        bucket_tasks = []
-        for bucket in project.get_import_variants_buckets():
-            task = graph.create_task(
-                f"Converting Variants {bucket}", self._do_write_variant,
-                [project, bucket], [],
-                input_files=project.get_input_filenames(bucket)
-            )
-            bucket_tasks.append(task)
-
-        # merge small parquet files into larger ones
-        bucket_sync = graph.create_task(
-            "Sync Parquet Generation", lambda: None, [], bucket_tasks
-        )
-        output_dir_tasks = []
-        for output_dir, partitions in self._variant_partitions(project):
-            output_dir_tasks.append(graph.create_task(
-                f"Merging {output_dir}", self._merge_parquets,
-                [project, output_dir, partitions], [bucket_sync]
-            ))
-
-        # dummy task used for running the parquet generation w/o impala import
-        all_parquet_task = graph.create_task(
-            "Parquet Tasks", lambda: None, [], output_dir_tasks + [bucket_sync]
-        )
-        return [pedigree_task, all_parquet_task]
 
     def generate_import_task_graph(self, project) -> TaskGraph:
         graph = TaskGraph()

--- a/dae/dae/impala_storage/schema2/tests/conftest.py
+++ b/dae/dae/impala_storage/schema2/tests/conftest.py
@@ -6,8 +6,8 @@ from box import Box
 from dae.variants_loaders.vcf.loader import VcfLoader
 from dae.variants_loaders.dae.loader import DenovoLoader
 from dae.pedigrees.loader import FamiliesLoader
-from dae.impala_storage.schema2.schema2_genotype_storage import \
-    Schema2GenotypeStorage
+from dae.impala_storage.schema2.impala2_genotype_storage import \
+    Impala2GenotypeStorage
 from dae.parquet.partition_descriptor import PartitionDescriptor
 from dae.parquet.parquet_writer import ParquetWriter
 from dae.parquet.schema2.parquet_io import \
@@ -37,7 +37,7 @@ def storage():
         },
     }
     config = Box(config)
-    return Schema2GenotypeStorage(config)
+    return Impala2GenotypeStorage(config)
 
 
 @pytest.fixture(scope="module")

--- a/dae/dae/impala_storage/schema2/tests/conftest.py
+++ b/dae/dae/impala_storage/schema2/tests/conftest.py
@@ -64,7 +64,6 @@ def import_test_study(resources_dir, gpf_instance_2013, storage):
                 gpf_instance_2013, partition_description,
                 loader_args=loader_args
             )
-
         # clean hdfs from prev test runs and copy resulting parquets in hdfs
         study_dir = f"/tests/test_schema2/studies/{study_id}"
         if storage.hdfs_helpers.exists(study_dir):
@@ -136,6 +135,12 @@ def run_vcf2schema2(out_dir, ped_file, vcf_file, gpf_instance,
         bucket_index=0,
         rows=20_000,
     )
+    ParquetWriter.write_meta(
+        out_dir,
+        variants_loader,
+        partition_description,
+        S2VariantsWriter,
+    )
 
 
 def run_denovo2schema2(out_dir, ped_file, denovo_file, gpf_instance,
@@ -160,6 +165,12 @@ def run_denovo2schema2(out_dir, ped_file, denovo_file, gpf_instance,
         S2VariantsWriter,
         bucket_index=100,
         rows=20_000,
+    )
+    ParquetWriter.write_meta(
+        out_dir,
+        variants_loader,
+        partition_description,
+        S2VariantsWriter,
     )
 
 

--- a/dae/dae/impala_storage/schema2/tests/test_schema2_genotype_storage.py
+++ b/dae/dae/impala_storage/schema2/tests/test_schema2_genotype_storage.py
@@ -5,8 +5,8 @@ from box import Box  # type: ignore
 import pytest
 import pandas as pd
 from fsspec.core import url_to_fs
-from dae.impala_storage.schema2.schema2_genotype_storage import \
-    Schema2GenotypeStorage
+from dae.impala_storage.schema2.impala2_genotype_storage import \
+    Impala2GenotypeStorage
 
 
 @dataclass(frozen=True)
@@ -60,7 +60,7 @@ def test_hdfs_upload_dataset(import_layout):
     if hdfs.exists(base_dir):
         hdfs.rm(base_dir, recursive=True)  # cleanup from previous tests
 
-    storage = Schema2GenotypeStorage(config)
+    storage = Impala2GenotypeStorage(config)
     hdfs_layout = storage.hdfs_upload_dataset(
         "study_id", import_layout.variant_dir, import_layout.pedigree_file,
         import_layout.meta_file)

--- a/dae/dae/impala_storage/tests/test_storage_is_serializable.py
+++ b/dae/dae/impala_storage/tests/test_storage_is_serializable.py
@@ -3,13 +3,13 @@ import cloudpickle  # type: ignore
 import pytest
 from dae.impala_storage.schema1.impala_genotype_storage import \
     ImpalaGenotypeStorage
-from dae.impala_storage.schema2.schema2_genotype_storage import \
-    Schema2GenotypeStorage
+from dae.impala_storage.schema2.impala2_genotype_storage import \
+    Impala2GenotypeStorage
 
 
 @pytest.mark.parametrize("storage_cls, storage_type", [
     (ImpalaGenotypeStorage, "impala"),
-    (Schema2GenotypeStorage, "impala2"),
+    (Impala2GenotypeStorage, "impala2"),
 ])
 def test_genotype_storage_is_cpickle_serializable(storage_cls, storage_type):
     storage = storage_cls({

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -318,6 +318,16 @@ class ImportProject():
     def study_id(self):
         return self.import_config["id"]
 
+    def get_parquet_dataset_dir(self) -> Optional[str]:
+        """Return parquet dataset direcotry if configured and exists."""
+        processing_config = self.import_config.get("processing_config", {})
+        parquet_dataset_dir = processing_config.get("parquet_dataset_dir")
+        if parquet_dataset_dir is None:
+            return None
+        if not fs_utils.exists(parquet_dataset_dir):
+            return None
+        return cast(str, parquet_dataset_dir)
+
     def has_genotype_storage(self):
         """Return if a genotype storage can be created."""
         if not self._has_destination():

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -318,8 +318,8 @@ class ImportProject():
     def study_id(self):
         return self.import_config["id"]
 
-    def get_parquet_dataset_dir(self) -> Optional[str]:
-        """Return parquet dataset direcotry if configured and exists."""
+    def get_processing_parquet_dataset_dir(self) -> Optional[str]:
+        """Return processing parquet dataset dir if configured and exists."""
         processing_config = self.import_config.get("processing_config", {})
         parquet_dataset_dir = processing_config.get("parquet_dataset_dir")
         if parquet_dataset_dir is None:
@@ -327,6 +327,18 @@ class ImportProject():
         if not fs_utils.exists(parquet_dataset_dir):
             return None
         return cast(str, parquet_dataset_dir)
+
+    def get_parquet_dataset_dir(self) -> Optional[str]:
+        """Return parquet dataset direcotry.
+
+        If processing parquet dataset dir is configured this method will
+        return it. Otherwise it will construct work dir parquet dataset
+        directory.
+        """
+        parquet_dataset_dir = self.get_processing_parquet_dataset_dir()
+        if parquet_dataset_dir is not None:
+            return parquet_dataset_dir
+        return fs_utils.join(self.work_dir, self.study_id)
 
     def has_genotype_storage(self):
         """Return if a genotype storage can be created."""

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -59,8 +59,9 @@ class ImportProject():
     """
 
     # pylint: disable=too-many-public-methods
-    def __init__(self, import_config, base_input_dir, base_config_dir=None,
-                 gpf_instance=None, config_filenames=None):
+    def __init__(
+            self, import_config: dict[str, Any], base_input_dir,
+            base_config_dir=None, gpf_instance=None, config_filenames=None):
         """Create a new project from the provided config.
 
         It is best not to call this ctor directly but to use one of the
@@ -70,7 +71,7 @@ class ImportProject():
         the configuration and instead injecting our own instance. Ideal for
         testing.
         """
-        self.import_config = import_config
+        self.import_config: dict[str, Any] = import_config
         if "denovo" in import_config["input"]:
             len_files = len(import_config["input"]["denovo"]["files"])
             assert len_files == 1, "Support for multiple denovo files is NYI"

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -170,6 +170,11 @@ class ImportProject():
                     buckets.append(bucket)
         return buckets
 
+    def get_variant_loader_types(self) -> list[str]:
+        return list(filter(
+            lambda lt: lt != "pedigree",
+            self.import_config["input"].keys()))
+
     def get_variant_loader(
             self,
             bucket: Optional[Bucket] = None, loader_type: Optional[str] = None,

--- a/dae/dae/import_tools/tests/test_custom_region_length.py
+++ b/dae/dae/import_tools/tests/test_custom_region_length.py
@@ -30,20 +30,20 @@ def test_import_task_bin_size(gpf_instance_2019, tmpdir, mocker,
     # Assert the expected output files and dirs are created in the work_dir
     # (i.e. tmpdir)
     files = os.listdir(tmpdir)
-    assert "test_import_variants" in files
+    assert "test_import" in files
 
-    variants_dir = join(tmpdir, "test_import_variants")
-    assert set(os.listdir(variants_dir)) == {
+    study_dir = join(tmpdir, "test_import")
+    assert set(os.listdir(study_dir)) == {
         "_PARTITION_DESCRIPTION",
         "_VARIANTS_SCHEMA",
         "family", "summary",
-        "meta.parquet",
+        "meta", "pedigree",
     }
 
     # This is the first output directory. Assert it has the right files
     # with the right content
     out_dir = join(
-        variants_dir,
+        study_dir,
         "summary/region_bin=1_0/frequency_bin=0")
     parquet_files = [
         "merged_region_bin_1_0_frequency_bin_0.parquet",
@@ -65,7 +65,7 @@ def test_import_task_bin_size(gpf_instance_2019, tmpdir, mocker,
 
     # Same for the second directory
     out_dir = join(
-        variants_dir,
+        study_dir,
         "summary/region_bin=1_1/frequency_bin=0")
     parquet_files = [
         "merged_region_bin_1_1_frequency_bin_0.parquet",
@@ -92,34 +92,34 @@ def _assert_variants(parquet_fn, bucket_index, positions):
 
 
 def test_bucket_generation(gpf_instance_2019, mocker):
-    import_config = dict(
-        input=dict(
-            pedigree=dict(
-                file=join(_input_dir, "pedigree.ped"),
-            ),
-            denovo=dict(
-                files=[join(_input_dir, "single_chromosome_variants.tsv")],
-                person_id="spid",
-                chrom="chrom",
-                pos="pos",
-                ref="ref",
-                alt="alt",
-            )
-        ),
-        processing_config=dict(
-            work_dir="",
-            denovo=dict(
-                chromosomes=["1"],
-                region_length=70_000_000
-            )
-        ),
-        partition_description=dict(
-            region_bin=dict(
-                chromosomes=["1"],
-                region_length=100_000_000
-            )
-        )
-    )
+    import_config = {
+        "input": {
+            "pedigree": {
+                "file": join(_input_dir, "pedigree.ped"),
+            },
+            "denovo": {
+                "files": [join(_input_dir, "single_chromosome_variants.tsv")],
+                "person_id": "spid",
+                "chrom": "chrom",
+                "pos": "pos",
+                "ref": "ref",
+                "alt": "alt",
+            }
+        },
+        "processing_config": {
+            "work_dir": "",
+            "denovo": {
+                "chromosomes": ["1"],
+                "region_length": 70_000_000
+            }
+        },
+        "partition_description": {
+            "region_bin": {
+                "chromosomes": ["1"],
+                "region_length": 100_000_000
+            }
+        }
+    }
     mocker.patch.object(import_tools.ImportProject, "get_gpf_instance",
                         return_value=gpf_instance_2019)
     project = import_tools.ImportProject.build_from_config(import_config)
@@ -132,34 +132,34 @@ def test_bucket_generation(gpf_instance_2019, mocker):
 
 
 def test_bucket_generation_chrom_mismatch(gpf_instance_short, mocker):
-    import_config = dict(
-        input=dict(
-            pedigree=dict(
-                file=join(_input_dir, "pedigree.ped"),
-            ),
-            denovo=dict(
-                files=[join(_input_dir, "single_chromosome_variants.tsv")],
-                person_id="spid",
-                chrom="chrom",
-                pos="pos",
-                ref="ref",
-                alt="alt",
-            )
-        ),
-        processing_config=dict(
-            work_dir="",
-            denovo=dict(
-                chromosomes=["2"],
-                region_length=140_000
-            )
-        ),
-        partition_description=dict(
-            region_bin=dict(
-                chromosomes=["1"],
-                region_length=150_000
-            )
-        )
-    )
+    import_config = {
+        "input": {
+            "pedigree": {
+                "file": join(_input_dir, "pedigree.ped"),
+            },
+            "denovo": {
+                "files": [join(_input_dir, "single_chromosome_variants.tsv")],
+                "person_id": "spid",
+                "chrom": "chrom",
+                "pos": "pos",
+                "ref": "ref",
+                "alt": "alt",
+            }
+        },
+        "processing_config": {
+            "work_dir": "",
+            "denovo": {
+                "chromosomes": ["2"],
+                "region_length": 140_000
+            }
+        },
+        "partition_description": {
+            "region_bin": {
+                "chromosomes": ["1"],
+                "region_length": 150_000
+            }
+        }
+    }
     mocker.patch.object(import_tools.ImportProject, "get_gpf_instance",
                         return_value=gpf_instance_short)
     project = import_tools.ImportProject.build_from_config(import_config)
@@ -175,30 +175,30 @@ def test_bucket_generation_chrom_mismatch(gpf_instance_short, mocker):
 _input_dir = join(
     os.path.dirname(os.path.realpath(__file__)),
     "resources", "import_task_bin_size")
-_denovo_multi_chrom_config = dict(
-    input=dict(
-        pedigree=dict(
-            file=join(_input_dir, "pedigree.ped")
-        ),
-        denovo=dict(
-            files=[join(_input_dir, "multi_chromosome_variants.tsv")],
-            person_id="spid",
-            chrom="chrom",
-            pos="pos",
-            ref="ref",
-            alt="alt",
-        )
-    ),
-    processing_config=dict(
-        work_dir="",
-    ),
-    partition_description=dict(
-        region_bin=dict(
-            chromosomes=["chr1"],
-            region_length=100000000
-        )
-    )
-)
+_denovo_multi_chrom_config = {
+    "input": {
+        "pedigree": {
+            "file": join(_input_dir, "pedigree.ped")
+        },
+        "denovo": {
+            "files": [join(_input_dir, "multi_chromosome_variants.tsv")],
+            "person_id": "spid",
+            "chrom": "chrom",
+            "pos": "pos",
+            "ref": "ref",
+            "alt": "alt",
+        }
+    },
+    "processing_config": {
+        "work_dir": "",
+    },
+    "partition_description": {
+        "region_bin": {
+            "chromosomes": ["chr1"],
+            "region_length": 100000000
+        }
+    }
+}
 
 
 @pytest.mark.parametrize("add_chrom_prefix", [None, "chr"])

--- a/dae/dae/import_tools/tests/test_import_project.py
+++ b/dae/dae/import_tools/tests/test_import_project.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import os
+from typing import Any
 import pytest
 import cloudpickle  # type: ignore
 from dae.import_tools.import_tools import ImportProject
@@ -14,12 +15,12 @@ def fixture_gpf_instance(fixture_dirname):
 
 
 def test_import_project_is_cpickle_serializable(fixture_dirname):
-    import_config = dict(
-        input={},
-        gpf_instance={
+    import_config = {
+        "input": {},
+        "gpf_instance": {
             "path": fixture_dirname("")
         }
-    )
+    }
     project = ImportProject.build_from_config(import_config)
     _ = cloudpickle.dumps(project)
 
@@ -63,20 +64,20 @@ def test_config_filenames_one_external(resources_dir):
 
 
 def test_config_filenames_embedded_config():
-    import_config = dict(
-        input={},
-    )
+    import_config: dict[str, Any] = {
+        "input": {},
+    }
     project = ImportProject.build_from_config(import_config)
     assert len(project.config_filenames) == 0
 
 
 def test_config_filenames_external_input_and_annotation():
-    import_config = dict(
-        input={},
-        annotation=dict(
-            file="annotation.yaml"
-        )
-    )
+    import_config = {
+        "input": {},
+        "annotation": {
+            "file": "annotation.yaml"
+        }
+    }
     project = ImportProject.build_from_config(import_config)
     assert project.config_filenames == ["annotation.yaml"]
 

--- a/dae/dae/parquet/parquet_writer.py
+++ b/dae/dae/parquet/parquet_writer.py
@@ -118,7 +118,6 @@ class ParquetWriter:
         include_reference=False,
     ):
         """Read variants from variant_loader and store them in parquet."""
-        # assert variants_loader.get_attribute("annotation_schema") is not None
         variants_writer = variants_writer_class(
             out_dir,
             variants_loader,
@@ -161,6 +160,21 @@ class ParquetWriter:
             rows=rows,
             include_reference=project.include_reference,
         )
+
+    @staticmethod
+    def write_meta(
+            out_dir,
+            variants_loader,
+            partition_description: PartitionDescriptor,
+            variants_writer_class: Type[
+                Union[S1VariantsWriter, S2VariantsWriter]]):
+        """Write dataset metadata."""
+        variants_writer = variants_writer_class(
+            out_dir,
+            variants_loader,
+            partition_description,
+        )
+        variants_writer.write_meta()
 
     @staticmethod
     def write_pedigree(

--- a/dae/dae/parquet/parquet_writer.py
+++ b/dae/dae/parquet/parquet_writer.py
@@ -119,7 +119,6 @@ class ParquetWriter:
     ):
         """Read variants from variant_loader and store them in parquet."""
         # assert variants_loader.get_attribute("annotation_schema") is not None
-
         variants_writer = variants_writer_class(
             out_dir,
             variants_loader,
@@ -165,13 +164,11 @@ class ParquetWriter:
 
     @staticmethod
     def write_pedigree(
-        out_dir: str,
+        output_filename: str,
         families: FamiliesData,
         partition_descriptor: PartitionDescriptor
     ) -> None:
         """Write FamiliesData to a pedigree parquet file."""
-        output_filename = os.path.join(out_dir, "pedigree.parquet")
-
         ParquetWriter.families_to_parquet(
             families, output_filename, partition_descriptor)
 

--- a/dae/dae/parquet/schema1/parquet_io.py
+++ b/dae/dae/parquet/schema1/parquet_io.py
@@ -361,12 +361,11 @@ class VariantsParquetWriter:
     def write_dataset(self):
         """Write the variants, parittion description and schema."""
         filenames = self._write_internal()
+        self.variants_loader.close()
+        return filenames
 
+    def write_meta(self):
         # TODO: This should be move to a different place so that these are
         # not written with every bucket.
         self.write_partition()
         self.write_schema()
-
-        self.variants_loader.close()
-
-        return filenames

--- a/dae/dae/parquet/schema2/parquet_io.py
+++ b/dae/dae/parquet/schema2/parquet_io.py
@@ -437,7 +437,9 @@ class VariantsParquetWriter:
 
     def write_dataset(self):
         filenames = self._write_internal()
+        return filenames
+
+    def write_meta(self):
         self.write_metadata()
         self.write_schema()
         self.write_partition()
-        return filenames

--- a/dae/dae/parquet/schema2/parquet_io.py
+++ b/dae/dae/parquet/schema2/parquet_io.py
@@ -37,8 +37,7 @@ class Schema2Layout:
     meta: str
 
 
-def schema2_layout(work_dir: str, study_id: str) -> Schema2Layout:
-    study_dir = fs_utils.join(work_dir, study_id)
+def schema2_layout(study_dir: str) -> Schema2Layout:
     return Schema2Layout(
         study_dir,
         fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),

--- a/dae/dae/parquet/schema2/parquet_io.py
+++ b/dae/dae/parquet/schema2/parquet_io.py
@@ -3,9 +3,8 @@ import sys
 import time
 import logging
 import json
-from dataclasses import dataclass
 from functools import reduce
-from typing import Dict, Any, Tuple
+from typing import Dict, Any
 import toml
 
 import numpy as np
@@ -26,32 +25,6 @@ from dae.parquet.schema2.serializers import AlleleParquetSerializer
 from dae.parquet.partition_descriptor import PartitionDescriptor
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class Schema2Layout:
-    study_dir: str
-    pedigree: str
-    summary: str
-    family: str
-    meta: str
-
-
-def schema2_layout(study_dir: str) -> Schema2Layout:
-    return Schema2Layout(
-        study_dir,
-        fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),
-        fs_utils.join(study_dir, "summary"),
-        fs_utils.join(study_dir, "family"),
-        fs_utils.join(study_dir, "meta", "meta.parquet"))
-
-
-def schema2_variants_layout(work_dir: str, study_id: str) -> Tuple[str, str]:
-    study_dir = fs_utils.join(work_dir, study_id)
-    return (
-        fs_utils.join(study_dir, "summary"),
-        fs_utils.join(study_dir, "family"),
-    )
 
 
 class ContinuousParquetFileWriter:

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from typing import Optional
 
 from dae.utils import fs_utils
 from dae.import_tools.import_tools import ImportStorage
@@ -15,11 +16,11 @@ logger = logging.getLogger(__file__)
 
 @dataclass(frozen=True)
 class Schema2DatasetLayout:
-    study_dir: str
+    study: str
     pedigree: str
-    summary: str
-    family: str
-    meta: str
+    summary: Optional[str]
+    family: Optional[str]
+    meta: Optional[str]
 
 
 def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
@@ -60,7 +61,7 @@ class Schema2ImportStorage(ImportStorage):
         layout = schema2_project_dataset_layout(project)
         gpf_instance = project.get_gpf_instance()
         ParquetWriter.write_variants(
-            layout.study_dir,
+            layout.study,
             project.get_variant_loader(
                 bucket, gpf_instance.reference_genome),
             cls._get_partition_description(project),
@@ -84,7 +85,7 @@ class Schema2ImportStorage(ImportStorage):
     @classmethod
     def _merge_parquets(cls, project, out_dir, partitions):
         layout = schema2_project_dataset_layout(project)
-        full_out_dir = fs_utils.join(layout.study_dir, out_dir)
+        full_out_dir = fs_utils.join(layout.study, out_dir)
         ParquetWriter.merge_parquets(
             cls._get_partition_description(project), full_out_dir, partitions
         )

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -1,0 +1,129 @@
+import logging
+from dataclasses import dataclass
+
+from dae.utils import fs_utils
+from dae.import_tools.import_tools import ImportStorage
+from dae.task_graph.graph import TaskGraph
+from dae.parquet.parquet_writer import ParquetWriter
+from dae.parquet.schema2.parquet_io import \
+    VariantsParquetWriter as S2VariantsWriter
+from dae.parquet.partition_descriptor import PartitionDescriptor
+
+
+logger = logging.getLogger(__file__)
+
+
+@dataclass(frozen=True)
+class Schema2DatasetLayout:
+    study_dir: str
+    pedigree: str
+    summary: str
+    family: str
+    meta: str
+
+
+def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
+    return Schema2DatasetLayout(
+        study_dir,
+        fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),
+        fs_utils.join(study_dir, "summary"),
+        fs_utils.join(study_dir, "family"),
+        fs_utils.join(study_dir, "meta", "meta.parquet"))
+
+
+def schema2_project_dataset_layout(project) -> Schema2DatasetLayout:
+    study_dir = fs_utils.join(project.work_dir, project.study_id)
+    return schema2_dataset_layout(study_dir)
+
+
+class Schema2ImportStorage(ImportStorage):
+    """Import logic for data in the Impala Schema 1 format."""
+
+    @staticmethod
+    def _get_partition_description(project, out_dir=None):
+        out_dir = out_dir if out_dir else project.work_dir
+        config_dict = project.get_partition_description_dict()
+
+        if config_dict is None:
+            return PartitionDescriptor()
+        return PartitionDescriptor.parse_dict(config_dict)
+
+    @classmethod
+    def _do_write_pedigree(cls, project):
+        layout = schema2_project_dataset_layout(project)
+        ParquetWriter.write_pedigree(
+            layout.pedigree, project.get_pedigree(),
+            cls._get_partition_description(project))
+
+    @classmethod
+    def _do_write_variant(cls, project, bucket):
+        layout = schema2_project_dataset_layout(project)
+        gpf_instance = project.get_gpf_instance()
+        ParquetWriter.write_variants(
+            layout.study_dir,
+            project.get_variant_loader(
+                bucket, gpf_instance.reference_genome),
+            cls._get_partition_description(project),
+            bucket,
+            project,
+            S2VariantsWriter)
+
+    @classmethod
+    def _variant_partitions(cls, project):
+        part_desc = cls._get_partition_description(project)
+        chromosome_lengths = dict(
+            project.get_gpf_instance().reference_genome.get_all_chrom_lengths()
+        )
+        sum_parts, fam_parts = \
+            part_desc.get_variant_partitions(chromosome_lengths)
+        for part in sum_parts:
+            yield part_desc.partition_directory("summary", part), part
+        for part in fam_parts:
+            yield part_desc.partition_directory("family", part), part
+
+    @classmethod
+    def _merge_parquets(cls, project, out_dir, partitions):
+        layout = schema2_project_dataset_layout(project)
+        full_out_dir = fs_utils.join(layout.study_dir, out_dir)
+        ParquetWriter.merge_parquets(
+            cls._get_partition_description(project), full_out_dir, partitions
+        )
+
+    def _build_all_parquet_tasks(self, project, graph):
+        pedigree_task = graph.create_task(
+            "Generating Pedigree", self._do_write_pedigree, [project], [],
+            input_files=[project.get_pedigree_filename()]
+        )
+
+        bucket_tasks = []
+        for bucket in project.get_import_variants_buckets():
+            task = graph.create_task(
+                f"Converting Variants {bucket}", self._do_write_variant,
+                [project, bucket], [],
+                input_files=project.get_input_filenames(bucket)
+            )
+            bucket_tasks.append(task)
+
+        # merge small parquet files into larger ones
+        bucket_sync = graph.create_task(
+            "Sync Parquet Generation", lambda: None, [], bucket_tasks
+        )
+        output_dir_tasks = []
+        for output_dir, partitions in self._variant_partitions(project):
+            output_dir_tasks.append(graph.create_task(
+                f"Merging {output_dir}", self._merge_parquets,
+                [project, output_dir, partitions], [bucket_sync]
+            ))
+
+        # dummy task used for running the parquet generation w/o impala import
+        all_parquet_task = graph.create_task(
+            "Parquet Tasks", lambda: None, [], output_dir_tasks + [bucket_sync]
+        )
+        return [pedigree_task, all_parquet_task]
+
+    def generate_import_task_graph(self, project) -> TaskGraph:
+        graph = TaskGraph()
+        if project.get_processing_parquet_dataset_dir() is None:
+            self._build_all_parquet_tasks(project, graph)
+
+        return graph

--- a/dae/dae/testing/import_helpers.py
+++ b/dae/dae/testing/import_helpers.py
@@ -21,7 +21,9 @@ class StudyInputLayout:
     cnv: list[pathlib.Path]
 
 
-def update_study_config(gpf_instance, study_id: str, study_config_update: str):
+def update_study_config(
+        gpf_instance, study_id: str,
+        study_config_update: dict[str, Any]):
     """Update study configuration."""
     config_path = pathlib.Path(gpf_instance.dae_dir) / \
         "studies" / \
@@ -29,9 +31,7 @@ def update_study_config(gpf_instance, study_id: str, study_config_update: str):
         f"{study_id}.yaml"
     with open(config_path, "r", encoding="utf") as infile:
         config = yaml.safe_load(infile.read())
-    config_update = yaml.safe_load(study_config_update)
-    config.update(config_update)
-
+    config = recursive_dict_update(config, study_config_update)
     builder = StudyConfigBuilder(config)
     with open(config_path, "wt", encoding="utf8") as outfile:
         outfile.write(builder.build_config())
@@ -89,7 +89,7 @@ def setup_import_project(
 def data_import(
         root_path: pathlib.Path, study: StudyInputLayout, gpf_instance,
         project_config_update: Optional[dict[str, Any]] = None,
-        study_config_update: str = ""):
+        study_config_update: Optional[dict[str, Any]] = None):
     """Set up an import project for a study and imports it."""
     setup_import_project(
         root_path, study, gpf_instance,
@@ -115,7 +115,7 @@ def vcf_import(
         ped_path: pathlib.Path, vcf_paths: list[pathlib.Path],
         gpf_instance,
         project_config_update: Optional[dict[str, Any]] = None,
-        study_config_update: str = ""):
+        study_config_update: Optional[dict[str, Any]] = None):
     """Import a VCF study and return the import project."""
     study = StudyInputLayout(study_id, ped_path, vcf_paths, [], [], [])
     project = data_import(
@@ -131,7 +131,7 @@ def vcf_study(
         ped_path: pathlib.Path, vcf_paths: list[pathlib.Path],
         gpf_instance,
         project_config_update: Optional[dict[str, Any]] = None,
-        study_config_update: str = ""):
+        study_config_update: Optional[dict[str, Any]] = None):
     """Import a VCF study and return the imported study."""
     vcf_import(
         root_path, study_id, ped_path, vcf_paths, gpf_instance,
@@ -147,7 +147,7 @@ def denovo_import(
         ped_path: pathlib.Path, denovo_paths: list[pathlib.Path],
         gpf_instance,
         project_config_update: Optional[dict[str, Any]] = None,
-        study_config_update: str = ""):
+        study_config_update: Optional[dict[str, Any]] = None):
     """Import a de Novo study and return the import project."""
     study = StudyInputLayout(study_id, ped_path, [], denovo_paths, [], [])
     project = data_import(
@@ -163,7 +163,7 @@ def denovo_study(
         ped_path: pathlib.Path, denovo_paths: list[pathlib.Path],
         gpf_instance,
         project_config_update: Optional[dict[str, Any]] = None,
-        study_config_update: str = ""):
+        study_config_update: Optional[dict[str, Any]] = None):
     """Import a de Novo study and return the imported study."""
     denovo_import(
         root_path, study_id, ped_path, denovo_paths, gpf_instance,
@@ -196,7 +196,7 @@ def setup_dataset(
     return dataset
 
 
-def study_update(gpf_instance, study, study_config_update: str):
+def study_update(gpf_instance, study, study_config_update: dict[str, Any]):
     update_study_config(gpf_instance, study.study_id, study_config_update)
     gpf_instance.reload()
     return gpf_instance.get_genotype_data(study.study_id)

--- a/dae/dae/testing/tests/test_setup_project_config.py
+++ b/dae/dae/testing/tests/test_setup_project_config.py
@@ -1,0 +1,32 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines
+import yaml
+
+import pytest
+
+from dae.testing.import_helpers import StudyInputLayout, setup_import_project
+from dae.testing import acgt_gpf
+
+
+@pytest.mark.parametrize("config_update, key, subkeys", [
+    ({}, "processing_config", {"work_dir"}),
+    ({"partition_description": {
+        "region_bin": {
+            "region_length": 22
+        }
+    }}, "partition_description", {"region_bin"}),
+    ({"processing_config": {
+        "parquet_dataset_dir": "aaa"
+    }}, "processing_config", {"work_dir", "parquet_dataset_dir"})
+])
+def test_setup_import_project(
+        tmp_path_factory, config_update, key, subkeys):
+    root_path = tmp_path_factory.mktemp("test_import_project")
+    gpf_instance = acgt_gpf(root_path)
+    study = StudyInputLayout(
+        "test_id", root_path / "fam.ped", [root_path / "in.vcf"], [], [], [])
+
+    pathname = setup_import_project(
+        root_path, study, gpf_instance, config_update)
+
+    project_config = yaml.safe_load(pathname.read_text())
+    assert set(project_config[key]) == subkeys

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -65,12 +65,12 @@ setuptools.setup(
 
     [dae.genotype_storage.factories]
     impala=dae.impala_storage.schema1.impala_genotype_storage:ImpalaGenotypeStorage
-    impala2=dae.impala_storage.schema2.schema2_genotype_storage:Schema2GenotypeStorage
+    impala2=dae.impala_storage.schema2.impala2_genotype_storage:Impala2GenotypeStorage
     inmemory=dae.inmemory_storage.inmemory_genotype_storage:InmemoryGenotypeStorage
 
     [dae.import_tools.storages]
     impala=dae.impala_storage.schema1.impala_schema1:ImpalaSchema1ImportStorage
-    impala2=dae.impala_storage.schema2.schema2_import_storage:Impala2ImportStorage
+    impala2=dae.impala_storage.schema2.impala2_import_storage:Impala2ImportStorage
     schema2=dae.schema2_storage.schema2_import_storage:Schema2ImportStorage
     inmemory=dae.inmemory_storage.inmemory_import_storage:InmemoryImportStorage
 

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -70,7 +70,8 @@ setuptools.setup(
 
     [dae.import_tools.storages]
     impala=dae.impala_storage.schema1.impala_schema1:ImpalaSchema1ImportStorage
-    impala2=dae.impala_storage.schema2.schema2_import_storage:Schema2ImportStorage
+    impala2=dae.impala_storage.schema2.schema2_import_storage:Impala2ImportStorage
+    schema2=dae.schema2_storage.schema2_import_storage:Schema2ImportStorage
     inmemory=dae.inmemory_storage.inmemory_import_storage:InmemoryImportStorage
 
     [console_scripts]

--- a/dae/tests/integration/import_tools/test_with_parquet_dataset.py
+++ b/dae/tests/integration/import_tools/test_with_parquet_dataset.py
@@ -1,0 +1,102 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
+
+import pytest
+
+from dae.testing import setup_pedigree, setup_vcf, vcf_import
+from dae.testing import alla_gpf
+from dae.testing.import_helpers import StudyInputLayout
+from dae.import_tools.cli import run_with_project
+
+
+@pytest.fixture(scope="module")
+def vcf_import_data(tmp_path_factory, genotype_storage):
+    root_path = tmp_path_factory.mktemp(
+        f"parquet_dataset_{genotype_storage.storage_id}")
+
+    gpf_instance = alla_gpf(root_path)
+
+    if genotype_storage:
+        gpf_instance\
+            .genotype_storages\
+            .register_default_storage(genotype_storage)
+
+    ped_path = setup_pedigree(
+        root_path / "vcf_data" / "in.ped",
+        """
+        familyId personId dadId	 momId	sex status role
+        f1       m1       0      0      2   1      mom
+        f1       d1       0      0      1   1      dad
+        f1       p1       d1     m1     1   2      prb
+        """)
+    vcf_path = setup_vcf(
+        root_path / "vcf_data" / "in.vcf.gz",
+        """
+        ##fileformat=VCFv4.2
+        ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+        ##contig=<ID=chrA>
+        #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT m1  d1  p1
+        chrA   1   .  A   C   .    .      .    GT     0/1 0/0 0/1
+        chrA   2   .  A   G   .    .      .    GT     0/0 0/1 0/1
+        """)
+
+    return root_path, gpf_instance, StudyInputLayout(
+        "with_parquet_dataset", ped_path, [vcf_path], [], [], [])
+
+
+@pytest.fixture(scope="module")
+def vcf_project_to_parquet(
+        tmp_path_factory, vcf_import_data, genotype_storage):
+    root_path, gpf_instance, layout = vcf_import_data
+
+    project_config_overwrite = {
+        "destination": {
+            "storage_type": genotype_storage.get_storage_type()
+        }
+    }
+    project = vcf_import(
+        root_path,
+        "parquet_dataset", layout.pedigree, layout.vcf,
+        gpf_instance,
+        project_config_overwrite=project_config_overwrite)
+    return project
+
+
+@pytest.fixture(scope="module")
+def vcf_project_from_parquet(
+        tmp_path_factory, vcf_import_data, genotype_storage):
+    root_path, gpf_instance, layout = vcf_import_data
+
+    project_config_update = {
+        "processing_config": {
+            "work_dir": str(root_path / "work_dir2"),
+            "parquet_dataset_dir": str(
+                root_path / "work_dir" / "parquet_dataset")
+        }
+    }
+    project = vcf_import(
+        root_path,
+        "parquet_dataset", layout.pedigree, layout.vcf,
+        gpf_instance,
+        project_config_update=project_config_update)
+    return project
+
+
+@pytest.mark.impala2(reason="supported for impala schema2")
+def test_with_destination_storage_type(
+        vcf_project_to_parquet, vcf_project_from_parquet, genotype_storage):
+
+    run_with_project(vcf_project_to_parquet)
+    assert os.path.exists(
+        os.path.join(
+            vcf_project_to_parquet.work_dir, "parquet_dataset", "pedigree",
+            "pedigree.parquet"))
+
+    run_with_project(vcf_project_from_parquet)
+
+    gpf_instance = vcf_project_from_parquet.get_gpf_instance()
+    gpf_instance.reload()
+    study = gpf_instance.get_genotype_data("parquet_dataset")
+    assert study is not None
+
+    assert len(list(study.query_variants())) == 2

--- a/dae/tests/integration/import_tools/test_with_parquet_dataset.py
+++ b/dae/tests/integration/import_tools/test_with_parquet_dataset.py
@@ -83,6 +83,7 @@ def vcf_project_from_parquet(
 
 
 @pytest.mark.impala2(reason="supported for impala schema2")
+@pytest.mark.gcp(reason="supported for gcp")
 def test_with_destination_storage_type(
         vcf_project_to_parquet, vcf_project_from_parquet, genotype_storage):
 

--- a/dae/tests/integration/study_query_variants/test_partitions.py
+++ b/dae/tests/integration/study_query_variants/test_partitions.py
@@ -70,28 +70,35 @@ def imported_study(tmp_path_factory, genotype_storage):
         bar    13  .  C   T   .    .      .    GT     0/0 1/0 1/0 1/0 0/1 0/0 0/0  # freq 2/8 = 25.0%, missense, g2
         """)  # noqa
 
-    partition_def = textwrap.dedent("""
-      partition_description:
-        region_bin:
-            chromosomes: ['foo', 'bar']
-            region_length: 100
-        family_bin:
-            family_bin_size: 2
-        frequency_bin:
-            rare_boundary: 30
-        coding_bin:
-            coding_effect_types: "splice-site,missense,synonymous"
-    """)
+    project_config_update = {
+        "partition_description": {
+            "region_bin": {
+                "chromosomes": ["foo", "bar"],
+                "region_length": 100
+            },
+            "family_bin": {
+                "family_bin_size": 2
+            },
+            "frequency_bin": {
+                "rare_boundary": 30,
+            },
+            "coding_bin": {
+                "coding_effect_types": "splice-site,missense,synonymous"
+            },
+        },
+        "processing_config": {
+            "vcf": {
+                "chromosomes": ["foo", "bar"],
+                "region_length": 8
+            }
+        }
+    }
 
-    processing_details = textwrap.dedent("""vcf:
-       chromosomes: ['foo', 'bar']
-       region_length: 8
-    """)
     study = vcf_study(
         root_path,
         "partitoned_vcf", ped_path, [vcf_path],
-        gpf_instance, partition_description=partition_def,
-        processing_details=processing_details)
+        gpf_instance,
+        project_config_update=project_config_update)
     return study
 
 

--- a/dae_conftests/dae_conftests/dae_conftests.py
+++ b/dae_conftests/dae_conftests/dae_conftests.py
@@ -451,11 +451,9 @@ def dae_transmitted(
         genome=gpf_instance_2013.reference_genome,
         regions=None,
     )
-    variants_loader = AnnotationPipelineDecorator(
+    return AnnotationPipelineDecorator(
         variants_loader, annotation_pipeline_internal
     )
-
-    return variants_loader
 
 
 @pytest.fixture
@@ -476,11 +474,9 @@ def iossifov2014_loader(
         gpf_instance_2013.reference_genome
     )
 
-    variants_loader = AnnotationPipelineDecorator(
+    return AnnotationPipelineDecorator(
         variants_loader, annotation_pipeline_internal
-    )
-
-    return variants_loader, families_loader
+    ), families_loader
 
 
 @pytest.fixture(scope="session")

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -10,7 +10,6 @@ channels:
 dependencies:
   - dask-jobqueue=0.8.1
   - dask-kubernetes=2023.3
-  - raven=6.10.0
   - bump2version=1.0.1
   - sphinx=6.1
   - sphinx_rtd_theme=1.2

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -3,9 +3,9 @@
 # platform: linux-64
 # conda create -c conda-forge -c bioconda -n <env name> --file <this file>
 channels:
-  - bioconda
-  - conda-forge
   - defaults
+  - conda-forge
+  - bioconda
   - iossifovlab
 dependencies:
   - dask-jobqueue=0.8.1

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ channels:
   - defaults
   - iossifovlab
 dependencies:
-  - python=3.10.9
+  - python=3.9
   - importlib_metadata=4.11.3
   - pysam=0.20.0
   - samtools=1.15.1

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,9 @@
 
 name: gpf
 channels:
-  - bioconda
-  - conda-forge
   - defaults
+  - conda-forge
+  - bioconda
   - iossifovlab
 dependencies:
   - python=3.9

--- a/gcp_genotype_storage/environment.yml
+++ b/gcp_genotype_storage/environment.yml
@@ -6,9 +6,9 @@
 
 name: gpf
 channels:
-  - bioconda
-  - conda-forge
   - defaults
+  - conda-forge
+  - bioconda
   - iossifovlab
 dependencies:
   - google-cloud-sdk=424

--- a/gcp_genotype_storage/environment.yml
+++ b/gcp_genotype_storage/environment.yml
@@ -11,6 +11,6 @@ channels:
   - defaults
   - iossifovlab
 dependencies:
-  - google-cloud-sdk=412.0.0
-  - google-cloud-bigquery=3.4.1
-  - gcsfs=2022.11.0
+  - google-cloud-sdk=424
+  - google-cloud-bigquery=3.9
+  - gcsfs=2023.3.0

--- a/gcp_genotype_storage/gcp_genotype_storage/gcp_import_storage.py
+++ b/gcp_genotype_storage/gcp_genotype_storage/gcp_import_storage.py
@@ -1,113 +1,28 @@
 import logging
 from typing import cast
 
-from dae.utils import fs_utils
 from dae.configuration.study_config_builder import StudyConfigBuilder
 from dae.impala_storage.schema1.import_commons import save_study_config
-from dae.parquet.parquet_writer import ParquetWriter
-from dae.import_tools.import_tools import ImportStorage
 from dae.task_graph.graph import TaskGraph
-from dae.parquet.partition_descriptor import PartitionDescriptor
-from dae.parquet.schema2.parquet_io import \
-    VariantsParquetWriter as S2VariantsWriter
-
-from gcp_genotype_storage.gcp_genotype_storage import GcpStudyLayout, \
-    GcpGenotypeStorage
+from dae.schema2_storage.schema2_import_storage import Schema2ImportStorage, \
+    schema2_dataset_layout
+from gcp_genotype_storage.gcp_genotype_storage import GcpGenotypeStorage
 
 
 logger = logging.getLogger(__file__)
 
 
-class GcpImportStorage(ImportStorage):
+class GcpImportStorage(Schema2ImportStorage):
     """Import logic for data in the GCP Schema 2."""
 
     @classmethod
-    def _pedigree_dir(cls, project):
-        return fs_utils.join(
-            cls._study_dir(project),
-            "pedigree")
-
-    @staticmethod
-    def _study_dir(project):
-        return fs_utils.join(project.work_dir, f"{project.study_id}")
-
-    @classmethod
-    def _pedigree_path(cls, project):
-        return fs_utils.join(
-            cls._pedigree_dir(project), "pedigree.parquet")
-
-    @classmethod
-    def _summary_variants_path(cls, project):
-        return fs_utils.join(cls._study_dir(project), "summary")
-
-    @classmethod
-    def _family_variants_path(cls, project):
-        return fs_utils.join(cls._study_dir(project), "family")
-
-    @classmethod
-    def _meta_path(cls, project):
-        return fs_utils.join(cls._study_dir(project), "meta", "meta.parquet")
-
-    @staticmethod
-    def _get_partition_description(project):
-        config_dict = project.get_partition_description_dict()
-        if config_dict is None:
-            return PartitionDescriptor()
-        return PartitionDescriptor.parse_dict(config_dict)
-
-    @classmethod
-    def _do_write_pedigree(cls, project):
-        pedigree_path = cls._pedigree_path(project)
-        ParquetWriter.write_pedigree(
-            pedigree_path, project.get_pedigree(),
-            cls._get_partition_description(project))
-
-    @classmethod
-    def _do_write_variant(cls, project, bucket):
-        out_dir = cls._study_dir(project)
-        gpf_instance = project.get_gpf_instance()
-        ParquetWriter.write_variants(
-            out_dir,
-            project.get_variant_loader(bucket,
-                                       gpf_instance.reference_genome),
-            cls._get_partition_description(project),
-            bucket,
-            project,
-            S2VariantsWriter)
-
-    @classmethod
-    def _variant_partitions(cls, project):
-        part_desc = cls._get_partition_description(project)
-        chromosome_lengths = dict(
-            project.get_gpf_instance().reference_genome.get_all_chrom_lengths()
-        )
-        sum_parts, fam_parts = \
-            part_desc.get_variant_partitions(chromosome_lengths)
-        for part in sum_parts:
-            yield part_desc.partition_directory("summary", part), part
-        for part in fam_parts:
-            yield part_desc.partition_directory("family", part), part
-
-    @classmethod
-    def _merge_parquets(cls, project, out_dir, partitions):
-        full_out_dir = fs_utils.join(cls._study_dir(project), out_dir)
-        ParquetWriter.merge_parquets(
-            cls._get_partition_description(project), full_out_dir, partitions
-        )
-
-    @classmethod
     def _do_import_dataset(cls, project):
-        parquet_data_layout = GcpStudyLayout(
-            cls._pedigree_path(project),
-            cls._summary_variants_path(project),
-            cls._family_variants_path(project),
-            cls._meta_path(project)
-        )
+        layout = schema2_dataset_layout(project.get_parquet_dataset_dir())
         genotype_storage = cast(
             GcpGenotypeStorage, project.get_genotype_storage())
         assert isinstance(genotype_storage, GcpGenotypeStorage)
         genotype_storage.gcp_import_dataset(
-            project.study_id, parquet_data_layout)
+            project.study_id, layout)
 
     @classmethod
     def _do_study_config(cls, project):
@@ -130,11 +45,11 @@ class GcpImportStorage(ImportStorage):
             "genotype_browser": {"enabled": False},
         }
 
-        if study_tables.summary_variants:
-            assert study_tables.family_variants is not None
+        if study_tables.summary:
+            assert study_tables.family is not None
             storage_config = study_config["genotype_storage"]
-            storage_config["tables"]["summary"] = study_tables.summary_variants
-            storage_config["tables"]["family"] = study_tables.family_variants
+            storage_config["tables"]["summary"] = study_tables.summary
+            storage_config["tables"]["family"] = study_tables.family
             storage_config["tables"]["meta"] = study_tables.meta
             study_config["genotype_browser"]["enabled"] = True
 
@@ -148,43 +63,18 @@ class GcpImportStorage(ImportStorage):
 
     def generate_import_task_graph(self, project) -> TaskGraph:
         graph = TaskGraph()
-        pedigree_task = graph.create_task(
-            "Generating Pedigree", self._do_write_pedigree, [project], [],
-            input_files=[project.get_pedigree_filename()]
-        )
+        all_parquet_tasks = []
+        if project.get_processing_parquet_dataset_dir() is None:
+            all_parquet_tasks = self._build_all_parquet_tasks(project, graph)
 
-        bucket_tasks = []
-        for bucket in project.get_import_variants_buckets():
-            task = graph.create_task(
-                f"Converting Variants {bucket}", self._do_write_variant,
-                [project, bucket], [],
-                input_files=project.get_input_filenames(bucket)
-            )
-            bucket_tasks.append(task)
+        if project.has_genotype_storage():
+            import_task = graph.create_task(
+                "Import Dataset into GCP genotype storage",
+                self._do_import_dataset,
+                [project], all_parquet_tasks)
 
-        # merge small parquet files into larger ones
-        bucket_sync = graph.create_task(
-            "Sync Parquet Generation", lambda: None, [], bucket_tasks
-        )
-        output_dir_tasks = []
-        for output_dir, partitions in self._variant_partitions(project):
-            output_dir_tasks.append(graph.create_task(
-                f"Merging {output_dir}", self._merge_parquets,
-                [project, output_dir, partitions], [bucket_sync]
-            ))
-
-        # dummy task used for running the parquet generation w/o impala import
-        all_parquet_task = graph.create_task(
-            "Parquet Tasks", lambda: None, [], output_dir_tasks + [bucket_sync]
-        )
-
-        import_task = graph.create_task(
-            "Import Dataset into GCP genotype storage",
-            self._do_import_dataset,
-            [project], [pedigree_task, all_parquet_task])
-
-        graph.create_task(
-            "Create study config",
-            self._do_study_config,
-            [project], [import_task])
+            graph.create_task(
+                "Create study config",
+                self._do_study_config,
+                [project], [import_task])
         return graph

--- a/gcp_genotype_storage/gcp_genotype_storage/tests/conftest.py
+++ b/gcp_genotype_storage/gcp_genotype_storage/tests/conftest.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import textwrap
+import yaml
 import pytest
 
 from dae.testing import setup_pedigree, setup_vcf, vcf_study
@@ -96,7 +97,7 @@ def partition_study(tmp_path_factory, gcp_storage_fixture):
     study = vcf_study(
         root_path,
         "partition_vcf", ped_path, [vcf_path],
-        gpf_instance, partition_description=textwrap.dedent("""
+        gpf_instance, project_config_update=yaml.safe_load(textwrap.dedent("""
           partition_description:
             region_bin:
               chromosomes: foo,bar
@@ -105,5 +106,5 @@ def partition_study(tmp_path_factory, gcp_storage_fixture):
               family_bin_size: 2
             frequency_bin:
               rare_boundary: 5
-        """))
+        """)))
     return study

--- a/wdae/wdae/studies/tests/test_study_config_genotype_browser_columns.py
+++ b/wdae/wdae/studies/tests/test_study_config_genotype_browser_columns.py
@@ -1,6 +1,7 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import textwrap
 
+import yaml
 import pytest
 
 from studies.study_wrapper import StudyWrapper
@@ -41,9 +42,9 @@ def trio_study(tmp_path_factory, gpf_fixture):
         root_path,
         "trio", ped_path, [vcf_path],
         gpf_fixture,
-        study_config_update=textwrap.dedent("""
-        id: trio
-        """))
+        study_config_update={
+            "id": "trio"
+        })
     return study
 
 
@@ -70,7 +71,7 @@ def test_genotype_browser_download_columns_default(trio_study):
 
 def test_genotype_browser_preview_columns_ext(trio_study, gpf_fixture):
     study = study_update(
-        gpf_fixture, trio_study, textwrap.dedent("""
+        gpf_fixture, trio_study, yaml.safe_load(textwrap.dedent("""
         genotype_browser:
             columns:
                 genotype:
@@ -79,7 +80,7 @@ def test_genotype_browser_preview_columns_ext(trio_study, gpf_fixture):
                         source: aaa
             preview_columns_ext:
                 - aaa
-        """)
+        """))
     )
     config = study.config.genotype_browser
     assert config.preview_columns_ext == [
@@ -89,7 +90,7 @@ def test_genotype_browser_preview_columns_ext(trio_study, gpf_fixture):
 
 def test_genotype_browser_download_columns_ext(trio_study, gpf_fixture):
     study = study_update(
-        gpf_fixture, trio_study, textwrap.dedent("""
+        gpf_fixture, trio_study, yaml.safe_load(textwrap.dedent("""
         genotype_browser:
             columns:
                 genotype:
@@ -98,7 +99,7 @@ def test_genotype_browser_download_columns_ext(trio_study, gpf_fixture):
                         source: aaa
             download_columns_ext:
                 - aaa
-        """)
+        """))
     )
     config = study.config.genotype_browser
     assert config.download_columns_ext == [
@@ -108,7 +109,7 @@ def test_genotype_browser_download_columns_ext(trio_study, gpf_fixture):
 
 def test_study_wrapper_preview_columns_ext(trio_study, gpf_fixture):
     study = study_update(
-        gpf_fixture, trio_study, textwrap.dedent("""
+        gpf_fixture, trio_study, yaml.safe_load(textwrap.dedent("""
         genotype_browser:
             columns:
                 genotype:
@@ -117,7 +118,7 @@ def test_study_wrapper_preview_columns_ext(trio_study, gpf_fixture):
                         source: aaa
             preview_columns_ext:
                 - aaa
-        """)
+        """))
     )
     wrapper = StudyWrapper(study, None, None)
     assert wrapper.preview_columns == [
@@ -127,7 +128,7 @@ def test_study_wrapper_preview_columns_ext(trio_study, gpf_fixture):
 
 def test_study_wrapper_download_columns_ext(trio_study, gpf_fixture):
     study = study_update(
-        gpf_fixture, trio_study, textwrap.dedent("""
+        gpf_fixture, trio_study, yaml.safe_load(textwrap.dedent("""
         genotype_browser:
             columns:
                 genotype:
@@ -136,7 +137,7 @@ def test_study_wrapper_download_columns_ext(trio_study, gpf_fixture):
                         source: aaa
             download_columns_ext:
                 - aaa
-        """)
+        """))
     )
     wrapper = StudyWrapper(study, None, None)
     assert wrapper.download_columns == [


### PR DESCRIPTION
## Background

When importing large variants datasets, it is usual for the import to be split into two parts:
- Annotation of the variants and preparation of the parquet dataset with all the genotype data.
- Import the parquet dataset into genotype storage.

It is common for large datasets to run these two tasks on different computers.

## Aim

Add support to import tools to start from an existing parquet dataset.

## Implementation

We added `parquet_dataset_dir` to the processing section of the import project. The layout of the schema2 parquet dataset is changed to have separate directories for each part of the dataset - `pedigree`, `summary`, `family` and `meta`.

The common production of schema2 parquet files is separated into a new import storage `Schema2ImportStorage`. Both `Impala2ImportStorage` and `GcpImportStorage` inherit from it.
 
A test for split import is added and run for both `impala2` and `gcp` genotype storages.
