### PR TITLE
Query runners exception propagation

### DIFF
--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -27,7 +27,7 @@ dae_named_cluster:
         scheduler_options:
           dashboard_address: :8898
         cores: 1
-        memory: 1GB
+        memory: 2GB
         log_directory: ./.sge_worker_logs
         job_extra_directives:
         - "-V"
@@ -38,8 +38,8 @@ dae_named_cluster:
         scheduler_options:
           dashboard_address: :8898
         cores: 1
-        memory: 2GB
-        walltime: "72:00:00"
+        memory: 4GB
+        walltime: "96:00:00"
         log_directory: ./.sge_worker_logs
         job_extra_directives:
         - "-V"
@@ -52,8 +52,8 @@ dae_named_cluster:
         scheduler_options:
           dashboard_address: :8898
         cores: 1
-        memory: 10GB
-        walltime: "72:00:00"
+        memory: 8GB
+        walltime: "96:00:00"
         log_directory: ./.sge_worker_logs
         job_extra_directives:
         - "-V"
@@ -70,6 +70,7 @@ dae_named_cluster:
       type: slurm
       number_of_threads: 10
       params:
+        walltime: "48:00:00"
         cores: 1
         memory: 1GB
         log_directory: ./slurm_worker_logs

--- a/dae/dae/impala_storage/helpers/hdfs_helpers.py
+++ b/dae/dae/impala_storage/helpers/hdfs_helpers.py
@@ -55,7 +55,7 @@ class HdfsHelpers:
         self.hdfs.mkdir(path)
 
     def makedirs(self, path):
-        """Make all dire alone the path."""
+        """Make all directories along the path."""
         if path[0] == os.sep:
             paths = path[1:].split(os.sep)
             paths[0] = "/" + paths[0]
@@ -86,10 +86,10 @@ class HdfsHelpers:
     def rename(self, path, new_path):
         self.hdfs.rename(path, new_path)
 
-    def put(self, local_filename, hdfs_filename):
+    def put(self, local_filename, hdfs_filename, recursive=False):
         assert os.path.exists(local_filename), local_filename
 
-        self.hdfs.upload(local_filename, hdfs_filename)
+        self.hdfs.put(local_filename, hdfs_filename, recursive=recursive)
 
     def put_in_directory(self, local_file, hdfs_dirname):
         basename = os.path.basename(local_file)

--- a/dae/dae/impala_storage/helpers/impala_query_runner.py
+++ b/dae/dae/impala_storage/helpers/impala_query_runner.py
@@ -91,9 +91,10 @@ class ImpalaQueryRunner(QueryRunner):
                             break
 
                 except Exception as ex:  # pylint: disable=broad-except
-                    logger.debug(
+                    logger.error(
                         "exception in runner (%s) run: %s",
                         self.study_id, type(ex), exc_info=True)
+                    self._put_value_in_result_queue(ex)
                 finally:
                     logger.debug(
                         "runner (%s) closing connection", self.study_id)

--- a/dae/dae/impala_storage/helpers/impala_query_runner.py
+++ b/dae/dae/impala_storage/helpers/impala_query_runner.py
@@ -1,5 +1,4 @@
 import time
-import queue
 import logging
 from contextlib import closing
 from dae.query_variants.query_runners import QueryRunner
@@ -100,34 +99,6 @@ class ImpalaQueryRunner(QueryRunner):
                         "runner (%s) closing connection", self.study_id)
 
         self._finalize(started)
-
-    def _put_value_in_result_queue(self, val):
-        assert self._result_queue is not None
-
-        no_interest = 0
-        while True:
-            try:
-                self._result_queue.put(val, timeout=0.1)
-                break
-            except queue.Full:
-                logger.debug(
-                    "runner (%s) nobody interested",
-                    self.study_id)
-
-                if self.closed():
-                    break
-                no_interest += 1
-                if no_interest % 1_000 == 0:
-                    logger.warning(
-                        "runner (%s) nobody interested %s",
-                        self.study_id, no_interest)
-                if no_interest > 5_000:
-                    logger.warning(
-                        "runner (%s) nobody interested %s"
-                        "closing...",
-                        self.study_id, no_interest)
-                    self.close()
-                    break
 
     def _wait_cursor_executing(self, cursor):
         while True:

--- a/dae/dae/impala_storage/helpers/tests/test_impala_query_runner.py
+++ b/dae/dae/impala_storage/helpers/tests/test_impala_query_runner.py
@@ -112,7 +112,10 @@ def test_impala_runner_result_experimental_2(impala_helpers):
 
     assert runner.started()
 
-    result.close()
+    with pytest.raises(
+            IOError,
+            match="AnalysisException: Could not resolve table reference:"):
+        result.close()
     time.sleep(0.1)
 
 

--- a/dae/dae/impala_storage/schema1/impala_variants.py
+++ b/dae/dae/impala_storage/schema1/impala_variants.py
@@ -1,13 +1,10 @@
 import logging
-import queue
-import time
 
 from contextlib import closing
 from typing import Dict, Any, Tuple, Set
 
 import pyarrow as pa  # type: ignore
 from impala.util import as_pandas  # type: ignore
-from sqlalchemy.exc import TimeoutError as SqlTimeoutError
 
 from dae.person_sets import PersonSetCollection
 
@@ -20,157 +17,16 @@ from dae.parquet.schema1.serializers import AlleleParquetSerializer
 
 from dae.variants.attributes import Role, Status, Sex
 
-from dae.query_variants.query_runners import QueryResult, QueryRunner
+from dae.query_variants.query_runners import QueryResult
 from dae.query_variants.sql.schema1.schema1_query_director import \
     ImpalaQueryDirector
 from dae.query_variants.sql.schema1.family_variants_query_builder import \
     FamilyVariantsQueryBuilder
 from dae.query_variants.sql.schema1.summary_variants_query_builder import \
     SummaryVariantsQueryBuilder
-
+from dae.impala_storage.helpers.impala_query_runner import ImpalaQueryRunner
 
 logger = logging.getLogger(__name__)
-
-
-class ImpalaQueryRunner(QueryRunner):
-    """Run a query in a separate thread."""
-
-    def __init__(self, connection_pool, query, deserializer=None):
-        super().__init__(deserializer=deserializer)
-
-        self.connection_pool = connection_pool
-        self.query = query
-
-    def connect(self):
-        """Connect to the connection pool and return the connection."""
-        started = time.time()
-        while True:
-            try:
-                connection = self.connection_pool.connect()
-                return connection
-            except SqlTimeoutError:
-                elapsed = time.time() - started
-                logger.debug(
-                    "runner (%s) timeout in connect; elapsed %0.2fsec",
-                    self.study_id, elapsed)
-                if self.closed():
-                    logger.info(
-                        "runner (%s) closed before connection established "
-                        "after %0.2fsec",
-                        self.study_id, elapsed)
-                    return None
-
-    def run(self):
-        started = time.time()
-        if self.closed():
-            logger.info(
-                "impala runner (%s) closed before executing...",
-                self.study_id)
-            return
-
-        logger.debug(
-            "impala runner (%s) started; "
-            "connectio pool: %s",
-            self.study_id, self.connection_pool.status())
-
-        connection = self.connect()
-
-        if connection is None:
-            self._finalize(started)
-            return
-
-        with closing(connection) as connection:
-            elapsed = time.time() - started
-            logger.debug(
-                "runner (%s) waited %0.2fsec for connection",
-                self.study_id, elapsed)
-            with connection.cursor() as cursor:
-                try:
-                    if self.closed():
-                        logger.info(
-                            "runner (%s) closed before execution "
-                            "after %0.2fsec",
-                            self.study_id, elapsed)
-                        self._finalize(started)
-                        return
-
-                    cursor.execute_async(self.query)
-                    self._wait_cursor_executing(cursor)
-
-                    while not self.closed():
-                        row = cursor.fetchone()
-                        if row is None:
-                            break
-                        val = self.deserializer(row)
-
-                        if val is None:
-                            continue
-
-                        self._put_value_in_result_queue(val)
-
-                        if self.closed():
-                            logger.debug(
-                                "query runner (%s) closed while iterating",
-                                self.study_id)
-                            break
-
-                except Exception as ex:  # pylint: disable=broad-except
-                    logger.debug(
-                        "exception in runner (%s) run: %s",
-                        self.study_id, type(ex), exc_info=True)
-                finally:
-                    logger.debug(
-                        "runner (%s) closing connection", self.study_id)
-
-        self._finalize(started)
-
-    def _put_value_in_result_queue(self, val):
-        assert self._result_queue is not None
-        no_interest = 0
-        while True:
-            try:
-                self._result_queue.put(val, timeout=0.1)
-                break
-            except queue.Full:
-                logger.debug(
-                    "runner (%s) nobody interested",
-                    self.study_id)
-
-                if self.closed():
-                    break
-                no_interest += 1
-                if no_interest % 1_000 == 0:
-                    logger.warning(
-                        "runner (%s) nobody interested %s",
-                        self.study_id, no_interest)
-                if no_interest > 5_000:
-                    logger.warning(
-                        "runner (%s) nobody interested %s"
-                        "closing...",
-                        self.study_id, no_interest)
-                    self.close()
-                    break
-
-    def _wait_cursor_executing(self, cursor):
-        while True:
-            if self.closed():
-                logger.debug(
-                    "query runner (%s) closed while executing",
-                    self.study_id)
-                break
-            if not cursor.is_executing():
-                logger.debug(
-                    "query runner (%s) execution finished",
-                    self.study_id)
-                break
-            time.sleep(0.1)
-
-    def _finalize(self, started):
-        with self._status_lock:
-            self._done = True
-        elapsed = time.time() - started
-        logger.debug("runner (%s) done in %0.3f sec", self.study_id, elapsed)
-        logger.debug("connection pool: %s", self.connection_pool.status())
 
 
 class ImpalaVariants:

--- a/dae/dae/impala_storage/schema1/impala_variants.py
+++ b/dae/dae/impala_storage/schema1/impala_variants.py
@@ -158,7 +158,7 @@ class ImpalaVariants:
         )
 
         query = query_builder.product
-        logger.debug("SUMMARY VARIANTS QUERY: %s", query)
+        logger.info("SUMMARY VARIANTS QUERY: %s", query)
 
         runner = ImpalaQueryRunner(
             self.connection_pool, query, deserializer=deserialize_row)
@@ -287,7 +287,7 @@ class ImpalaVariants:
 
         query = query_builder.product
 
-        logger.debug("FAMILY VARIANTS QUERY: %s", query)
+        logger.info("FAMILY VARIANTS QUERY: %s", query)
         deserialize_row = query_builder.create_row_deserializer(
             self.serializer)
         assert deserialize_row is not None

--- a/dae/dae/impala_storage/schema1/tests/test_impala_query_runner.py
+++ b/dae/dae/impala_storage/schema1/tests/test_impala_query_runner.py
@@ -5,9 +5,10 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 
 import pytest
+
 from dae.query_variants.query_runners import QueryResult
 
-from dae.impala_storage.schema1.impala_variants import ImpalaQueryRunner
+from dae.impala_storage.helpers.impala_query_runner import ImpalaQueryRunner
 
 
 @pytest.fixture(scope="session")
@@ -26,7 +27,7 @@ def test_impala_runner_simple(impala_helpers):
     assert impala_helpers is not None
 
     query = "SELECT * FROM gpf_variant_db.test_study_impala_01_variants"
-    result_queue = Queue(maxsize=3)
+    result_queue: Queue = Queue(maxsize=3)
 
     runner = create_runner(impala_helpers, query)
     runner._set_result_queue(result_queue)
@@ -47,7 +48,7 @@ def test_impala_runner_simple(impala_helpers):
     executor.shutdown(wait=True)
 
 
-def test_impala_runner_result_simple(impala_helpers):
+def test_impala_runner_result_with_exception(impala_helpers):
     query = "SELECT * FROM gpf_variant_db.test_study_impala_01_variants"
 
     runner = create_runner(impala_helpers, query)
@@ -63,7 +64,10 @@ def test_impala_runner_result_simple(impala_helpers):
         print(row)
         break
 
-    result.close()
+    with pytest.raises(
+            IOError,
+            match="AnalysisException: Could not resolve table reference:"):
+        result.close()
     time.sleep(0.5)
 
     assert runner.closed()
@@ -86,7 +90,10 @@ def test_impala_runner_result_experimental_1(impala_helpers):
         print(row)
         time.sleep(0.5)
 
-    result.close()
+    with pytest.raises(
+            IOError,
+            match="AnalysisException: Could not resolve table reference:"):
+        result.close()
 
 
 def test_impala_runner_result_experimental_2(impala_helpers):
@@ -130,7 +137,10 @@ def test_impala_runner_result_experimental(impala_helpers):
         print(row)
         break
 
-    result.close()
+    with pytest.raises(
+            IOError,
+            match="AnalysisException: Could not resolve table reference:"):
+        result.close()
     time.sleep(0.5)
 
     assert runner.closed()

--- a/dae/dae/impala_storage/schema2/impala_variants.py
+++ b/dae/dae/impala_storage/schema2/impala_variants.py
@@ -6,7 +6,7 @@ import numpy as np
 from impala.util import as_pandas
 from dae.query_variants.query_runners import QueryRunner
 from dae.variants.attributes import Role, Status, Sex
-from dae.impala_storage.schema2.impala_query_runner import ImpalaQueryRunner
+from dae.impala_storage.helpers.impala_query_runner import ImpalaQueryRunner
 from dae.query_variants.sql.schema2.base_variants import SqlSchema2Variants
 from dae.query_variants.sql.schema2.base_query_builder import Dialect
 from dae.variants.variant import SummaryVariantFactory

--- a/dae/dae/inmemory_storage/raw_variants.py
+++ b/dae/dae/inmemory_storage/raw_variants.py
@@ -48,7 +48,7 @@ class RawVariantsQueryRunner(QueryRunner):
 
                 while True:
                     try:
-                        self._result_queue.put(val, timeout=0.1)
+                        self._put_value_in_result_queue(val)
                         break
                     except queue.Full:
                         if self.closed():
@@ -61,8 +61,10 @@ class RawVariantsQueryRunner(QueryRunner):
             logger.debug("variants iterator done")
 
         except BaseException as ex:  # pylint: disable=broad-except
-            logger.warning(
+            logger.error(
                 "exception in runner run: %s", type(ex), exc_info=True)
+            self._put_value_in_result_queue(ex)
+
         finally:
             self.close()
 

--- a/dae/dae/query_variants/query_runners.py
+++ b/dae/dae/query_variants/query_runners.py
@@ -157,7 +157,9 @@ class QueryResult:
                 logger.info(
                     "exception in result close: %s", type(ex), exc_info=True)
         while not self.result_queue.empty():
-            self.result_queue.get()
+            item = self.result_queue.get()
+            if isinstance(item, Exception):
+                self._exceptions.append(item)
 
         logger.debug("closing thread pool executor")
         self.executor.shutdown(wait=True)

--- a/dae/dae/query_variants/sql/schema2/base_variants.py
+++ b/dae/dae/query_variants/sql/schema2/base_variants.py
@@ -139,7 +139,7 @@ class SqlSchema2Variants(abc.ABC):
             return_unknown=return_unknown,
             limit=limit,
         )
-        logger.debug("SUMMARY VARIANTS QUERY:\n%s", query)
+        logger.info("SUMMARY VARIANTS QUERY:\n%s", query)
 
         # pylint: disable=protected-access
         runner = self.RUNNER_CLASS(
@@ -226,7 +226,7 @@ class SqlSchema2Variants(abc.ABC):
             pedigree_fields=pedigree_fields
         )
 
-        logger.debug("FAMILY VARIANTS QUERY:\n%s", query)
+        logger.info("FAMILY VARIANTS QUERY:\n%s", query)
         deserialize_row = self._deserialize_family_variant
 
         # pylint: disable=protected-access

--- a/dae/dae/tools/impala_tables_summary_variants.py
+++ b/dae/dae/tools/impala_tables_summary_variants.py
@@ -139,20 +139,20 @@ def create_summary_table(study_id, impala_variants):
     schema = collect_summary_schema(impala_variants)
     partition_bins = []
 
-    schema_statement = []
-    partition_statement = []
+    schema_parts = []
+    partition_parts = []
     for field_name, field_type in schema.items():
         if field_name in PARTITIONS:
-            partition_statement.append(f"`{field_name}` {field_type}")
+            partition_parts.append(f"`{field_name}` {field_type}")
             partition_bins.append(field_name)
         else:
-            schema_statement.append(f"`{field_name}` {field_type}")
+            schema_parts.append(f"`{field_name}` {field_type}")
 
-    schema_statement = ", ".join(schema_statement)
-    if not partition_statement:
+    schema_statement = ", ".join(schema_parts)
+    if not partition_parts:
         partition_statement = ""
     else:
-        partition_statement = ", ".join(partition_statement)
+        partition_statement = ", ".join(partition_parts)
         partition_statement = f"PARTITIONED BY ({partition_statement}) "
 
     # pylint: disable=protected-access
@@ -267,24 +267,24 @@ def insert_into_summary_table(
         f"`{field}`" for field in family_summary_fields
     ])
 
-    insert_partition_statement = []
-    select_partition_statement = []
+    insert_partition_parts = []
+    select_partition_parts = []
     for bin_name, bin_value in parition.items():
         if bin_name == "region_bin":
-            insert_partition_statement.append(
+            insert_partition_parts.append(
                 f"`{bin_name}` = '{bin_value}'")
-            select_partition_statement.append(
+            select_partition_parts.append(
                 f"variants.`{bin_name}` = '{bin_value}'")
         else:
-            insert_partition_statement.append(
+            insert_partition_parts.append(
                 f"`{bin_name}` = {bin_value}")
-            select_partition_statement.append(
+            select_partition_parts.append(
                 f"variants.`{bin_name}` = {bin_value}")
-    insert_partition_statement = ", ".join(insert_partition_statement)
+    insert_partition_statement = ", ".join(insert_partition_parts)
 
     region_bin = parition["region_bin"]
     region = region_bins[region_bin]
-    select_partition_statement = " AND ".join(select_partition_statement)
+    select_partition_statement = " AND ".join(select_partition_parts)
 
     region_statements = []
     if region_split == 0:

--- a/gcp_genotype_storage/gcp_genotype_storage/bigquery_query_runner.py
+++ b/gcp_genotype_storage/gcp_genotype_storage/bigquery_query_runner.py
@@ -41,9 +41,10 @@ class BigQueryQueryRunner(QueryRunner):
                     break
 
         except Exception as ex:  # pylint: disable=broad-except
-            logger.debug(
+            logger.error(
                 "exception in runner (%s) run: %s",
                 self.study_id, type(ex), exc_info=True)
+            self._put_value_in_result_queue(ex)
         finally:
             logger.debug(
                 "runner (%s) closing connection", self.study_id)

--- a/wdae/wdae/wdae/gpfjs_settings.py
+++ b/wdae/wdae/wdae/gpfjs_settings.py
@@ -16,6 +16,15 @@ ALLOWED_HOSTS += ["localhost"]
 
 CORS_ORIGIN_WHITELIST = [
     "http://0.0.0.0:8000",
+    # For docker-compose
+    "http://localhost:9000",
+    "http://127.0.0.1:9000",
+    # For local development with `ng serve`
+    "http://localhost:4200",
+    "http://127.0.0.1:4200",
+    # For local development
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
 ]
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
## Aim

For running queries on different genotype storage backends, we use `QueryRunner` classes, specialized for each of the backends.

Exceptions raised inside these runners were not propagated to the classes that use instances of `QueryRunner`.

The main aim of this PR is to propagate exceptions thrown from inside `QueryRunner` to the calling class.

Additionally, some improvements in Impala2 genotype storage are implemented. Now when importing an Impala2 study into the storage, the Impala tables stats are computed by default. We use incremental stats computation when the study has region partitioning to avoid memory problems on small nodes like the production nodes.
