### PR TITLE
Small fixes

### DIFF
--- a/dae/dae/common_reports/common_report.py
+++ b/dae/dae/common_reports/common_report.py
@@ -198,8 +198,13 @@ class CommonReport:
         if not study.config.common_report.enabled:
             return None
         report_filename = study.config.common_report.file_path
-        if os.path.exists(report_filename) and not force:
-            return CommonReport.load(report_filename)
+        try:
+            if os.path.exists(report_filename) and not force:
+                return CommonReport.load(report_filename)
+        except Exception:  # pylint: disable=broad-except
+            logger.warning(
+                "unable to load common report for %s", study.study_id,
+                exc_info=True)
         report = CommonReport.build_report(study)
         report.save(report_filename)
         return report

--- a/dae/dae/genomic_resources/repository_factory.py
+++ b/dae/dae/genomic_resources/repository_factory.py
@@ -56,7 +56,7 @@ def load_definition_file(filename):
 GRR_DEFINITION_FILE_ENV = "GRR_DEFINITION_FILE"
 
 
-def get_configured_definition():
+def get_default_grr_definition():
     """Return default genomic resources repository definition."""
     logger.info("using default GRR definitions")
     env_repo_definition_path = os.environ.get(GRR_DEFINITION_FILE_ENV)
@@ -178,7 +178,7 @@ def build_genomic_resource_repository(
         if file_name is not None:
             definition = load_definition_file(file_name)
         else:
-            definition = get_configured_definition()
+            definition = get_default_grr_definition()
     else:
         if file_name is not None:
             raise ValueError(

--- a/dae/dae/genomic_resources/tests/test_cli_manifest.py
+++ b/dae/dae/genomic_resources/tests/test_cli_manifest.py
@@ -110,20 +110,17 @@ def test_repo_manifest_no_agruments(
     assert out == \
         f"working with repository: {path}\n"
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "manifest of <sub/two> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "manifest of <sub/two(1.0)> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "manifest of <three(2.0)> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "manifest of <xxxxx-genome> is up to date"),
     ]
 
@@ -228,6 +225,8 @@ def test_resource_dry_run_manifest_needs_update_message(
     assert captured.err == ""
 
     assert caplog.record_tuples == [
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
         ("grr_manage", logging.INFO,
          "manifest of <one> should be updated; entries to update in manifest "
          "['data.txt']"),
@@ -253,6 +252,8 @@ def test_repo_dry_run_manifest_needs_update_message(
     assert captured.err == ""
 
     assert caplog.record_tuples == [
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
         ("grr_manage", logging.INFO,
          "manifest of <one> should be updated; entries to update in manifest "
          "['data.txt']"),
@@ -283,6 +284,8 @@ def test_resource_dry_run_manifest_no_update_message(
     assert captured.err == ""
 
     assert caplog.record_tuples == [
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
         ("grr_manage", logging.INFO, "manifest of <one> is up to date")
     ]
 
@@ -307,6 +310,8 @@ def test_resource_manifest_no_agruments(
     assert err == ""
     assert out == f"working with repository: {path}\n"
     assert caplog.record_tuples == [
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
         ("grr_manage", logging.INFO, "manifest of <one> is up to date")
     ]
 
@@ -325,6 +330,8 @@ def test_repo_dry_run_manifest_no_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
         ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
         ("grr_manage", logging.INFO,

--- a/dae/dae/genomic_resources/tests/test_cli_repair.py
+++ b/dae/dae/genomic_resources/tests/test_cli_repair.py
@@ -122,7 +122,6 @@ def test_repo_repair_dry_run(proto_fixture):
     assert not (path / GR_CONTENTS_FILE_NAME).exists()
 
 
-@pytest.mark.skip()
 def test_resource_repair_need_update_message(
         proto_fixture, capsys, caplog, mocker):
     path, _proto = proto_fixture
@@ -136,19 +135,21 @@ def test_resource_repair_need_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("grr_manage", logging.INFO,
          "No hash stored for <one>, need update"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Statistics of <one> need update"),
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
     ]
 
 
-@pytest.mark.skip()
 def test_repo_repair_need_update_message(
         proto_fixture, capsys, caplog):
     path, proto_fixture = proto_fixture
@@ -161,19 +162,25 @@ def test_repo_repair_need_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
         ("grr_manage",
          logging.INFO,
          "manifest of <one> is up to date"),
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
         ("grr_manage",
          logging.INFO,
          "No hash stored for <one>, need update"),
         ("grr_manage",
          logging.INFO,
          "Statistics of <one> need update"),
+        ("dae.genomic_resources.genomic_scores",
+         logging.ERROR,
+         "Couldn't load statistics of one"),
     ]
 
 
-@pytest.mark.skip()
 def test_resource_repair_no_update_message(
         proto_fixture, capsys, caplog):
     # Given
@@ -193,16 +200,17 @@ def test_resource_repair_no_update_message(
     assert out == ""
     assert err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "<one> statistics hash is up to date"),
     ]
 
 
-@pytest.mark.skip()
 def test_repo_repair_no_update_message(
         proto_fixture, capsys, caplog):
     # Given
@@ -221,16 +229,17 @@ def test_repo_repair_no_update_message(
     assert out == ""
     assert err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "<one> statistics hash is up to date"),
     ]
 
 
-@pytest.mark.skip()
 def test_resource_repair_dry_run_needs_manifest_update_message(
         proto_fixture, capsys, caplog):
     # Given
@@ -255,17 +264,18 @@ def test_resource_repair_dry_run_needs_manifest_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> should be updated; entries to update in manifest "
          "['data.txt']"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Manifest of <one> needs update, cannot check statistics"),
     ]
 
 
-@pytest.mark.skip()
 def test_repo_repair_dry_run_needs_manifest_update_message(
         proto_fixture, capsys, caplog):
     # Given
@@ -287,17 +297,18 @@ def test_repo_repair_dry_run_needs_manifest_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> should be updated; entries to update in manifest "
          "['data.txt']"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Manifest of <one> needs update, cannot check statistics"),
     ]
 
 
-@pytest.mark.skip()
 def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
         proto_fixture, capsys, caplog):
     # Given
@@ -329,19 +340,21 @@ def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> should be updated; entries to update in manifest "
          "['data.txt.gz', 'data.txt.gz.tbi']"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Manifest of <one> needs update, cannot check statistics"),
     ]
 
     # And after that::
     # Given
     cli_manage([
-        "resource-manifest", "-R", str(path), "-r", "one", "-j", "1"])
+        "resource-manifest", "-R", str(path), "-r", "one", ])
     _, _ = capsys.readouterr()
     caplog.clear()
 
@@ -357,19 +370,17 @@ def test_resource_repair_dry_run_needs_manifest_and_histogram_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Stored hash for <one> is outdated, need update"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Statistics of <one> need update"),
     ]
 
 
-@pytest.mark.skip()
 def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
         proto_fixture, capsys, caplog):
     # Given
@@ -399,19 +410,21 @@ def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.genomic_scores", logging.ERROR,
+         "Couldn't load statistics of one"),
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> should be updated; entries to update in manifest "
          "['data.txt.gz', 'data.txt.gz.tbi']"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Manifest of <one> needs update, cannot check statistics"),
     ]
 
     # And after that::
     # Given
     cli_manage([
-        "repo-manifest", "-R", str(path), "-j", "1"])
+        "repo-manifest", "-R", str(path), ])
     _, _ = capsys.readouterr()
     caplog.clear()
 
@@ -425,13 +438,12 @@ def test_repo_repair_dry_run_needs_manifest_and_histogram_update_message(
     assert captured.out == ""
     assert captured.err == ""
     assert caplog.record_tuples == [
-        ("grr_manage",
-         logging.INFO,
+        ("dae.genomic_resources.repository_factory", logging.INFO,
+         "using default GRR definitions"),
+        ("grr_manage", logging.INFO,
          "manifest of <one> is up to date"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Stored hash for <one> is outdated, need update"),
-        ("grr_manage",
-         logging.INFO,
+        ("grr_manage", logging.INFO,
          "Statistics of <one> need update"),
     ]

--- a/dae/dae/tools/grr_cache_repo.py
+++ b/dae/dae/tools/grr_cache_repo.py
@@ -8,7 +8,7 @@ import logging
 
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.genomic_resources.repository_factory import load_definition_file, \
-    get_configured_definition, \
+    get_default_grr_definition, \
     build_genomic_resource_repository
 from dae.genomic_resources.cached_repository import GenomicResourceCachedRepo
 from dae.configuration.gpf_config_parser import GPFConfigParser
@@ -57,7 +57,7 @@ def cli_cache_repo(argv=None):
     if args.definition is not None:
         definition = load_definition_file(args.definition)
     else:
-        definition = get_configured_definition()
+        definition = get_default_grr_definition()
 
     repository = build_genomic_resource_repository(definition=definition)
     if not isinstance(repository, GenomicResourceCachedRepo):


### PR DESCRIPTION
## Aim

Implementation of a couple of small fixes.

- `grr_manage` command line tool uses the default GRR to search for a reference genome if we do not pass the explicit external `--grr` parameter.
- the function for the generation of common reports `CommonReports.build_and_save` handles the case when there is an existing common report but in a wrong JSON format.
