### PR TITLE
Support for multiple aggregators with single source score.

### DIFF
--- a/dae/dae/annotation/annotator_base.py
+++ b/dae/dae/annotation/annotator_base.py
@@ -181,11 +181,11 @@ class Annotator(abc.ABC):
             annotatable = override
 
         attributes = self._do_annotate(annotatable, context)
-        attributes_list = self.get_annotation_config()
-        for attr in attributes_list:
-            if attr["destination"] == attr["source"]:
-                continue
-            attributes[attr["destination"]] = attributes[attr["source"]]
-            del attributes[attr["source"]]
+        # attributes_list = self.get_annotation_config()
+        # for attr in attributes_list:
+        #     if attr["destination"] == attr["source"]:
+        #         continue
+        #     attributes[attr["destination"]] = attributes[attr["source"]]
+        #     del attributes[attr["source"]]
 
         return attributes

--- a/dae/dae/annotation/annotator_base.py
+++ b/dae/dae/annotation/annotator_base.py
@@ -181,11 +181,4 @@ class Annotator(abc.ABC):
             annotatable = override
 
         attributes = self._do_annotate(annotatable, context)
-        # attributes_list = self.get_annotation_config()
-        # for attr in attributes_list:
-        #     if attr["destination"] == attr["source"]:
-        #         continue
-        #     attributes[attr["destination"]] = attributes[attr["source"]]
-        #     del attributes[attr["source"]]
-
         return attributes

--- a/dae/dae/annotation/score_annotator.py
+++ b/dae/dae/annotation/score_annotator.py
@@ -289,7 +289,7 @@ class NPScoreAnnotator(PositionScoreAnnotator):
         for attr in self.get_annotation_config():
             result.append(NPScoreQuery(
                 attr["source"], attr.get("position_aggregator"),
-                attr.get("nucleotidy_aggregator")))
+                attr.get("nucleotide_aggregator")))
         return result
 
 

--- a/dae/dae/annotation/score_annotator.py
+++ b/dae/dae/annotation/score_annotator.py
@@ -7,7 +7,9 @@ from typing import cast, Any
 
 from dae.genomic_resources.genomic_scores import \
     build_allele_score_from_resource, build_position_score_from_resource, \
-    build_np_score_from_resource
+    build_np_score_from_resource, \
+    PositionScoreQuery, NPScoreQuery, ScoreQuery
+
 from dae.genomic_resources.aggregators import AGGREGATOR_SCHEMA
 
 from .annotatable import Annotatable, VCFAllele
@@ -49,6 +51,7 @@ class VariantScoreAnnotatorBase(Annotator):
         super().__init__(config)
 
         self.score = score
+        self.score_queries: list[ScoreQuery] = self._collect_score_queries()
         self._annotation_schema = None
 
         self.non_default_position_aggregators: dict = {}
@@ -108,12 +111,15 @@ class VariantScoreAnnotatorBase(Annotator):
             self.non_default_nucleotide_aggregators = \
                 non_default_nucleotide_aggregators
 
+    def _collect_score_queries(self) -> list[ScoreQuery]:
+        return []
+
     def get_scores(self):
         return [attr["source"] for attr in self.get_annotation_config()]
 
     def _scores_not_found(self, attributes):
         values = {
-            score_id: None for score_id in self.get_scores()
+            attr["destination"]: None for attr in self.get_annotation_config()
         }
         attributes.update(values)
 
@@ -173,6 +179,13 @@ class PositionScoreAnnotator(VariantScoreAnnotatorBase):
                 "nucleotide_aggregator is not allowed in position score")
         return cast(dict, validator.document)
 
+    def _collect_score_queries(self) -> list[ScoreQuery]:
+        result: list[ScoreQuery] = []
+        for attr in self.get_annotation_config():
+            result.append(PositionScoreQuery(
+                attr["source"], attr.get("position_aggregator")))
+        return result
+
     def _fetch_substitution_scores(self, allele):
         scores = self.score.fetch_scores(
             allele.chromosome, allele.position,
@@ -185,14 +198,9 @@ class PositionScoreAnnotator(VariantScoreAnnotatorBase):
             chrom,
             pos_begin,
             pos_end,
-            self.get_scores(),
-            self.non_default_position_aggregators
+            self.score_queries
         )
-        scores = {
-            sc_name: sc_agg.get_final()
-            for sc_name, sc_agg in scores_agg.items()
-        }
-        return scores
+        return [sagg.get_final() for sagg in scores_agg]
 
     def _do_annotate(
             self, annotatable: Annotatable, context):
@@ -220,10 +228,9 @@ class PositionScoreAnnotator(VariantScoreAnnotatorBase):
             self._scores_not_found(attributes)
             return attributes
 
-        for score in self.get_scores():
-            value = scores[score]
-            attributes[score] = value
-        return attributes
+        return dict(zip(
+            [attr["destination"] for attr in self.get_annotation_config()],
+            scores))
 
 
 def build_np_score_annotator(pipeline: AnnotationPipeline, config: dict):
@@ -277,23 +284,29 @@ class NPScoreAnnotator(PositionScoreAnnotator):
             self.get_scores()
         )
 
-    def _fetch_aggregated_scores(self, chrom, pos_begin, pos_end):
-        scores_agg = self.score.fetch_scores_agg(
-            chrom,
-            pos_begin,
-            pos_end,
-            self.get_scores(),
-            self.non_default_position_aggregators,
-            self.non_default_nucleotide_aggregators
-        )
-        if scores_agg is None:
-            return None
+    def _collect_score_queries(self) -> list[ScoreQuery]:
+        result: list[ScoreQuery] = []
+        for attr in self.get_annotation_config():
+            result.append(NPScoreQuery(
+                attr["source"], attr.get("position_aggregator"),
+                attr.get("nucleotidy_aggregator")))
+        return result
 
-        scores = {
-            sc_name: sc_agg.get_final()
-            for sc_name, sc_agg in scores_agg.items()
-        }
-        return scores
+    # def _fetch_aggregated_scores(self, chrom, pos_begin, pos_end):
+    #     scores_agg = self.score.fetch_scores_agg(
+    #         chrom,
+    #         pos_begin,
+    #         pos_end,
+    #         self.score_queries)
+
+    #     if scores_agg is None:
+    #         return None
+
+    #     scores = {
+    #         sc_name: sc_agg.get_final()
+    #         for sc_name, sc_agg in scores_agg.items()
+    #     }
+    #     return scores
 
 
 def build_allele_score_annotator(pipeline: AnnotationPipeline, config: dict):
@@ -373,7 +386,7 @@ class AlleleScoreAnnotator(VariantScoreAnnotatorBase):
             self._scores_not_found(attributes)
             return attributes
 
-        scores_dict = self.score.fetch_scores(
+        scores = self.score.fetch_scores(
             annotatable.chromosome,
             annotatable.position,
             annotatable.reference,
@@ -382,23 +395,22 @@ class AlleleScoreAnnotator(VariantScoreAnnotatorBase):
         )
         logger.debug(
             "allele score found for annotatable %s: %s",
-            annotatable, scores_dict)
+            annotatable, scores)
 
-        if scores_dict is None:
+        if scores is None:
             self._scores_not_found(attributes)
             return attributes
 
-        for score_id, score_value in scores_dict.items():
+        for attr, value in zip(self.get_annotation_config(), scores):
             try:
-                if score_value in ("", " "):
-                    attributes[score_id] = None
+                if value in ("", " "):
+                    attributes[attr["destination"]] = None
                 else:
-                    attributes[score_id] = score_value
+                    attributes[attr["destination"]] = value
             except ValueError as ex:
                 logger.error(
                     "problem with: %s: %s - %s",
-                    score_id, annotatable, score_value)
-                logger.error(ex)
+                    attr, annotatable, value, exc_info=True)
                 raise ex
 
         return attributes

--- a/dae/dae/annotation/score_annotator.py
+++ b/dae/dae/annotation/score_annotator.py
@@ -292,22 +292,6 @@ class NPScoreAnnotator(PositionScoreAnnotator):
                 attr.get("nucleotidy_aggregator")))
         return result
 
-    # def _fetch_aggregated_scores(self, chrom, pos_begin, pos_end):
-    #     scores_agg = self.score.fetch_scores_agg(
-    #         chrom,
-    #         pos_begin,
-    #         pos_end,
-    #         self.score_queries)
-
-    #     if scores_agg is None:
-    #         return None
-
-    #     scores = {
-    #         sc_name: sc_agg.get_final()
-    #         for sc_name, sc_agg in scores_agg.items()
-    #     }
-    #     return scores
-
 
 def build_allele_score_annotator(pipeline: AnnotationPipeline, config: dict):
     """Construct an Allele Score annotator."""

--- a/dae/dae/genomic_resources/aggregators.py
+++ b/dae/dae/genomic_resources/aggregators.py
@@ -1,10 +1,10 @@
 import re
 import math
 
-from typing import cast, Any
+from typing import cast, Any, Callable, Type
 
 
-class AbstractAggregator:
+class Aggregator:
     """Base class for score aggregators."""
 
     def __init__(self):
@@ -42,7 +42,7 @@ class AbstractAggregator:
         return cast(bool, self.get_final() == obj)
 
 
-class MaxAggregator(AbstractAggregator):
+class MaxAggregator(Aggregator):
     """Maximum value aggregator for genomic scores."""
 
     def __init__(self):
@@ -66,7 +66,7 @@ class MaxAggregator(AbstractAggregator):
         return self.current_max
 
 
-class MinAggregator(AbstractAggregator):
+class MinAggregator(Aggregator):
     """Minimum value aggregator for genomic scores."""
 
     def __init__(self):
@@ -90,7 +90,7 @@ class MinAggregator(AbstractAggregator):
         return self.current_min
 
 
-class MeanAggregator(AbstractAggregator):
+class MeanAggregator(Aggregator):
     """Aggregator for genomic scores that calculates mean value."""
 
     def __init__(self):
@@ -113,7 +113,7 @@ class MeanAggregator(AbstractAggregator):
         return None
 
 
-class ConcatAggregator(AbstractAggregator):
+class ConcatAggregator(Aggregator):
     """Aggregator that concatenates all passed values."""
 
     def __init__(self):
@@ -135,7 +135,7 @@ class ConcatAggregator(AbstractAggregator):
         return self.out
 
 
-class MedianAggregator(AbstractAggregator):
+class MedianAggregator(Aggregator):
     """Aggregator for genomic scores that calculates median value."""
 
     def __init__(self):
@@ -165,7 +165,7 @@ class MedianAggregator(AbstractAggregator):
         return (first + second) / 2
 
 
-class ModeAggregator(AbstractAggregator):
+class ModeAggregator(Aggregator):
     """Aggregator for genomic scores that calculates mode value."""
 
     def __init__(self):
@@ -200,7 +200,7 @@ class ModeAggregator(AbstractAggregator):
         return modes[0]
 
 
-class JoinAggregator(AbstractAggregator):
+class JoinAggregator(Aggregator):
     """Aggregator that joins all passed values using a separator."""
 
     def __init__(self, separator):
@@ -220,7 +220,7 @@ class JoinAggregator(AbstractAggregator):
         return self.separator.join(self.values)
 
 
-class ListAggregator(AbstractAggregator):
+class ListAggregator(Aggregator):
     """Aggregator that builds a list of all passed values."""
 
     def __init__(self):
@@ -239,7 +239,7 @@ class ListAggregator(AbstractAggregator):
         return self.values
 
 
-class DictAggregator(AbstractAggregator):
+class DictAggregator(Aggregator):
     """Aggregator that builds a dictionary of all passed values."""
 
     def __init__(self):
@@ -258,7 +258,7 @@ class DictAggregator(AbstractAggregator):
         return self.values
 
 
-AGGREGATOR_CLASS_DICT = {
+AGGREGATOR_CLASS_DICT: dict[str, Type[Aggregator]] = {
     "max": MaxAggregator,
     "min": MinAggregator,
     "mean": MeanAggregator,
@@ -286,7 +286,7 @@ AGGREGATOR_SCHEMA = {
 }
 
 
-def get_aggregator_class(aggregator):
+def get_aggregator_class(aggregator) -> Callable[[], Aggregator]:
     return AGGREGATOR_CLASS_DICT[aggregator]
 
 
@@ -305,7 +305,7 @@ def create_aggregator_definition(aggregator_type):
     }
 
 
-def create_aggregator(aggregator_def):
+def create_aggregator(aggregator_def) -> Aggregator:
     """Create an aggregator by aggregator definition."""
     aggregator_name = aggregator_def["name"]
     aggregator_class = get_aggregator_class(aggregator_name)
@@ -315,6 +315,6 @@ def create_aggregator(aggregator_def):
     return aggregator_class()
 
 
-def build_aggregator(aggregator_type):
+def build_aggregator(aggregator_type) -> Aggregator:
     aggregator_def = create_aggregator_definition(aggregator_type)
     return create_aggregator(aggregator_def)

--- a/dae/dae/genomic_resources/tests/test_allele_score.py
+++ b/dae/dae/genomic_resources/tests/test_allele_score.py
@@ -39,7 +39,7 @@ def test_the_simplest_allele_score():
     score.open()
 
     assert score.get_all_scores() == ["freq"]
-    assert score.fetch_scores("1", 10, "A", "C") == {"freq": 0.03}
+    assert score.fetch_scores("1", 10, "A", "C") == [0.03]
 
 
 def test_allele_score_fetch_region():

--- a/dae/dae/genomic_resources/tests/test_fsspec_protocol.py
+++ b/dae/dae/genomic_resources/tests/test_fsspec_protocol.py
@@ -32,32 +32,32 @@ def test_resource_paths(rw_fsspec_proto):
 
 def test_build_resource_file_state(rw_fsspec_proto):
     proto = rw_fsspec_proto
-    timestamp = time.time()
+    timestamp = 42
     res = proto.get_resource("one")
 
     state = proto.build_resource_file_state(
-        res, "data.txt")
+        res, "data.txt", timestamp=timestamp)
 
     assert state.filename == "data.txt"
-    assert state.timestamp == pytest.approx(timestamp, abs=5)
+    assert state.timestamp == pytest.approx(timestamp, abs=0.1)
     assert state.md5 == "c1cfdaf7e22865b29b8d62a564dc8f23"
 
     res = proto.get_resource("sub/two")
     state = proto.build_resource_file_state(
-        res, "genes.gtf")
+        res, "genes.gtf", timestamp=timestamp)
 
     assert state.filename == "genes.gtf"
-    assert state.timestamp == pytest.approx(timestamp, abs=5)
+    assert state.timestamp == pytest.approx(timestamp, abs=0.1)
     assert state.md5 == "d9636a8dca9e5626851471d1c0ea92b1"
 
 
 def test_save_load_resource_file_state(rw_fsspec_proto):
     proto = rw_fsspec_proto
-    timestamp = time.time()
+    timestamp = 42
 
     res = proto.get_resource("sub/two")
     state = proto.build_resource_file_state(
-        res, "genes.gtf")
+        res, "genes.gtf", timestamp=timestamp)
 
     proto.save_resource_file_state(res, state)
     state_path = proto._get_resource_file_state_path(res, "genes.gtf")
@@ -66,7 +66,7 @@ def test_save_load_resource_file_state(rw_fsspec_proto):
     loaded = proto.load_resource_file_state(res, "genes.gtf")
     assert loaded is not None
     assert loaded.filename == "genes.gtf"
-    assert loaded.timestamp == pytest.approx(timestamp, abs=5)
+    assert loaded.timestamp == pytest.approx(timestamp, abs=0.1)
     assert loaded.md5 == "d9636a8dca9e5626851471d1c0ea92b1"
 
 

--- a/dae/dae/genomic_resources/tests/test_repository_factory.py
+++ b/dae/dae/genomic_resources/tests/test_repository_factory.py
@@ -1,4 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+# type: ignore
 
 import yaml
 from dae.genomic_resources import build_genomic_resource_repository
@@ -144,4 +145,4 @@ def test_build_a_configuration_with_embedded():
 
     score = build_position_score_from_resource(res)
     score.open()
-    assert score.fetch_scores("chr1", 23) == {"score": 0.01}
+    assert score.fetch_scores("chr1", 23) == [0.01]

--- a/dae/dae/genomic_resources/tests/test_vcf_info_score.py
+++ b/dae/dae/genomic_resources/tests/test_vcf_info_score.py
@@ -104,7 +104,7 @@ def test_clinvar_fetch_region(
 @pytest.mark.parametrize("chrom,pos,ref,alt,scores,expected", [
     (
         "chrA", 1, "A", "T", ["CLNDN", "ALLELEID"],
-        {"CLNDN": "not_provided", "ALLELEID": 1003021}
+        ["not_provided", 1003021]
     ),
     (
         "chrA", 1, "A", "G", ["CLNDN", "ALLELEID"],
@@ -112,12 +112,12 @@ def test_clinvar_fetch_region(
     ),
     (
         "chrA", 2, "A", "T", ["CLNDN", "CLNSIG"],
-        {"CLNDN": "Combined_immunodeficiency_due_to_OX40_deficiency",
-         "CLNSIG": "Likely_benign"}
+        ["Combined_immunodeficiency_due_to_OX40_deficiency",
+         "Likely_benign"]
     ),
     (
         "chrA", 3, "A", "T", ["DBVARID"],
-        {"DBVARID": None}
+        [None]
     )
 ])
 def test_clinvar_fetch_scores(
@@ -383,7 +383,7 @@ def test_gnomad_vcf_fetch_region(
 @pytest.mark.parametrize("chrom,pos,ref,alt,scores,expected", [
     (
         "chrA", 1, "A", "C", ["AN", "AC"],
-        {"AN": 53780, "AC": 0},
+        [53780, 0],
     ),
     (
         "chrA", 1, "A", "G", ["AN", "AC"],
@@ -391,7 +391,7 @@ def test_gnomad_vcf_fetch_region(
     ),
     (
         "chrA", 4, "A", "C", ["AN", "AC"],
-        {"AN": 89638, "AC": 1},
+        [89638, 1],
     ),
 ])
 def test_gnomad_vcf_fetch_rscores(


### PR DESCRIPTION
## Background

We want to support annotation with the following configuration:

```yaml
            - position_score:
                resource_id: position_score1
                attributes:
                - source: test100way
                  destination: test100min
                  position_aggregator: min
                - source: test100way
                  destination: test100max
                  position_aggregator: max
```
The specifics of this annotation configuration are that we want to produce two attributes, `test100min` and `test100max` that use the same source score, `test100way`.

The API of the `PositionScore`, `NPScore`, and `AlleleScore` classes do not support this type of annotation.

## Aim

Change the API of genomic scores classes to support this type of annotation.

## Implementation

We changed the genomic scores classes API to return a list of values instead of a dictionary. The genomic score annotators are adapted to use the new genomic scores API.
