### PR TITLE
Management and users fixes

### DIFF
--- a/wdae/wdae/groups_api/serializers.py
+++ b/wdae/wdae/groups_api/serializers.py
@@ -39,7 +39,7 @@ class GroupRetrieveSerializer(GroupSerializer):
         model = Group
         fields = ("id", "name", "users", "datasets")
 
-    def get_datasets(self, group):  # pylint: disable=no-self-use
-        return [
+    def get_datasets(self, group):
+        return sorted([
             get_dataset_info(d.dataset_id) for d in group.dataset_set.all()
-        ]
+        ], key=lambda d: d["datasetName"].lower())

--- a/wdae/wdae/groups_api/tests/test_groups_rest.py
+++ b/wdae/wdae/groups_api/tests/test_groups_rest.py
@@ -428,6 +428,25 @@ def test_group_retrieve(admin_client, hundred_groups):
     }]
 
 
+def test_group_retrieve_alphabetical_order(admin_client, hundred_groups):
+    url = "/api/v3/groups/any_dataset"
+    response = admin_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.data
+
+    assert data["name"] == "any_dataset"
+    assert data["users"] == []
+    assert data["datasets"][0]["datasetName"] == "(TEST_REMOTE) iossifov_2014"
+    assert data["datasets"][1]["datasetName"] == "comp"
+    assert data["datasets"][3]["datasetName"] == "Dataset1"
+    assert data["datasets"][3]["datasetName"] == "Dataset1"
+    assert data["datasets"][7]["datasetName"] == "f1_group"
+    assert data["datasets"][8]["datasetName"] == "f1_study"
+    assert data["datasets"][9]["datasetName"] == "f1_trio"
+    assert data["datasets"][14]["datasetName"] == "FAKE_STUDY"
+    assert data["datasets"][-1]["datasetName"] == "TRIO"
+
+
 def test_group_retrieve_missing(admin_client):
     url = "/api/v3/groups/somegroupthatdoesnotexist"
     response = admin_client.get(url)

--- a/wdae/wdae/wdae_create_dev_users.sh
+++ b/wdae/wdae/wdae_create_dev_users.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-wdaemanage.py user_create admin@iossifovlab.com -p secret -g any_dataset:admin || true
-wdaemanage.py user_create research@iossifovlab.com -p secret || true
+wdaemanage.py user_create admin@iossifovlab.com -p secret -g any_dataset:any_user:admin || true
+wdaemanage.py user_create research@iossifovlab.com -p secret -g any_user || true


### PR DESCRIPTION
## Background
There were the following problems in the management tab:
- Users/groups/dataset lists were often sorted by database ID and not names, resulting in confusing orders.
- On the datasets view, when a dataset has n groups that share the same user, that user will be duplicated n times in the resulting user list.
- Default users which were created with a script were missing the default basic groups

## Aim

Fix the issues.

## Related issues

Closes #428.
Closes #429.
