### PR TITLE
Temporary restore of the original reference genome `get_sequence` method.

### DIFF
--- a/dae/dae/dask/named_cluster.yaml
+++ b/dae/dae/dask/named_cluster.yaml
@@ -1,7 +1,7 @@
 dae_named_cluster:
   default: local
   clusters:
-    - name: local
+    - name: local_small
       type: local
       params:
         memory_limit: 2GB
@@ -19,6 +19,11 @@ dae_named_cluster:
       # params:
       #  threads_per_worker: 1
       #   dashboard_address: :8898
+    - name: local
+      type: local
+      params:
+        memory_limit: 4GB
+        threads_per_worker: 1
     - name: sge_small
       type: sge
       number_of_threads: 10

--- a/pylintrc
+++ b/pylintrc
@@ -485,7 +485,7 @@ max-locals=20
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=25
 
 # Maximum number of return / yield for function / method body.
 max-returns=6


### PR DESCRIPTION
## Background

While working on reference genome statistics, we added a `fetch` method to the reference genome and created a new implementation of `get_sequence` method based on `fetch`.

This new implementation is kind of buggy (see #439)

## Aim

Temporarily restore the original implementation of `get_sequence` method while investigating the #439 

