### PR TITLE
Add route for Sentry tunneling of frontend errors

### DIFF
--- a/wdae/wdae/sentry/urls.py
+++ b/wdae/wdae/sentry/urls.py
@@ -1,0 +1,10 @@
+from django.urls import re_path
+
+from rest_framework.routers import SimpleRouter
+from . import views
+
+router = SimpleRouter(trailing_slash=False)
+
+urlpatterns = [
+    re_path(r"^/?$", views.sentry),
+]

--- a/wdae/wdae/sentry/views.py
+++ b/wdae/wdae/sentry/views.py
@@ -1,0 +1,40 @@
+import codecs
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.decorators import api_view, parser_classes
+from django.conf import settings
+from rest_framework.exceptions import ParseError
+from rest_framework.parsers import BaseParser
+
+import json
+import os
+import requests
+from urllib.parse import urlparse
+
+
+class PlainTextParser(BaseParser):
+    media_type = "text/plain"
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        parser_context = parser_context or {}
+        encoding = parser_context.get('encoding', settings.DEFAULT_CHARSET)
+
+        try:
+            decoded_stream = codecs.getreader(encoding)(stream)
+            text_content = decoded_stream.read()
+            return text_content
+        except ValueError as exc:
+            raise ParseError("Plain text parse error - %s" % str(exc))
+
+
+@api_view(["POST"])
+@parser_classes([PlainTextParser])
+def sentry(request):
+    data = request.data.split("\n")
+    header = json.loads(data[0])
+    dsn = urlparse(header["dsn"])
+    project_id = dsn.path.strip("/")
+    sentry_host = os.environ.get("SENTRY_HOST")
+    upstream_sentry_url = f"https://{sentry_host}/api/{project_id}/envelope/"
+    requests.post(upstream_sentry_url, data=request.data.encode(), timeout=30)
+    return Response({}, status.HTTP_200_OK)

--- a/wdae/wdae/sentry/views.py
+++ b/wdae/wdae/sentry/views.py
@@ -30,7 +30,7 @@ class PlainTextParser(BaseParser):
 @api_view(["POST"])
 @parser_classes([PlainTextParser])
 def sentry(request):
-    dsn = os.environ.get("SENTRY_DSN")
+    dsn = os.environ.get("WDAE_SENTRY_DSN")
     fake_dsn = "https://0@0.ingest.sentry.io/0"  # gpfjs: main.ts
     project_id = urlparse(dsn).path.strip("/")
     sentry_host = dsn.split("@")[1].split("/")[0]

--- a/wdae/wdae/sentry/views.py
+++ b/wdae/wdae/sentry/views.py
@@ -30,11 +30,14 @@ class PlainTextParser(BaseParser):
 @api_view(["POST"])
 @parser_classes([PlainTextParser])
 def sentry(request):
-    data = request.data.split("\n")
-    header = json.loads(data[0])
-    dsn = urlparse(header["dsn"])
-    project_id = dsn.path.strip("/")
-    sentry_host = os.environ.get("SENTRY_HOST")
+    dsn = os.environ.get("SENTRY_DSN")
+    fake_dsn = "https://0@0.ingest.sentry.io/0"  # gpfjs: main.ts
+    project_id = urlparse(dsn).path.strip("/")
+    sentry_host = dsn.split("@")[1].split("/")[0]
     upstream_sentry_url = f"https://{sentry_host}/api/{project_id}/envelope/"
-    requests.post(upstream_sentry_url, data=request.data.encode(), timeout=30)
+    requests.post(
+        upstream_sentry_url,
+        data=request.data.replace(fake_dsn, dsn).encode(),
+        timeout=30
+    )
     return Response({}, status.HTTP_200_OK)

--- a/wdae/wdae/wdae/urls.py
+++ b/wdae/wdae/wdae/urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
     re_path(r"^api/v3/person_sets", include("person_sets_api.urls")),
     path("o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     re_path(r"^accounts/login/?$", WdaeLoginView.as_view(), name="login_user"),
+    re_path(r"^api/v3/sentry", include("sentry.urls")),
 ]


### PR DESCRIPTION
## Background and implementation

We wish to use Sentry to aggregate and report errors on our frontend, but without revealing our DSN. To this end, we tunnel our Sentry requests through to our backend using a fake DSN on the frontend, which is substituted with our real DSN and re-sent towards Sentry.
