### PR TITLE
Reorganize annotators hierarchy

### DIFF
--- a/dae/dae/annotation/annotator_base.py
+++ b/dae/dae/annotation/annotator_base.py
@@ -118,17 +118,13 @@ class Annotator(abc.ABC):
         """Return annotator type."""
 
     @abc.abstractmethod
-    def _do_annotate(
-        self, annotatable: Annotatable, context: dict
-    ) -> dict:
-        """Annotate the annotatable.
-
-        Internal abstract method used for annotation.
-        """
-
-    @abc.abstractmethod
     def get_annotation_config(self) -> list[dict]:
         """Return annotation config."""
+
+    @abc.abstractmethod
+    def annotate(self, annotatable: Annotatable,
+                 context: dict[str, Any]) -> dict[str, Any]:
+        """Produce annotation attributes for an annotatable."""
 
     @abc.abstractmethod
     def close(self):
@@ -153,7 +149,16 @@ class Annotator(abc.ABC):
             result[attr["destination"]] = None
         return result
 
-    def _remap_annotation_attributes(self, attributes):
+    def _remap_annotation_attributes(
+            self, attributes: dict[str, Any]) -> dict[str, Any]:
+        """Remap the annotation attributes from source to destination.
+
+        The method uses the annotation configuration and renames
+        annotation attributes from their source name to destination.
+
+        This implementation is suitable for most annotators and is used in
+        the `AnnotatorBase` implementation.
+        """
         attributes_config = self.get_annotation_config()
         for attr in attributes_config:
             if attr["destination"] == attr["source"]:
@@ -162,32 +167,62 @@ class Annotator(abc.ABC):
             del attributes[attr["source"]]
         return attributes
 
+    def _get_annotatable_override(
+            self, annotatable: Annotatable,
+            context: dict[str, Any]) -> Optional[Annotatable]:
+        """Find and return an annotatable override if configured.
+
+        Otherwise returns the default annotatable.
+        """
+        if self.input_annotatable is None:
+            return annotatable
+
+        if self.input_annotatable not in context:
+            raise ValueError(
+                f"can't find input annotatable {self.input_annotatable} "
+                f"in annotation context: {context}")
+        override = context[self.input_annotatable]
+        logger.debug(
+            "input annotatable %s found %s.",
+            self.input_annotatable, override)
+
+        if override is None:
+            logger.warning(
+                "can't find input annotatable %s "
+                "in annotation context: %s",
+                self.input_annotatable, context)
+            return None
+
+        if not isinstance(override, Annotatable):
+            raise ValueError(
+                f"The object with a key {self.input_annotatable} in the "
+                f"annotation context {context} is not an Annotabable.")
+
+        return override
+
+
+class AnnotatorBase(Annotator):
+    """Base implementation of the `Annotator` class."""
+
+    @abc.abstractmethod
+    def _do_annotate(
+        self, annotatable: Annotatable, context: dict
+    ) -> dict:
+        """Annotate the annotatable.
+
+        Internal abstract method used for annotation. It should produce
+        all source attributes defined for annotator.
+        """
+
     def annotate(self, annotatable: Annotatable,
                  context: dict[str, Any]) -> dict[str, Any]:
-        """Annotate and relabel attributes as configured."""
-        if self.input_annotatable is not None:
-            if self.input_annotatable not in context:
-                raise ValueError(
-                    f"can't find input annotatable {self.input_annotatable} "
-                    f"in annotation context: {context}")
-            override = context[self.input_annotatable]
-            logger.debug(
-                "input annotatable %s found %s.",
-                self.input_annotatable, override)
+        """Annotate and relabel attributes as configured.
 
-            if override is None:
-                logger.warning(
-                    "can't find input annotatable %s "
-                    "in annotation context: %s",
-                    self.input_annotatable, context)
-                return self._empty_result()
-
-            if not isinstance(override, Annotatable):
-                raise ValueError(
-                    f"The object with a key {self.input_annotatable} in the "
-                    f"annotation context {context} is not an Annotabable.")
-
-            annotatable = override
-
-        attributes = self._do_annotate(annotatable, context)
-        return attributes
+        Uses `_do_annotate` to produce the annotation attributes.
+        """
+        annotatable_override = self._get_annotatable_override(
+            annotatable, context)
+        if annotatable_override is None:
+            return self._empty_result()
+        attributes = self._do_annotate(annotatable_override, context)
+        return self._remap_annotation_attributes(attributes)

--- a/dae/dae/annotation/annotator_base.py
+++ b/dae/dae/annotation/annotator_base.py
@@ -153,6 +153,15 @@ class Annotator(abc.ABC):
             result[attr["destination"]] = None
         return result
 
+    def _remap_annotation_attributes(self, attributes):
+        attributes_config = self.get_annotation_config()
+        for attr in attributes_config:
+            if attr["destination"] == attr["source"]:
+                continue
+            attributes[attr["destination"]] = attributes[attr["source"]]
+            del attributes[attr["source"]]
+        return attributes
+
     def annotate(self, annotatable: Annotatable,
                  context: dict[str, Any]) -> dict[str, Any]:
         """Annotate and relabel attributes as configured."""

--- a/dae/dae/annotation/effect_annotator.py
+++ b/dae/dae/annotation/effect_annotator.py
@@ -258,4 +258,4 @@ class EffectAnnotatorAdapter(Annotator):
             "lgd_gene_list": lgd_gene_list
         }
 
-        return result
+        return self._remap_annotation_attributes(result)

--- a/dae/dae/annotation/effect_annotator.py
+++ b/dae/dae/annotation/effect_annotator.py
@@ -18,7 +18,7 @@ from dae.genomic_resources.gene_models import \
 
 from .annotatable import Annotatable, CNVAllele, VCFAllele
 
-from .annotator_base import Annotator, ATTRIBUTES_SCHEMA
+from .annotator_base import AnnotatorBase, ATTRIBUTES_SCHEMA
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def build_effect_annotator(pipeline, config):
     return EffectAnnotatorAdapter(config, genome, gene_models)
 
 
-class EffectAnnotatorAdapter(Annotator):
+class EffectAnnotatorAdapter(AnnotatorBase):
     """Defines variant effect annotator."""
 
     DEFAULT_ANNOTATION = {
@@ -258,4 +258,4 @@ class EffectAnnotatorAdapter(Annotator):
             "lgd_gene_list": lgd_gene_list
         }
 
-        return self._remap_annotation_attributes(result)
+        return result

--- a/dae/dae/annotation/gene_score_annotator.py
+++ b/dae/dae/annotation/gene_score_annotator.py
@@ -9,7 +9,7 @@ from dae.genomic_resources import GenomicResource
 from dae.genomic_resources.aggregators import AGGREGATOR_SCHEMA
 from dae.genomic_resources.aggregators import build_aggregator
 
-from .annotator_base import Annotator, ATTRIBUTES_SCHEMA
+from .annotator_base import AnnotatorBase, ATTRIBUTES_SCHEMA
 from .annotatable import Annotatable
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ def build_gene_score_annotator(pipeline, config):
     return GeneScoreAnnotator(config, gene_score_resource)
 
 
-class GeneScoreAnnotator(Annotator):
+class GeneScoreAnnotator(AnnotatorBase):
     """Annotator that annotates variants by using gene score resources."""
 
     DEFAULT_AGGREGATOR_TYPE = "dict"
@@ -145,7 +145,7 @@ class GeneScoreAnnotator(Annotator):
                 gene_score, genes, aggregator_type
             )
 
-        return self._remap_annotation_attributes(attributes)
+        return attributes
 
     def close(self):
         pass

--- a/dae/dae/annotation/gene_score_annotator.py
+++ b/dae/dae/annotation/gene_score_annotator.py
@@ -145,7 +145,7 @@ class GeneScoreAnnotator(Annotator):
                 gene_score, genes, aggregator_type
             )
 
-        return attributes
+        return self._remap_annotation_attributes(attributes)
 
     def close(self):
         pass

--- a/dae/dae/annotation/liftover_annotator.py
+++ b/dae/dae/annotation/liftover_annotator.py
@@ -12,7 +12,7 @@ from dae.genomic_resources.liftover_resource import \
 from dae.utils.variant_utils import trim_str_left, reverse_complement
 
 from .annotatable import Annotatable, VCFAllele
-from .annotator_base import Annotator, ATTRIBUTES_SCHEMA
+from .annotator_base import AnnotatorBase, ATTRIBUTES_SCHEMA
 
 
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def build_liftover_annotator(pipeline, config):
     return LiftOverAnnotator(config, liftover_chain, target_genome)
 
 
-class LiftOverAnnotator(Annotator):
+class LiftOverAnnotator(AnnotatorBase):
     """Defines a Lift Over annotator."""
 
     def __init__(
@@ -55,14 +55,6 @@ class LiftOverAnnotator(Annotator):
         self.chain: LiftoverChain = chain
         self.target_genome: ReferenceGenome = target_genome
         self._annotation_schema = None
-        self._liftover_annotatable_dest = self._configure_destination()
-
-    def _configure_destination(self):
-        for attr in self.get_annotation_config():
-            if attr["source"] == "liftover_annotatable":
-                return attr["destination"]
-        raise ValueError(
-            f"bad LiftOverAnnotator configuration: {self.config}")
 
     def annotator_type(self) -> str:
         return "liftover_annotator"
@@ -218,12 +210,12 @@ class LiftOverAnnotator(Annotator):
             logger.warning(
                 "%s not ready to annotate CNV variants: %s",
                 self.annotator_type(), annotatable)
-            return {self._liftover_annotatable_dest: None}
+            return {"liftover_annotatable": None}
 
         lo_allele = self.liftover_allele(cast(VCFAllele, annotatable))
         if lo_allele is None:
             logger.info(
                 "unable to liftover allele: %s", annotatable)
-            return {self._liftover_annotatable_dest: None}
+            return {"liftover_annotatable": None}
 
-        return {self._liftover_annotatable_dest: lo_allele}
+        return {"liftover_annotatable": lo_allele}

--- a/dae/dae/annotation/liftover_annotator.py
+++ b/dae/dae/annotation/liftover_annotator.py
@@ -55,6 +55,14 @@ class LiftOverAnnotator(Annotator):
         self.chain: LiftoverChain = chain
         self.target_genome: ReferenceGenome = target_genome
         self._annotation_schema = None
+        self._liftover_annotatable_dest = self._configure_destination()
+
+    def _configure_destination(self):
+        for attr in self.get_annotation_config():
+            if attr["source"] == "liftover_annotatable":
+                return attr["destination"]
+        raise ValueError(
+            f"bad LiftOverAnnotator configuration: {self.config}")
 
     def annotator_type(self) -> str:
         return "liftover_annotator"
@@ -210,12 +218,12 @@ class LiftOverAnnotator(Annotator):
             logger.warning(
                 "%s not ready to annotate CNV variants: %s",
                 self.annotator_type(), annotatable)
-            return {"liftover_annotatable": None}
+            return {self._liftover_annotatable_dest: None}
 
         lo_allele = self.liftover_allele(cast(VCFAllele, annotatable))
         if lo_allele is None:
             logger.info(
                 "unable to liftover allele: %s", annotatable)
-            return {"liftover_annotatable": None}
+            return {self._liftover_annotatable_dest: None}
 
-        return {"liftover_annotatable": lo_allele}
+        return {self._liftover_annotatable_dest: lo_allele}

--- a/dae/dae/annotation/normalize_allele_annotator.py
+++ b/dae/dae/annotation/normalize_allele_annotator.py
@@ -78,6 +78,14 @@ class NormalizeAlleleAnnotator(Annotator):
 
         self.genome = genome
         self._annotation_schema = None
+        self._destination = self._construct_destination()
+
+    def _construct_destination(self):
+        for attr in self.get_annotation_config():
+            if attr["source"] == "normalized_allele":
+                return attr["destination"]
+        raise ValueError(
+            f"bad NormalizeAlleleAnnotator configuration: {self.config}")
 
     def annotator_type(self) -> str:
         return "normalize_allele_annotator"
@@ -165,9 +173,9 @@ class NormalizeAlleleAnnotator(Annotator):
             logger.warning(
                 "%s not ready to annotate CNV variants: %s",
                 self.annotator_type(), annotatable)
-            return {"normalized_allele": None}
+            return {self._destination: None}
 
         assert isinstance(annotatable, VCFAllele), annotatable
 
         normalized_allele = normalize_allele(annotatable, self.genome)
-        return {"normalized_allele": normalized_allele}
+        return {self._destination: normalized_allele}

--- a/dae/dae/annotation/normalize_allele_annotator.py
+++ b/dae/dae/annotation/normalize_allele_annotator.py
@@ -8,7 +8,7 @@ from dae.genomic_resources.reference_genome import \
     build_reference_genome_from_resource
 
 from .annotatable import Annotatable, VCFAllele
-from .annotator_base import Annotator, ATTRIBUTES_SCHEMA
+from .annotator_base import AnnotatorBase, ATTRIBUTES_SCHEMA
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ def build_normalize_allele_annotator(pipeline, config):
     return NormalizeAlleleAnnotator(config, genome)
 
 
-class NormalizeAlleleAnnotator(Annotator):
+class NormalizeAlleleAnnotator(AnnotatorBase):
     """Provides annotator for normalizing alleles."""
 
     def __init__(self, config, genome: ReferenceGenome):
@@ -78,14 +78,6 @@ class NormalizeAlleleAnnotator(Annotator):
 
         self.genome = genome
         self._annotation_schema = None
-        self._destination = self._construct_destination()
-
-    def _construct_destination(self):
-        for attr in self.get_annotation_config():
-            if attr["source"] == "normalized_allele":
-                return attr["destination"]
-        raise ValueError(
-            f"bad NormalizeAlleleAnnotator configuration: {self.config}")
 
     def annotator_type(self) -> str:
         return "normalize_allele_annotator"
@@ -173,9 +165,9 @@ class NormalizeAlleleAnnotator(Annotator):
             logger.warning(
                 "%s not ready to annotate CNV variants: %s",
                 self.annotator_type(), annotatable)
-            return {self._destination: None}
+            return {"normalized_allele": None}
 
         assert isinstance(annotatable, VCFAllele), annotatable
 
         normalized_allele = normalize_allele(annotatable, self.genome)
-        return {self._destination: normalized_allele}
+        return {"normalized_allele": normalized_allele}

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -958,7 +958,7 @@ class PositionScore(GenomicScore):
     def fetch_scores_agg(  # pylint: disable=too-many-arguments,too-many-locals
             self, chrom: str, pos_begin: int, pos_end: int,
             scores: Optional[list[PositionScoreQuery]] = None
-    ) -> Optional[list[Aggregator]]:
+    ) -> list[Aggregator]:
         """Fetch score values in a region and aggregates them.
 
         Case 1:
@@ -1075,7 +1075,7 @@ class NPScore(GenomicScore):
     def fetch_scores_agg(
             self, chrom: str, pos_begin: int, pos_end: int,
             scores: Optional[list[NPScoreQuery]] = None
-    ) -> Optional[list[Aggregator]]:
+    ) -> list[Aggregator]:
         """Fetch score values in a region and aggregates them."""
         # pylint: disable=too-many-locals
         # FIXME:
@@ -1084,16 +1084,16 @@ class NPScore(GenomicScore):
                 f"{chrom} is not among the available chromosomes for "
                 f"NP Score resource {self.score_id}")
 
-        score_lines = list(self._fetch_lines(chrom, pos_begin, pos_end))
-        if not score_lines:
-            return None
-
         if scores is None:
             scores = [
                 NPScoreQuery(score_id)
                 for score_id in self.get_all_scores()]
 
         score_aggs = self._build_scores_agg(scores)
+
+        score_lines = list(self._fetch_lines(chrom, pos_begin, pos_end))
+        if not score_lines:
+            return [sagg.position_aggregator for sagg in score_aggs]
 
         def aggregate_nucleotides():
             for sagg in score_aggs:


### PR DESCRIPTION
## Background

In PR https://github.com/iossifovlab/gpf/pull/447, we introduced support in genomic score annotators for multiple destination attributes produced from the same source attribute.

```yaml
            - position_score:
                resource_id: position_score1
                attributes:
                - source: test100way
                  destination: test100min
                  position_aggregator: min
                - source: test100way
                  destination: test100max
                  position_aggregator: max
```

These changes brake the behavior of default remapping of annotation attributes from the source to the destination:
https://github.com/iossifovlab/gpf/blob/22de1988f1a383ecce20db3363f772ef34f7e8b8/dae/dae/annotation/annotator_base.py#L184

On the other hand, the default behavior is suitable for most of the annotators. The only exception is `PositionScoreAnnotator` and `NPScoreAnnotator`.

## Aim

Reorganize the `Annotator` hierarchy to support both requirements naturally.

## Implementation

To handle those requirements, we transform the `Annotator` base to have an abstract `annotate` method and add a new class `AnnotatorBase` with a default implementation of the `annotator` method that relies on simpler abstract `_do_annotate` method.

