### PR TITLE
Auto-generation of common reports

### DIFF
--- a/dae/dae/common_reports/common_report.py
+++ b/dae/dae/common_reports/common_report.py
@@ -175,7 +175,7 @@ class CommonReport:
     def load(report_filename: str) -> Optional[CommonReport]:
         """Load a common report from a file.
 
-        I file does not exists returns None.
+        If file does not exists returns None.
         """
         if not os.path.exists(report_filename):
             return None
@@ -183,3 +183,23 @@ class CommonReport:
             cr_json = json.load(crf)
 
         return CommonReport(cr_json)
+
+    @staticmethod
+    def build_and_save(study, force=False):
+        """Build a common report for a study, saves it and returns the report.
+
+        If the common reports are disabled for the study, the function skips
+        building the report and returns None.
+
+        If the report already exists the default behavior is to skip building
+        the report. You can force building the report by
+        passing `force=True` to the function.
+        """
+        if not study.config.common_report.enabled:
+            return None
+        report_filename = study.config.common_report.file_path
+        if os.path.exists(report_filename) and not force:
+            return CommonReport.load(report_filename)
+        report = CommonReport.build_report(study)
+        report.save(report_filename)
+        return report

--- a/dae/dae/common_reports/common_report.py
+++ b/dae/dae/common_reports/common_report.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+import os
 import time
 import logging
+import json
+from typing import Optional
 
 from dae.variants.attributes import Role
 
@@ -11,31 +16,28 @@ from dae.common_reports.denovo_report import DenovoReport
 logger = logging.getLogger(__name__)
 
 
-# FIXME: Too many instance attributes, refactor?
-class CommonReport:  # pylint: disable=too-many-instance-attributes
+class CommonReport:
     """Class representing a common report JSON."""
 
-    def __init__(self, json):
-        self.study_id = json["id"]
-        self.people_report = PeopleReport(json["people_report"])
-        self.families_report = FamiliesReport(json["families_report"])
-        self.denovo_report = DenovoReport(json.get("denovo_report"))
-        self.study_name = json["study_name"]
-        self.phenotype = json["phenotype"]
-        self.study_type = json["study_type"]
-        self.study_year = json["study_year"]
-        self.pub_med = json["pub_med"]
-        self.families = json["families"]
-        self.number_of_probands = json["number_of_probands"]
-        self.number_of_siblings = json["number_of_siblings"]
-        self.denovo = json["denovo"]
-        self.transmitted = json["transmitted"]
-        self.study_description = json["study_description"]
+    def __init__(self, data):
+        self.study_id = data["id"]
+        self.people_report = PeopleReport(data["people_report"])
+        self.families_report = FamiliesReport(data["families_report"])
+        self.denovo_report = DenovoReport(data.get("denovo_report"))
+        self.study_name = data["study_name"]
+        self.phenotype = data["phenotype"]
+        self.study_type = data["study_type"]
+        self.study_year = data["study_year"]
+        self.pub_med = data["pub_med"]
+        self.families = data["families"]
+        self.number_of_probands = data["number_of_probands"]
+        self.number_of_siblings = data["number_of_siblings"]
+        self.denovo = data["denovo"]
+        self.transmitted = data["transmitted"]
+        self.study_description = data["study_description"]
 
-    # FIXME: Too many locals
     @staticmethod
-    def from_genotype_study(genotype_data_study):
-        # pylint: disable=too-many-locals
+    def build_report(genotype_data_study):
         """Generate common report JSON from genotpye data study."""
         config = genotype_data_study.config.common_report
 
@@ -161,3 +163,23 @@ class CommonReport:  # pylint: disable=too-many-instance-attributes
             "transmitted": self.transmitted,
             "study_description": self.study_description,
         }
+
+    def save(self, report_filename: str) -> None:
+        """Save common report into a file."""
+        if not os.path.exists(os.path.dirname(report_filename)):
+            os.makedirs(os.path.dirname(report_filename))
+        with open(report_filename, "w+", encoding="utf8") as crf:
+            json.dump(self.to_dict(full=True), crf)
+
+    @staticmethod
+    def load(report_filename: str) -> Optional[CommonReport]:
+        """Load a common report from a file.
+
+        I file does not exists returns None.
+        """
+        if not os.path.exists(report_filename):
+            return None
+        with open(report_filename, "r", encoding="utf-8") as crf:
+            cr_json = json.load(crf)
+
+        return CommonReport(cr_json)

--- a/dae/dae/common_reports/denovo_report.py
+++ b/dae/dae/common_reports/denovo_report.py
@@ -286,14 +286,15 @@ class DenovoReport:
         config = genotype_data.config.common_report
         effect_groups = config.effect_groups
         effect_types = config.effect_types
-        print(
-            f"DENOVO REPORTS: person set collections {person_set_collections}")
+        logger.info(
+            "DENOVO REPORTS: person set collections %s",
+            person_set_collections)
         start = time.time()
-        denovo_variants = genotype_data.query_variants(
-            limit=None, inheritance=["denovo"],
-        )
-
-        denovo_variants = list(denovo_variants)
+        denovo_variants = []
+        if genotype_data.config.has_denovo:
+            denovo_variants = list(genotype_data.query_variants(
+                limit=None, inheritance=["denovo"],
+            ))
 
         elapsed = time.time() - start
         logger.info(

--- a/dae/dae/common_reports/tests/test_common_report.py
+++ b/dae/dae/common_reports/tests/test_common_report.py
@@ -3,7 +3,7 @@ from dae.common_reports.common_report import CommonReport
 
 
 def test_common_report(study4):
-    common_report = CommonReport.from_genotype_study(study4)
+    common_report = CommonReport.build_report(study4)
 
     assert common_report.study_id == "Study4"
     assert common_report.families_report

--- a/dae/dae/common_reports/tests/test_common_report_autogenerate.py
+++ b/dae/dae/common_reports/tests/test_common_report_autogenerate.py
@@ -59,6 +59,9 @@ def test_trios2_study_common_reports_enabled(trios2_fixture):
 def test_missing_common_report(trios2_fixture):
     gpf_instance, study = trios2_fixture
     report_filename = study.config.common_report.file_path
+    assert os.path.exists(report_filename)
+    os.remove(report_filename)
+
     assert not os.path.exists(report_filename)
 
     report = gpf_instance.get_common_report(study.study_id)

--- a/dae/dae/common_reports/tests/test_common_report_autogenerate.py
+++ b/dae/dae/common_reports/tests/test_common_report_autogenerate.py
@@ -1,0 +1,67 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
+
+import pytest
+
+from dae.testing import setup_pedigree, setup_denovo, denovo_study
+from dae.testing.foobar_import import foobar_gpf
+
+
+@pytest.fixture
+def trios2_fixture(tmp_path_factory):
+    root_path = tmp_path_factory.mktemp(
+        "common_reports_trios2")
+    gpf_instance = foobar_gpf(root_path)
+    ped_path = setup_pedigree(
+        root_path / "trios2_data" / "in.ped",
+        """
+        familyId personId dadId	 momId	sex status role
+        f1       m1       0      0      2   1      mom
+        f1       d1       0      0      1   1      dad
+        f1       p1       d1     m1     1   2      prb
+        f1       s1       d1     m1     2   1      sib
+        f2       m2       0      0      2   1      mom
+        f2       d2       0      0      1   1      dad
+        f2       p2       d2     m2     1   2      prb
+        """)
+    denovo_path = setup_denovo(
+        root_path / "trios2_data" / "in.tsv",
+        """
+          familyId  location  variant    bestState
+          f1        foo:7     sub(A->G)  2||2||1||1/0||0||1||0
+          f1        foo:10    sub(A->G)  2||2||1||1/0||0||1||1
+          f2        foo:10    sub(A->G)  2||2||1/0||0||1
+          f1        foo:11    sub(T->A)  2||2||1||2/0||0||1||0
+          f1        bar:10    sub(G->A)  2||2||2||1/0||0||0||1
+          f2        bar:11    sub(G->A)  2||2||1/0||0||1
+          f2        bar:12    sub(G->A)  2||2||1/0||0||1
+          f2        bar:14    del(2)     2||2||1/0||0||1
+        """
+    )
+
+    study = denovo_study(
+        root_path,
+        "trios2", ped_path, [denovo_path],
+        gpf_instance)
+    return gpf_instance, study
+
+
+def test_trios2_study_common_reports_enabled(trios2_fixture):
+    _gpf_instance, study = trios2_fixture
+    config = study.config
+
+    assert config is not None
+    assert config.common_report is not None
+
+    assert config.common_report.enabled
+
+
+def test_missing_common_report(trios2_fixture):
+    gpf_instance, study = trios2_fixture
+    report_filename = study.config.common_report.file_path
+    assert not os.path.exists(report_filename)
+
+    report = gpf_instance.get_common_report(study.study_id)
+    assert report is not None
+
+    assert os.path.exists(report_filename)

--- a/dae/dae/common_reports/tests/test_common_report_config.py
+++ b/dae/dae/common_reports/tests/test_common_report_config.py
@@ -22,7 +22,7 @@ def trios2_study(tmp_path_factory):
         f2       d2       0      0      1   1      dad
         f2       p2       d2     m2     1   2      prb
         """)
-    vcf_path = setup_denovo(
+    denovo_path = setup_denovo(
         root_path / "trios2_data" / "in.tsv",
         """
           familyId  location  variant    bestState
@@ -39,14 +39,8 @@ def trios2_study(tmp_path_factory):
 
     study = denovo_study(
         root_path,
-        "trios2", ped_path, [vcf_path],
-        gpf_instance,
-        study_config_update={
-            "id": "trios2",
-            "common_report": {
-                "enabled": True
-            }
-        })
+        "trios2", ped_path, [denovo_path],
+        gpf_instance)
     return study
 
 

--- a/dae/dae/configuration/schemas/study_config.py
+++ b/dae/dae/configuration/schemas/study_config.py
@@ -70,7 +70,7 @@ person_filters_schema = {
     "filter_type": {"type": "string"},
 }
 
-family_filters_schema = dict(
+family_filters_schema = dict(  # pylint: disable=use-dict-literal
     **person_filters_schema,
     role={"type": "string"},
 )

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -373,8 +373,7 @@ class GPFInstance:
         report = CommonReport.load(
             study.config.common_report.file_path)
         if report is None:
-            report = CommonReport.build_report(study)
-            report.save(study.config.common_report.file_path)
+            report = CommonReport.build_and_save(study)
         return report
 
     def get_all_common_report_configs(self):

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -370,8 +370,12 @@ class GPFInstance:
             return None
         if not study.config.common_report.enabled:
             return None
-        return CommonReport.load(
+        report = CommonReport.load(
             study.config.common_report.file_path)
+        if report is None:
+            report = CommonReport.build_report(study)
+            report.save(study.config.common_report.file_path)
+        return report
 
     def get_all_common_report_configs(self):
         """Return all common report configuration."""

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -3,7 +3,6 @@
 
 import os
 import logging
-import json
 from functools import cached_property
 from typing import Optional, Union
 from pathlib import Path
@@ -369,19 +368,10 @@ class GPFInstance:
         study = self.get_genotype_data(study_id)
         if study is None or study.is_remote:
             return None
-        try:
-            common_report_path = study.config.common_report.file_path
-            if not common_report_path or not os.path.exists(
-                common_report_path
-            ):
-                return None
-
-            with open(common_report_path, "r", encoding="utf-8") as crf:
-                cr_json = json.load(crf)
-
-            return CommonReport(cr_json)
-        except AssertionError:
+        if not study.config.common_report.enabled:
             return None
+        return CommonReport.load(
+            study.config.common_report.file_path)
 
     def get_all_common_report_configs(self):
         """Return all common report configuration."""

--- a/dae/dae/person_filters.py
+++ b/dae/dae/person_filters.py
@@ -62,16 +62,16 @@ class PersonFilterRange(CriteriaFilter):
 
     def apply_to_df(self, df: pd.DataFrame) -> pd.DataFrame:
         if self.values_min is not None and self.values_max is not None:
-            return df[
+            return df[  # type: ignore
                 np.logical_and(
                     df[self.criteria] >= self.values_min,
                     df[self.criteria] <= self.values_max,
                 )
             ]
         if self.values_min is not None:
-            return df[df[self.criteria] >= self.values_min]
+            return df[df[self.criteria] >= self.values_min]  # type: ignore
         if self.values_max is not None:
-            return df[df[self.criteria] <= self.values_max]
+            return df[df[self.criteria] <= self.values_max]  # type: ignore
         return df[-np.isnan(df[self.criteria])]
 
 

--- a/dae/dae/person_sets.py
+++ b/dae/dae/person_sets.py
@@ -27,7 +27,7 @@ class PersonSet:
             self, psid: str, name: str,
             values: List[str], color: str,
             persons: Dict[str, Person]):
-        self.id: str = psid
+        self.id: str = psid  # pylint: disable=invalid-name
         self.name: str = name
         self.values: List[str] = values
         self.color: str = color
@@ -86,7 +86,7 @@ class PersonSetCollection:
 
         assert config.get("default") is not None
 
-        self.id: str = pscid
+        self.id: str = pscid  # pylint: disable=invalid-name
         self.name: str = name
         self.config = config
         self.sources = sources

--- a/dae/dae/studies/study.py
+++ b/dae/dae/studies/study.py
@@ -10,7 +10,7 @@ from os.path import basename, exists
 
 from abc import ABC, abstractmethod
 
-from typing import Dict, List, cast
+from typing import Dict, List, cast, Any
 
 from dae.query_variants.query_runners import QueryResult
 from dae.pedigrees.family import FamiliesData
@@ -475,7 +475,7 @@ class GenotypeData(ABC):  # pylint: disable=too-many-public-methods
         try:
             started = time.time()
 
-            variants = {}
+            variants: dict[str, Any] = {}
             with closing(result) as result:
                 result.start()
 

--- a/dae/dae/studies/tests/test_study_without_variants.py
+++ b/dae/dae/studies/tests/test_study_without_variants.py
@@ -42,10 +42,11 @@ def no_variants_study(gpf_instance_2013, tmp_path):
 
     default_config = GPFConfigParser.parse_and_interpolate_file(
         gpf_instance_2013.dae_config.default_study_config.conf_file)
-    content = GPFConfigParser.parse_and_interpolate(content, parser=toml.loads)
+    parsed_content = GPFConfigParser.parse_and_interpolate(
+        content, parser=toml.loads)
     tmp_path.mkdir(exist_ok=True)
     config = GPFConfigParser.process_config(
-        content, study_config_schema, default_config, tmp_path)
+        parsed_content, study_config_schema, default_config, tmp_path)
 
     genotype_storage = \
         gpf_instance_2013.genotype_storages.get_genotype_storage(
@@ -70,5 +71,5 @@ def test_study_simple(no_variants_study):
 
 def test_common_reports(no_variants_study):
     """Test building a common report from a study without variants."""
-    common_report = CommonReport.from_genotype_study(no_variants_study)
+    common_report = CommonReport.build_report(no_variants_study)
     assert common_report

--- a/dae/dae/studies/variants_db.py
+++ b/dae/dae/studies/variants_db.py
@@ -282,6 +282,10 @@ class VariantsDb:
 
         self._load_all_genotype_studies(genotype_study_configs)
         self._load_all_genotype_groups(genotype_group_configs)
+        for study in self.get_all_genotype_data():
+            # pylint: disable=import-outside-toplevel
+            from dae.common_reports.common_report import CommonReport
+            CommonReport.build_and_save(study)
 
     def _load_study_configs(self):
         logger.info("loading study configs: %s", self.dae_config.studies)

--- a/dae/dae/studies/variants_db.py
+++ b/dae/dae/studies/variants_db.py
@@ -229,6 +229,9 @@ location_column = "variant.location"
 domain_min = 0.001
 domain_max = 100
 
+
+[common_report]
+enabled = true
 """  # noqa
 
 

--- a/dae/dae/tools/generate_common_report.py
+++ b/dae/dae/tools/generate_common_report.py
@@ -70,7 +70,7 @@ def main(argv, gpf_instance=None):
                     study.study_id)
                 continue
 
-            common_report = CommonReport.from_genotype_study(study)
+            common_report = CommonReport.build_report(study)
             file_path = study.config.common_report.file_path
 
             if not os.path.exists(os.path.dirname(file_path)):

--- a/integration/remote/entrypoint.sh
+++ b/integration/remote/entrypoint.sh
@@ -65,5 +65,10 @@ rm -rf $DAE_DB_DIR/wdae/wdae_django_default.cache
     grr_cache_repo --definition /wd/integration/grr_definition.yaml\
         --instance $DAE_DB_DIR/gpf_instance.yaml
 
-/opt/conda/bin/conda run --no-capture-output -n gpf \
-    /wd/wdae/wdae/wdaemanage.py runserver 0.0.0.0:21010
+while true; do
+
+    /opt/conda/bin/conda run --no-capture-output -n gpf \
+        /wd/wdae/wdae/wdaemanage.py runserver 0.0.0.0:21010
+    sleep 10
+
+done

--- a/pylintrc
+++ b/pylintrc
@@ -470,7 +470,7 @@ spelling-store-unknown-words=no
 max-args=11
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=12
+max-attributes=17
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -1,4 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
 import json
 import pytest
 
@@ -147,14 +148,19 @@ def test_variant_reports_no_permissions(user_client):
     assert data
 
 
-@pytest.mark.xfail(reason="this test is flipping; should be investigated")
-def test_variant_reports_not_found(admin_client):
+def test_autogenerate_common_report(admin_client, wdae_gpf_instance):
+    study = wdae_gpf_instance.get_genotype_data("Study3")
+    assert study is not None
+    report_filename = study.config.common_report.file_path
+    assert not os.path.exists(report_filename)
+
     url = "/api/v3/common_reports/studies/Study3"
     response = admin_client.get(url)
 
-    assert response
-    assert response.data["error"] == "Common report Study3 not found"
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == "Study3"
+
+    assert os.path.exists(report_filename)
 
 
 def test_families_data_download(admin_client):
@@ -170,7 +176,7 @@ def test_families_data_download(admin_client):
     assert len(streaming_content) == 34
 
 
-@pytest.mark.xfail(reason="this test is flipping; should be investigated")
+# @pytest.mark.xfail(reason="this test is flipping; should be investigated")
 def test_families_data_download_no_permissions(user_client):
     url = "/api/v3/common_reports/families_data/study4"
     response = user_client.get(url)

--- a/wdae/wdae/common_reports_api/tests/test_remote_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_remote_common_reports_api.py
@@ -1,5 +1,4 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-
 import pytest
 from rest_framework import status  # type: ignore
 
@@ -19,7 +18,7 @@ def test_remote_variant_reports(admin_client):
     assert data
 
 
-@pytest.mark.xfail(reason="unstable test")
+# @pytest.mark.xfail(reason="unstable test")
 def test_remote_families_data_download(admin_client):
     url = "/api/v3/common_reports/families_data/TEST_REMOTE_iossifov_2014"
     response = admin_client.get(url)
@@ -29,28 +28,33 @@ def test_remote_families_data_download(admin_client):
 
     streaming_content = list(response.streaming_content)
     assert streaming_content
-
-    assert len(streaming_content) == 9450
+    assert len(streaming_content) == 44
 
     header = streaming_content[0].decode("utf8")
     assert header[-1] == "\n"
     header = header[:-1].split("\t")
-    assert len(header) == 8
+    assert len(header) == 15
 
     assert header == [
-        "familyId",
-        "personId",
-        "dadId",
-        "momId",
+        "family_id",
+        "person_id",
+        "mom_id",
+        "dad_id",
         "sex",
         "status",
         "role",
-        "genotype_data_study",
+        "sample_id",
+        "layout",
+        "generated",
+        "not_sequenced",
+        "family_bin",
+        "index",
+        "member_index",
+        "missing",
     ]
 
     first_person = streaming_content[1].decode("utf8")
     assert first_person[-1] == "\n"
     first_person = first_person[:-1].split("\t")
-    assert len(first_person) == 8
-
-    assert first_person[-1] == "iossifov_2014"
+    assert len(first_person) == 15
+    # assert first_person[-1] == "iossifov_2014"

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -10,7 +10,10 @@ from dae.pedigrees.serializer import FamiliesTsvSerializer
 
 
 class VariantReportsView(QueryDatasetView):
-    def get(self, request, common_report_id):
+    """Variant reports view class."""
+
+    def get(self, _request, common_report_id):
+        """Return a variant report when requested."""
         assert common_report_id
 
         common_report = self.gpf_instance.get_common_report(
@@ -26,7 +29,10 @@ class VariantReportsView(QueryDatasetView):
 
 
 class VariantReportsFullView(QueryDatasetView):
-    def get(self, request, common_report_id):
+    """Variants report full view class."""
+
+    def get(self, _request, common_report_id):
+        """Return full variant report when requested."""
         assert common_report_id
 
         common_report = self.gpf_instance.get_common_report(
@@ -36,13 +42,16 @@ class VariantReportsFullView(QueryDatasetView):
         if common_report is not None:
             return Response(common_report.to_dict(full=True))
         return Response(
-            {"error": "Common report {} not found".format(common_report_id)},
+            {"error": f"Common report {common_report_id} not found"},
             status=status.HTTP_404_NOT_FOUND,
         )
 
 
 class FamilyCounterListView(QueryDatasetView):
+    """Family couters list view class."""
+
     def post(self, request):
+        """Return family counters for specified study and group name."""
         data = request.data
 
         common_report_id = data["study_id"]
@@ -69,7 +78,10 @@ class FamilyCounterListView(QueryDatasetView):
 
 
 class FamilyCounterDownloadView(QueryDatasetView):
+    """Family counters download view class."""
+
     def post(self, request):
+        """Return family couters for a specified study and group name."""
         data = request.data
 
         study_id = data["study_id"]
@@ -112,7 +124,10 @@ class FamilyCounterDownloadView(QueryDatasetView):
 
 
 class FamiliesDataDownloadView(QueryDatasetView):
+    """Families data download view class."""
+
     def get(self, request, dataset_id):
+        """Return full family data for a specified study and tags."""
         tags = request.GET.get("tags")
 
         if not dataset_id:

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -154,7 +154,7 @@ class WGPFInstance(GPFInstance):
         genotype_data = super().get_genotype_data(genotype_data_id)
         if genotype_data is not None:
             return genotype_data
-
+        assert self._remote_study_db is not None
         genotype_data = self._remote_study_db\
             .get_genotype_data(genotype_data_id)
         return genotype_data
@@ -164,6 +164,7 @@ class WGPFInstance(GPFInstance):
             super().get_genotype_data_config(genotype_data_id)
         if genotype_data_config is not None:
             return genotype_data_config
+        assert self._remote_study_db is not None
         return self._remote_study_db\
             .get_genotype_data_config(genotype_data_id)
 
@@ -294,7 +295,7 @@ def get_wgpf_instance_path(config_filename=None):
     """Return the path to the GPF instance in use."""
     if _GPF_INSTANCE is not None:
         return pathlib.Path(_GPF_INSTANCE.dae_dir)
-
+    dae_dir: Optional[pathlib.Path]
     if config_filename is not None:
         dae_dir = pathlib.Path(config_filename).parent
         return dae_dir


### PR DESCRIPTION
## Aim

We changed the default configuration of common reports to be enabled by default.

When someone tries to access a common report from `GPFInstance.get_common_report`, the method will check if the common report cache already exists, and if not, it will generate it.

The auto-generation of the common reports cache is added after loading studies when creating `GPFInstance`.