### PR TITLE
Import tools small fixes

### DIFF
--- a/dae/dae/common_reports/tests/test_common_report_autogenerate.py
+++ b/dae/dae/common_reports/tests/test_common_report_autogenerate.py
@@ -28,7 +28,7 @@ def trios2_fixture(tmp_path_factory):
         root_path / "trios2_data" / "in.tsv",
         """
           familyId  location  variant    bestState
-          f1        foo:7     sub(A->G)  2||2||1||1/0||0||1||0
+          f1        foo:7     sub(A->G)  2||2||1||2/0||0||1||0
           f1        foo:10    sub(A->G)  2||2||1||1/0||0||1||1
           f2        foo:10    sub(A->G)  2||2||1/0||0||1
           f1        foo:11    sub(T->A)  2||2||1||2/0||0||1||0

--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -53,7 +53,7 @@ class ImpalaSchema1ImportStorage(ImportStorage):
     def _do_write_meta(cls, project):
         out_dir = cls._variants_dir(project)
         gpf_instance = project.get_gpf_instance()
-        loader_type = project.get_variant_loader_types()[0]
+        loader_type = next(iter(project.get_variant_loader_types()))
         ParquetWriter.write_meta(
             out_dir,
             project.get_variant_loader(
@@ -169,7 +169,7 @@ class ImpalaSchema1ImportStorage(ImportStorage):
     def _do_study_config(cls, project):
         start = time.time()
         pedigree_table = cls._construct_pedigree_table(project.study_id)
-        variants_types = project.get_import_variants_types()
+        variants_types = project.get_variant_loader_types()
         study_config = {
             "id": project.study_id,
             "conf_dir": ".",

--- a/dae/dae/impala_storage/schema1/impala_schema1.py
+++ b/dae/dae/impala_storage/schema1/impala_schema1.py
@@ -84,9 +84,12 @@ class ImpalaSchema1ImportStorage(ImportStorage):
     @classmethod
     def _variant_partitions(cls, project):
         part_desc = cls._get_partition_description(project)
-        chromosome_lengths = dict(
-            project.get_gpf_instance().reference_genome.get_all_chrom_lengths()
-        )
+        chromosomes = project.get_variant_loader_chromosomes()
+        chromosome_lengths = dict(filter(
+            lambda cl: cl[0] in chromosomes,
+            project.get_gpf_instance()
+            .reference_genome
+            .get_all_chrom_lengths()))
         _, fam_parts = \
             part_desc.get_variant_partitions(chromosome_lengths)
         for part in fam_parts:

--- a/dae/dae/impala_storage/schema1/tests/test_impala_genotype_storage.py
+++ b/dae/dae/impala_storage/schema1/tests/test_impala_genotype_storage.py
@@ -130,7 +130,6 @@ def test_impala_partition_import(
         with conn.cursor() as cursor:
             cursor.execute(f"DESCRIBE EXTENDED {db}.test_study_variants")
             rows = list(cursor)
-            # import pdb; pdb.set_trace()
             assert any(
                 row[1] == "gpf_partitioning_coding_bin_coding_effect_types"
                 and all([

--- a/dae/dae/impala_storage/schema2/impala2_import_storage.py
+++ b/dae/dae/impala_storage/schema2/impala2_import_storage.py
@@ -53,7 +53,7 @@ class Impala2ImportStorage(Schema2ImportStorage):
         meta_table = genotype_storage\
             ._construct_metadata_table(project.study_id)
 
-        variants_types = project.get_import_variants_types()
+        variants_types = project.get_variant_loader_types()
         study_config = {
             "id": project.study_id,
             "conf_dir": ".",

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -151,7 +151,7 @@ class ImportProject():
         families_loader = self.get_pedigree_loader()
         return families_loader.load()
 
-    def get_import_variants_types(self) -> set[str]:
+    def get_variant_loader_types(self) -> set[str]:
         """Collect all variant import types used in the project."""
         result = set()
         for loader_type in ["denovo", "vcf", "cnv", "dae"]:
@@ -169,11 +169,6 @@ class ImportProject():
                 for bucket in self._loader_region_bins(loader_type):
                     buckets.append(bucket)
         return buckets
-
-    def get_variant_loader_types(self) -> list[str]:
-        return list(filter(
-            lambda lt: lt in {"vcf", "dae", "denovo", "cnv"},
-            self.import_config["input"].keys()))
 
     def get_variant_loader(
             self,

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -172,7 +172,7 @@ class ImportProject():
 
     def get_variant_loader_types(self) -> list[str]:
         return list(filter(
-            lambda lt: lt != "pedigree",
+            lambda lt: lt in {"vcf", "dae", "denovo", "cnv"},
             self.import_config["input"].keys()))
 
     def get_variant_loader(

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -160,6 +160,25 @@ class ImportProject():
                 result.add(loader_type)
         return result
 
+    def get_variant_loader_chromosomes(
+            self, loader_type: Optional[str] = None) -> list[str]:
+        """Collect all chromosomes available in input files."""
+        if loader_type is None:
+            loader_types = self.get_variant_loader_types()
+        else:
+            if loader_type not in self.get_variant_loader_types():
+                return []
+            loader_types = {loader_type}
+        chromosomes = set()
+        for ltype in loader_types:
+            loader = self.get_variant_loader(loader_type=ltype)
+            chromosomes.update(loader.chromosomes)
+        result = []
+        for chrom in self.get_gpf_instance().reference_genome.chromosomes:
+            if chrom in chromosomes:
+                result.append(chrom)
+        return result
+
     def get_import_variants_buckets(self) -> list[Bucket]:
         """Split variant files into buckets enabling parallel processing."""
         buckets = []

--- a/dae/dae/import_tools/tests/test_import_project_loaders.py
+++ b/dae/dae/import_tools/tests/test_import_project_loaders.py
@@ -1,0 +1,54 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+
+
+import pytest
+
+from dae.testing import acgt_gpf, setup_pedigree, setup_vcf, setup_denovo
+from dae.testing.import_helpers import StudyInputLayout, setup_import_project
+
+
+@pytest.fixture
+def project_fixture(tmp_path_factory):
+    root_path = tmp_path_factory.mktemp("import_project_tests")
+    gpf_instance = acgt_gpf(root_path)
+
+    ped_path = setup_pedigree(
+        root_path / "input_data" / "in.ped",
+        """
+        familyId personId dadId	 momId	sex status role
+        f1       m1       0      0      2   1      mom
+        f1       d1       0      0      1   1      dad
+        f1       p1       d1     m1     1   2      prb
+        """)
+    vcf_path = setup_vcf(
+        root_path / "input_data" / "in.vcf.gz",
+        """
+        ##fileformat=VCFv4.2
+        ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+        ##contig=<ID=chr1>
+        ##contig=<ID=chr2>
+        #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT m1  d1  p1
+        chr1   7   .  A   C   .    .      .    GT     0/1 0/0 0/1
+        """)
+    denovo_path = setup_denovo(
+        root_path / "trios2_data" / "in.tsv",
+        """
+          familyId  location  variant    bestState
+          f1        chr2:11    sub(A->G)  2||2||1/0||0||1
+        """
+    )
+    project = setup_import_project(
+        root_path / "project",
+        StudyInputLayout(
+            "mixed", ped_path, [vcf_path], [denovo_path], [], []),
+        gpf_instance)
+
+    return project
+
+
+def test_import_project_chromosomes_simple(project_fixture):
+    assert project_fixture.get_variant_loader_chromosomes() == ["chr1", "chr2"]
+
+
+def test_import_project_variant_loader_types(project_fixture):
+    assert project_fixture.get_variant_loader_types() == {"vcf", "denovo"}

--- a/dae/dae/inmemory_storage/inmemory_import_storage.py
+++ b/dae/dae/inmemory_storage/inmemory_import_storage.py
@@ -65,7 +65,7 @@ class InmemoryImportStorage(ImportStorage):
             cls, project: ImportProject,
             loader_type=None) -> list[dict[str, Any]]:
         if loader_type is None:
-            loader_types = project.get_import_variants_types()
+            loader_types = project.get_variant_loader_types()
         else:
             loader_types = set([loader_type])
 
@@ -109,7 +109,7 @@ class InmemoryImportStorage(ImportStorage):
     def _do_study_import(cls, project: ImportProject) -> None:
         pedigree_config = cls._do_copy_pedigree(project)
         variants_config = cls._do_copy_variants(project)
-        variants_types = project.get_import_variants_types()
+        variants_types = project.get_variant_loader_types()
         config = {
             "id": project.study_id,
             "has_denovo": "denovo" in variants_types,

--- a/dae/dae/inmemory_storage/tests/test_inmemory_import_storage.py
+++ b/dae/dae/inmemory_storage/tests/test_inmemory_import_storage.py
@@ -32,7 +32,7 @@ def test_simple_project_destination_study_dir(simple_project):
 
 
 def test_simple_project_get_loader_types(simple_project):
-    loader_types = simple_project.get_import_variants_types()
+    loader_types = simple_project.get_variant_loader_types()
     assert loader_types == {"denovo"}
 
 

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -60,7 +60,7 @@ class Schema2ImportStorage(ImportStorage):
     def _do_write_meta(cls, project):
         layout = schema2_project_dataset_layout(project)
         gpf_instance = project.get_gpf_instance()
-        loader_type = project.get_variant_loader_types()[0]
+        loader_type = next(iter(project.get_variant_loader_types()))
         ParquetWriter.write_meta(
             layout.study,
             project.get_variant_loader(

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -85,9 +85,12 @@ class Schema2ImportStorage(ImportStorage):
     @classmethod
     def _variant_partitions(cls, project):
         part_desc = cls._get_partition_description(project)
-        chromosome_lengths = dict(
-            project.get_gpf_instance().reference_genome.get_all_chrom_lengths()
-        )
+        chromosomes = project.get_variant_loader_chromosomes()
+        chromosome_lengths = dict(filter(
+            lambda cl: cl[0] in chromosomes,
+            project.get_gpf_instance()
+            .reference_genome
+            .get_all_chrom_lengths()))
         sum_parts, fam_parts = \
             part_desc.get_variant_partitions(chromosome_lengths)
         for part in sum_parts:

--- a/dae/dae/testing/acgt_import.py
+++ b/dae/dae/testing/acgt_import.py
@@ -11,6 +11,8 @@ def acgt_gpf(root_path, storage=None):
         {25 * "ACGT"}
         >chr2
         {25 * "ACGT"}
+        >chr3
+        {25 * "ACGT"}
         """
     )
 

--- a/dae/dae/testing/import_helpers.py
+++ b/dae/dae/testing/import_helpers.py
@@ -38,7 +38,7 @@ def update_study_config(
         outfile.write(builder.build_config())
 
 
-def setup_import_project(
+def setup_import_project_config(
     root_path: pathlib.Path, study: StudyInputLayout,
     gpf_instance,
     project_config_update: Optional[dict[str, Any]] = None,
@@ -90,12 +90,12 @@ def setup_import_project(
     return root_path / "import_project" / "import_config.yaml"
 
 
-def data_import(
+def setup_import_project(
         root_path: pathlib.Path, study: StudyInputLayout, gpf_instance,
         project_config_update: Optional[dict[str, Any]] = None,
         project_config_overwrite: Optional[dict[str, Any]] = None):
     """Set up an import project for a study and imports it."""
-    setup_import_project(
+    project_config = setup_import_project_config(
         root_path, study, gpf_instance,
         project_config_update=project_config_update,
         project_config_overwrite=project_config_overwrite)
@@ -103,7 +103,7 @@ def data_import(
     # pylint: disable=import-outside-toplevel
     from dae.import_tools.import_tools import ImportProject
     project = ImportProject.build_from_file(
-        root_path / "import_project" / "import_config.yaml",
+        project_config,
         gpf_instance=gpf_instance)
     return project
 
@@ -117,7 +117,7 @@ def vcf_import(
         project_config_overwrite: Optional[dict[str, Any]] = None):
     """Import a VCF study and return the import project."""
     study = StudyInputLayout(study_id, ped_path, vcf_paths, [], [], [])
-    project = data_import(
+    project = setup_import_project(
         root_path, study, gpf_instance,
         project_config_update=project_config_update,
         project_config_overwrite=project_config_overwrite)
@@ -155,7 +155,7 @@ def denovo_import(
         project_config_overwrite: Optional[dict[str, Any]] = None):
     """Import a de Novo study and return the import project."""
     study = StudyInputLayout(study_id, ped_path, [], denovo_paths, [], [])
-    project = data_import(
+    project = setup_import_project(
         root_path, study, gpf_instance,
         project_config_update=project_config_update,
         project_config_overwrite=project_config_overwrite)

--- a/dae/dae/testing/tests/test_setup_project_config.py
+++ b/dae/dae/testing/tests/test_setup_project_config.py
@@ -3,7 +3,8 @@ import yaml
 
 import pytest
 
-from dae.testing.import_helpers import StudyInputLayout, setup_import_project
+from dae.testing.import_helpers import StudyInputLayout, \
+    setup_import_project_config
 from dae.testing import acgt_gpf
 
 
@@ -25,7 +26,7 @@ def test_setup_import_project(
     study = StudyInputLayout(
         "test_id", root_path / "fam.ped", [root_path / "in.vcf"], [], [], [])
 
-    pathname = setup_import_project(
+    pathname = setup_import_project_config(
         root_path, study, gpf_instance, config_update)
 
     project_config = yaml.safe_load(pathname.read_text())

--- a/dae/dae/tools/tests/test_dae2parquet.py
+++ b/dae/dae/tools/tests/test_dae2parquet.py
@@ -27,7 +27,6 @@ def test_dae2parquet_transmitted(
     assert os.path.exists(temp_filename)
 
     files_glob = os.path.join(temp_filename, "*variants*.parquet")
-    # import pdb; pdb.set_trace()
 
     parquet_files = glob.glob(files_glob)
     assert len(parquet_files) == 1

--- a/dae/tests/integration/study_query_variants/test_partitions.py
+++ b/dae/tests/integration/study_query_variants/test_partitions.py
@@ -62,7 +62,7 @@ def imported_study(tmp_path_factory, genotype_storage):
         ##fileformat=VCFv4.2
         ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
         ##contig=<ID=foo>
-        #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT m1  d1  p1  s1  m2   d2 p2 
+        #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT m1  d1  p1  s1  m2   d2 p2
         foo    7   .  A   C   .    .      .    GT     0/1 0/0 0/1 0/0 0/0 0/0 0/0  # freq 1/8 = 12.5%, splice-site, g1
         foo    10  .  C   G   .    .      .    GT     0/0 0/1 0/1 0/0 0/0 0/0 0/0  # freq 1/8 = 12.5%, intron, g1
         bar    11  .  C   G   .    .      .    GT     1/0 0/0 0/0 0/1 1/1 1/1 1/1  # freq 5/8 = 62.5%, missense, g2
@@ -197,7 +197,6 @@ def test_query_pedigree_fields(imported_study):
 
 def test_af_parent_count(imported_study):
     for v in imported_study.query_variants():
-        # import pdb; pdb.set_trace()
         assert v.get_attribute("af_parents_called_count") == [4]
 
 

--- a/gcp_genotype_storage/gcp_genotype_storage/gcp_import_storage.py
+++ b/gcp_genotype_storage/gcp_genotype_storage/gcp_import_storage.py
@@ -31,7 +31,7 @@ class GcpImportStorage(Schema2ImportStorage):
         # pylint: disable=protected-access
         study_tables = genotype_storage._study_tables({"id": project.study_id})
 
-        variants_types = project.get_import_variants_types()
+        variants_types = project.get_variant_loader_types()
         study_config = {
             "id": project.study_id,
             "conf_dir": ".",


### PR DESCRIPTION
## Aim

- Fix the `ImportTools.get_variant_loader_types` method to properly return variant types.
- Remove `ImportTools.get_input_variant_types` and migrate the code to use `ImportTools.get_variant_loader_types`.
- Implement `ImportTools.get_variant_loader_chromosomes` to return the list of actual input contigs.
- Reduce the bucket merge tasks to the actual contigs available in the import project input.
