### PR TITLE
Quick fix of `remote_instance_mirror.py` to work with new genotype storage configuration

### DIFF
--- a/dae/dae/genotype_storage/genotype_storage_registry.py
+++ b/dae/dae/genotype_storage/genotype_storage_registry.py
@@ -92,7 +92,7 @@ class GenotypeStorageRegistry:
         """
         for storage_config in genotype_storages_config["storages"]:
             self.register_storage_config(storage_config)
-        default_storage_id = genotype_storages_config.default
+        default_storage_id = genotype_storages_config.get("default")
         if default_storage_id is not None:
             storage = self.get_genotype_storage(default_storage_id)
             self.register_default_storage(storage)


### PR DESCRIPTION
## Background

In GPF 3.7dev we changed the organization and configuration of genotype storages. These changes broke the `remote_instance_mirror.py` tool.

## Aim

Make a quick fix for the `remote_instance_mirror.py` tool to work with the new genotype storage configuration.

## Implementation

Minimal changes to make the `remote_instance_mirror.py` tool work with the new genotype storage configuration.
