### PR TITLE
Annotators transformed into plugins.

### DIFF
--- a/dae/dae/annotation/tests/test_annotation_factory.py
+++ b/dae/dae/annotation/tests/test_annotation_factory.py
@@ -4,7 +4,7 @@ import pytest
 from dae.genomic_resources import build_genomic_resource_repository
 from dae.genomic_resources.repository import GenomicResourceRepo
 from dae.annotation.annotation_factory import build_annotation_pipeline, \
-    build_np_score_annotator
+    get_annotator_factory
 
 
 @pytest.fixture(scope="session")
@@ -61,5 +61,5 @@ def test_annotation_factory_np_score(annotation_pipeline1):
         ],
     }
 
-    annotator = build_np_score_annotator(annotation_pipeline1, config)
+    annotator = get_annotator_factory("np_score")(annotation_pipeline1, config)
     assert annotator is not None

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -63,6 +63,15 @@ setuptools.setup(
     vcf_info=dae.genomic_resources.vcf_info_score:build_vcf_info_from_resource
     gene_models=dae.genomic_resources.gene_models:build_gene_models_from_resource
 
+    [dae.annotation.annotators]
+    allele_score=dae.annotation.score_annotator:build_allele_score_annotator
+    np_score=dae.annotation.score_annotator:build_np_score_annotator
+    position_score=dae.annotation.score_annotator:build_position_score_annotator
+    effect_annotator=dae.annotation.effect_annotator:build_effect_annotator
+    liftover_annotator=dae.annotation.liftover_annotator:build_liftover_annotator
+    normalize_allele_annotator=dae.annotation.normalize_allele_annotator:build_normalize_allele_annotator
+    gene_score_annotator=dae.annotation.gene_score_annotator:build_gene_score_annotator
+
     [dae.genotype_storage.factories]
     impala=dae.impala_storage.schema1.impala_genotype_storage:ImpalaGenotypeStorage
     impala2=dae.impala_storage.schema2.impala2_genotype_storage:Impala2GenotypeStorage


### PR DESCRIPTION
## Background

We want to have an extensible framework for creating and adding annotators.

## Aim

Add an extension point for registering new annotators. The annotator factory methods should be discovered at module loading time.

## Implementation

An extension point for registering new annotator factory methods was added. All existing annotators are registered at the
`dae.annotation.annotators` extension point.
