### PR TITLE
Updates to `grr_browse` tool

### DIFF
--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -5,6 +5,7 @@ import logging
 import argparse
 import pathlib
 import copy
+import pprint
 
 from typing import Dict, Union
 from urllib.parse import urlparse
@@ -39,7 +40,7 @@ from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.genomic_resources.fsspec_protocol import build_fsspec_protocol
 from dae.genomic_resources.repository_factory import \
     build_genomic_resource_repository, get_default_grr_definition, \
-    load_definition_file
+    load_definition_file, get_default_grr_definition_path, DEFAULT_DEFINITION
 
 from dae.genomic_resources import get_resource_implementation_builder
 from dae.genomic_resources.resource_implementation import ResourceStatistics
@@ -133,7 +134,10 @@ def _run_list_command(
         if isinstance(proto, GenomicResourceCachedRepo):
             files_msg = f"{len(proto.get_resource_cached_files(res.get_id())):2d}/{files_msg}"
 
-        res_size_msg = convert_size(res_size) if hasattr(args, 'hr') and args.hr is True else res_size
+        res_size_msg = res_size \
+            if hasattr(args, 'bytes') and args.bytes is True \
+            else convert_size(res_size)
+
         print(
             f"{res.get_type():20} {res.get_version_str():7s} "
             f"{files_msg} {res_size_msg:12} "
@@ -753,7 +757,19 @@ def cli_browse(cli_args=None):
         default=None,
         help="path to GRR definition file.")
 
-    parser.add_argument("--hr", default=False, action="store_true", help="Projects the size in human-readable format.")
+    parser.add_argument(
+        "--bytes",
+        default=False,
+        action="store_true",
+        help="Print the resource size in bytes"
+    )
+
+    parser.add_argument(
+        "--print-grr",
+        default=False,
+        action="store_true",
+        help="Print the path and content of the GRR definition to be used"
+    )
 
     if cli_args is None:
         cli_args = sys.argv[1:]
@@ -763,7 +779,21 @@ def cli_browse(cli_args=None):
     if args.version:
         print(f"GPF version: {VERSION} ({RELEASE})")
         sys.exit(0)
-    repo = build_genomic_resource_repository(file_name=args.grr)
+
+    definition_path = args.grr if args.grr is not None \
+                      else get_default_grr_definition_path()
+    definition = load_definition_file(definition_path) \
+            if definition_path is not None \
+            else DEFAULT_DEFINITION
+
+    if args.print_grr:
+        if definition_path is not None:
+            print("Working with GRR definition:", definition_path)
+        else:
+            print("No GRR definition found, using the DEFAULT_DEFINITION")
+        pprint.pprint(definition)
+
+    repo = build_genomic_resource_repository(definition=definition)
     _run_list_command(repo, args)
 
 

--- a/dae/dae/genomic_resources/repository_factory.py
+++ b/dae/dae/genomic_resources/repository_factory.py
@@ -56,25 +56,31 @@ def load_definition_file(filename):
 GRR_DEFINITION_FILE_ENV = "GRR_DEFINITION_FILE"
 
 
-def get_default_grr_definition():
-    """Return default genomic resources repository definition."""
-    logger.info("using default GRR definitions")
+def get_default_grr_definition_path() -> Optional[str]:
+    """Return a path to default genomic resources repository definition."""
     env_repo_definition_path = os.environ.get(GRR_DEFINITION_FILE_ENV)
     if env_repo_definition_path is not None:
         logger.debug(
-            "loading GRR definition from environment variable %s=%s",
+            "found GRR definition from environment variable %s=%s",
             GRR_DEFINITION_FILE_ENV, env_repo_definition_path)
-        return load_definition_file(env_repo_definition_path)
-
+        return env_repo_definition_path
     default_repo_definition_path = f"{os.environ['HOME']}/.grr_definition.yaml"
     logger.debug(
-        "checking default repo definition at %s",
+        "checking default GRR definition at %s",
         default_repo_definition_path)
     if pathlib.Path(default_repo_definition_path).exists():
         logger.debug(
-            "using repo definition at %s", default_repo_definition_path)
-        return load_definition_file(default_repo_definition_path)
+            "found GRR definition at %s", default_repo_definition_path)
+        return default_repo_definition_path
+    return None
 
+
+def get_default_grr_definition():
+    """Return default genomic resources repository definition."""
+    logger.info("using default GRR definitions")
+    definition_path = get_default_grr_definition_path()
+    if definition_path:
+        return load_definition_file(definition_path)
     return copy.deepcopy(DEFAULT_DEFINITION)
 
 
@@ -209,7 +215,6 @@ def build_genomic_resource_repository(
             raise ValueError(
                 "The children attribute in the definition of a group "
                 "repository must be a list")
-        # repo_id = definition.get("id")
 
         children = cast(List[dict], definition.pop("children"))
         repo: GenomicResourceRepo = \

--- a/dae/dae/genomic_resources/tests/test_cached_repo.py
+++ b/dae/dae/genomic_resources/tests/test_cached_repo.py
@@ -427,7 +427,7 @@ def test_cached_repo_list_cli(cache_repository, capsys):
         print(out)
         assert err == ""
         assert out == \
-            "Basic                0        1/ 3           14 test_grr one\n"
+            "Basic                0        1/ 3 14.0 B       test_grr one\n"
 
 
 def test_cached_repo_nested_list_cli(cache_repository, capsys):
@@ -465,6 +465,6 @@ def test_cached_repo_nested_list_cli(cache_repository, capsys):
         print(out)
         assert err == ""
         assert out == \
-            "Basic                0        1/ 2            7 test_grr one\n" \
-            "gene_models          0        1/ 2           41 test_grr " \
+            "Basic                0        1/ 2 7.0 B        test_grr one\n" \
+            "gene_models          0        1/ 2 41.0 B       test_grr " \
             "sub/two\n"

--- a/dae/dae/genomic_resources/tests/test_cli.py
+++ b/dae/dae/genomic_resources/tests/test_cli.py
@@ -77,8 +77,8 @@ def test_cli_list(repo_fixture, capsys):
 
     assert err == ""
     assert out == \
-        "Basic                0        2            7 manage one\n" \
-        "gene_models          1.0      2           50 manage sub/two\n"
+        "Basic                0        2 7.0 B        manage one\n" \
+        "gene_models          1.0      2 50.0 B       manage sub/two\n"
 
 
 def test_cli_list_without_repo_argument(repo_fixture, capsys, mocker):
@@ -96,8 +96,8 @@ def test_cli_list_without_repo_argument(repo_fixture, capsys, mocker):
     assert err == ""
     assert out == \
         f"working with repository: {str(path)}\n" \
-        "Basic                0        2            7 manage one\n" \
-        "gene_models          1.0      2           50 manage sub/two\n"
+        "Basic                0        2 7.0 B        manage one\n" \
+        "gene_models          1.0      2 50.0 B       manage sub/two\n"
 
 
 def test_find_repo_dir_simple(repo_fixture):

--- a/dae/dae/genomic_resources/tests/test_cli_browse.py
+++ b/dae/dae/genomic_resources/tests/test_cli_browse.py
@@ -55,8 +55,8 @@ def test_cli_browse_with_grr_argument(repo_fixture, repo_def, capsys):
 
     assert err == ""
     assert out == \
-        "Basic                0        2            7 test_grr one\n" \
-        "gene_models          1.0      2           50 test_grr sub/two\n"
+        "Basic                0        2 7.0 B        test_grr one\n" \
+        "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
 
 def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
@@ -69,8 +69,8 @@ def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Basic                0        2            7 test_grr one\n" \
-        "gene_models          1.0      2           50 test_grr sub/two\n"
+        "Basic                0        2 7.0 B        test_grr one\n" \
+        "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
 
 def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
@@ -83,5 +83,5 @@ def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Basic                0        2            7 test_grr one\n" \
-        "gene_models          1.0      2           50 test_grr sub/two\n"
+        "Basic                0        2 7.0 B        test_grr one\n" \
+        "gene_models          1.0      2 50.0 B       test_grr sub/two\n"


### PR DESCRIPTION
Some updates to `grr_browse` tool:
- Print in human-readable by default
- Added flag to print in bytes (old behaviour)
- Added flag to print GRR definition path and content
- Properly print child repos for group repos (caching status, all resources even if duplicated, etc.)