### PR TITLE
Grr browse improvements

### DIFF
--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -1,4 +1,5 @@
 """Provides CLI for management of genomic resources repositories."""
+import json
 import os
 import sys
 import logging
@@ -794,7 +795,7 @@ def cli_browse(cli_args=None):
             print("Working with GRR definition:", definition_path)
         else:
             print("No GRR definition found, using the DEFAULT_DEFINITION")
-        pprint.pprint(definition)
+        print(yaml.dump(definition))
 
     repo = build_genomic_resource_repository(definition=definition)
     _run_list_command(repo, args)

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -1,12 +1,10 @@
 """Provides CLI for management of genomic resources repositories."""
-import json
 import os
 import sys
 import logging
 import argparse
 import pathlib
 import copy
-import pprint
 
 from typing import Dict, Union
 from urllib.parse import urlparse
@@ -768,12 +766,6 @@ def cli_browse(cli_args=None):
         help="Print the resource size in bytes"
     )
 
-    parser.add_argument(
-        "--print-grr",
-        default=True,
-        action="store_true",
-        help="Print the path and content of the GRR definition to be used"
-    )
 
     if cli_args is None:
         cli_args = sys.argv[1:]
@@ -790,12 +782,12 @@ def cli_browse(cli_args=None):
             if definition_path is not None \
             else DEFAULT_DEFINITION
 
-    if args.print_grr:
-        if definition_path is not None:
-            print("Working with GRR definition:", definition_path)
-        else:
-            print("No GRR definition found, using the DEFAULT_DEFINITION")
-        print(yaml.dump(definition))
+
+    if definition_path is not None:
+        print("Working with GRR definition:", definition_path)
+    else:
+        print("No GRR definition found, using the DEFAULT_DEFINITION")
+    print(yaml.dump(definition))
 
     repo = build_genomic_resource_repository(definition=definition)
     _run_list_command(repo, args)

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -787,7 +787,7 @@ def cli_browse(cli_args=None):
         print("Working with GRR definition:", definition_path)
     else:
         print("No GRR definition found, using the DEFAULT_DEFINITION")
-    print(yaml.dump(definition))
+    print(yaml.safe_dump(definition, sort_keys=False))
 
     repo = build_genomic_resource_repository(definition=definition)
     _run_list_command(repo, args)

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -769,7 +769,7 @@ def cli_browse(cli_args=None):
 
     parser.add_argument(
         "--print-grr",
-        default=False,
+        default=True,
         action="store_true",
         help="Print the path and content of the GRR definition to be used"
     )

--- a/dae/dae/genomic_resources/tests/test_cli_browse.py
+++ b/dae/dae/genomic_resources/tests/test_cli_browse.py
@@ -55,10 +55,10 @@ def test_cli_browse_with_grr_argument(repo_fixture, repo_def, capsys):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" \
-        "directory: " + str(repo_fixture[0]) + "\n" \
+        f"Working with GRR definition: {str(repo_def)}\n" \
         "id: test_grr\n" \
-        "type: directory\n\n" \
+        "type: directory\n" \
+        f"directory: {str(repo_fixture[0])}\n\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -73,10 +73,10 @@ def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" \
-        "directory: " + str(repo_fixture[0]) + "\n" \
+        f"Working with GRR definition: {str(repo_def)}\n" \
         "id: test_grr\n" \
-        "type: directory\n\n" \
+        "type: directory\n" \
+        f"directory: {str(repo_fixture[0])}\n\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -93,9 +93,9 @@ def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" \
-        "directory: " + str(repo_fixture[0]) + "\n" \
+        f"Working with GRR definition: {str(repo_def)}\n" \
         "id: test_grr\n" \
-        "type: directory\n\n" \
+        "type: directory\n" \
+        f"directory: {str(repo_fixture[0])}\n\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"

--- a/dae/dae/genomic_resources/tests/test_cli_browse.py
+++ b/dae/dae/genomic_resources/tests/test_cli_browse.py
@@ -55,10 +55,10 @@ def test_cli_browse_with_grr_argument(repo_fixture, repo_def, capsys):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" + \
-        "directory: " + str(repo_fixture[0]) + "\n" + \
-        "id: test_grr\n" + \
-        "type: directory\n\n" + \
+        "Working with GRR definition: " + str(repo_def) + "\n" \
+        "directory: " + str(repo_fixture[0]) + "\n" \
+        "id: test_grr\n" \
+        "type: directory\n\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -73,10 +73,10 @@ def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" + \
-        "directory: " + str(repo_fixture[0]) + "\n" + \
-        "id: test_grr\n" + \
-        "type: directory\n\n" + \
+        "Working with GRR definition: " + str(repo_def) + "\n" \
+        "directory: " + str(repo_fixture[0]) + "\n" \
+        "id: test_grr\n" \
+        "type: directory\n\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -93,9 +93,9 @@ def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" + \
-        "directory: " + str(repo_fixture[0]) + "\n" + \
-        "id: test_grr\n" + \
-        "type: directory\n\n" + \
+        "Working with GRR definition: " + str(repo_def) + "\n" \
+        "directory: " + str(repo_fixture[0]) + "\n" \
+        "id: test_grr\n" \
+        "type: directory\n\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"

--- a/dae/dae/genomic_resources/tests/test_cli_browse.py
+++ b/dae/dae/genomic_resources/tests/test_cli_browse.py
@@ -55,10 +55,10 @@ def test_cli_browse_with_grr_argument(repo_fixture, repo_def, capsys):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" \
-        "{'directory': '" + str(repo_fixture[0]) + "',\n" \
-        " 'id': 'test_grr',\n" \
-        " 'type': 'directory'}\n" \
+        "Working with GRR definition: " + str(repo_def) + "\n" + \
+        "directory: " + str(repo_fixture[0]) + "\n" + \
+        "id: test_grr\n" + \
+        "type: directory\n\n" + \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -73,10 +73,10 @@ def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" \
-        "{'directory': '" + str(repo_fixture[0]) + "',\n" \
-        " 'id': 'test_grr',\n" \
-        " 'type': 'directory'}\n" \
+        "Working with GRR definition: " + str(repo_def) + "\n" + \
+        "directory: " + str(repo_fixture[0]) + "\n" + \
+        "id: test_grr\n" + \
+        "type: directory\n\n" + \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -89,11 +89,13 @@ def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
     cli_browse([])
     out, err = capsys.readouterr()
 
+    print(out, str(repo_fixture)[0])
+
     assert err == ""
     assert out == \
-        "Working with GRR definition: " + str(repo_def) + "\n" \
-        "{'directory': '" + str(repo_fixture[0]) + "',\n" \
-        " 'id': 'test_grr',\n" \
-        " 'type': 'directory'}\n" \
+        "Working with GRR definition: " + str(repo_def) + "\n" + \
+        "directory: " + str(repo_fixture[0]) + "\n" + \
+        "id: test_grr\n" + \
+        "type: directory\n\n" + \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"

--- a/dae/dae/genomic_resources/tests/test_cli_browse.py
+++ b/dae/dae/genomic_resources/tests/test_cli_browse.py
@@ -55,6 +55,10 @@ def test_cli_browse_with_grr_argument(repo_fixture, repo_def, capsys):
 
     assert err == ""
     assert out == \
+        "Working with GRR definition: " + str(repo_def) + "\n" \
+        "{'directory': '" + str(repo_fixture[0]) + "',\n" \
+        " 'id': 'test_grr',\n" \
+        " 'type': 'directory'}\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -69,6 +73,10 @@ def test_cli_browse_with_env_variable(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
+        "Working with GRR definition: " + str(repo_def) + "\n" \
+        "{'directory': '" + str(repo_fixture[0]) + "',\n" \
+        " 'id': 'test_grr',\n" \
+        " 'type': 'directory'}\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"
 
@@ -83,5 +91,9 @@ def test_cli_browse_default_defintion(repo_fixture, repo_def, capsys, mocker):
 
     assert err == ""
     assert out == \
+        "Working with GRR definition: " + str(repo_def) + "\n" \
+        "{'directory': '" + str(repo_fixture[0]) + "',\n" \
+        " 'id': 'test_grr',\n" \
+        " 'type': 'directory'}\n" \
         "Basic                0        2 7.0 B        test_grr one\n" \
         "gene_models          1.0      2 50.0 B       test_grr sub/two\n"


### PR DESCRIPTION
## Background and aim

The improvements can be split into two subtasks. With migration into YAML, the idea is to transition the GRR definition into YAML format as the first task and the second is to make printing of the GRR default behavior.

## Implementation

Closes #434.
