### PR TITLE
Region split utils

### DIFF
--- a/dae/dae/genomic_resources/genomic_position_table/table.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table.py
@@ -165,37 +165,3 @@ class GenomicPositionTable(abc.ABC):
         This is to be overwritten by the subclass. It should return a list of
         the chromomes in the file in the order determinted by the file.
         """
-
-    def get_chromosome_length(self, chrom, step=100_000_000):
-        """Return the length of a chromosome (or contig).
-
-        Returned value is guarnteed to be larget than the actual contig length.
-        """
-        def any_records(riter):
-            try:
-                next(riter)
-            except StopIteration:
-                return False
-
-            return True
-
-        # First we find any region that includes the last record i.e.
-        # the length of the chromosome
-        left, right = None, None
-        pos = step
-        while left is None or right is None:
-            if any_records(self.get_records_in_region(chrom, pos, None)):
-                left = pos
-                pos = pos * 2
-            else:
-                right = pos
-                pos = pos // 2
-        # Second we use binary search to narrow the region until we find the
-        # index of the last element (in left) and the length (in right)
-        while (right - left) > 5_000_000:
-            pos = (left + right) // 2
-            if any_records(self.get_records_in_region(chrom, pos, None)):
-                left = pos
-            else:
-                right = pos
-        return right

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -15,7 +15,7 @@ from functools import lru_cache
 from jinja2 import Template
 
 from dae.task_graph.graph import TaskGraph
-from dae.utils.regions import split_into_regions, get_chromosome_length
+from dae.utils.regions import split_into_regions, get_chromosome_length_tabix
 from . import GenomicResource
 from .reference_genome import build_reference_genome_from_resource
 from .resource_implementation import GenomicResourceImplementation, \
@@ -657,7 +657,7 @@ class GenomicScore(
             else:
                 if isinstance(self.table, InmemoryGenomicPositionTable):
                     raise ValueError("In memory tables are not supported")
-                chrom_length = get_chromosome_length(
+                chrom_length = get_chromosome_length_tabix(
                     self.table.pysam_file, chrom
                 )
             regions.extend(

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -15,6 +15,7 @@ from functools import lru_cache
 from jinja2 import Template
 
 from dae.task_graph.graph import TaskGraph
+from dae.utils.regions import split_into_regions, get_chromosome_length
 from . import GenomicResource
 from .reference_genome import build_reference_genome_from_resource
 from .resource_implementation import GenomicResourceImplementation, \
@@ -24,6 +25,7 @@ from .resource_implementation import GenomicResourceImplementation, \
     ResourceConfigValidationMixin
 from .genomic_position_table import build_genomic_position_table, Line, \
     TabixGenomicPositionTable, VCFGenomicPositionTable, VCFLine
+from .genomic_position_table.table_inmemory import InmemoryGenomicPositionTable
 from .histogram import Histogram, HistogramStatisticMixin
 from .statistics.min_max import MinMaxValue, MinMaxValueStatisticMixin
 
@@ -646,12 +648,21 @@ class GenomicScore(
         return ref_genome
 
     def _get_chrom_regions(self, region_size, grr=None):
+        regions = []
         ref_genome_id = self.resource.get_labels().get("reference_genome")
         ref_genome = self._get_reference_genome_cached(grr, ref_genome_id)
-        if ref_genome is not None:
-            regions = self._split_into_regions(region_size, ref_genome)
-        else:
-            regions = self._split_into_regions(region_size)
+        for chrom in self.get_all_chromosomes():
+            if ref_genome is not None:
+                chrom_length = ref_genome.get_chrom_length(chrom)
+            else:
+                if isinstance(self.table, InmemoryGenomicPositionTable):
+                    raise ValueError("In memory tables are not supported")
+                chrom_length = get_chromosome_length(
+                    self.table.pysam_file, chrom
+                )
+            regions.extend(
+                split_into_regions(chrom, chrom_length, region_size)
+            )
         return regions
 
     def _add_min_max_tasks(self, graph, region_size, grr=None):
@@ -663,7 +674,10 @@ class GenomicScore(
         """
         min_max_tasks = []
         regions = self._get_chrom_regions(region_size, grr)
-        for chrom, start, end in regions:
+        for region in regions:
+            chrom = region.chrom
+            start = region.start
+            end = region.stop
             min_max_tasks.append(graph.create_task(
                 f"{self.score_id}_calculate_min_max_{chrom}_{start}_{end}",
                 GenomicScore._do_min_max,
@@ -740,7 +754,10 @@ class GenomicScore(
         """
         histogram_tasks = []
         regions = self._get_chrom_regions(region_size, grr)
-        for chrom, start, end in regions:
+        for region in regions:
+            chrom = region.chrom
+            start = region.start
+            end = region.stop
             histogram_tasks.append(graph.create_task(
                 f"{self.score_id}_calculate_histogram_{chrom}_{start}_{end}",
                 GenomicScore._do_histogram,
@@ -834,34 +851,6 @@ class GenomicScore(
             ) as outfile:
                 score_histogram.plot(outfile)
         return merged_histograms
-
-    def _split_into_regions(self, region_size, reference_genome=None):
-        chromosomes = self.get_all_chromosomes()
-        for chrom in chromosomes:
-            if reference_genome is not None \
-                    and chrom in reference_genome.chromosomes:
-                chrom_len = reference_genome.get_chrom_length(chrom)
-            else:
-                if reference_genome is not None:
-                    logger.info(
-                        "chromosome %s of %s not found in reference genome %s",
-                        chrom, self.resource.resource_id,
-                        reference_genome.resource_id
-                    )
-                else:
-                    logger.info(
-                        "chromosome %s of %s using table, no reference genome",
-                        chrom, self.resource.resource_id
-                    )
-                chrom_len = self.table.get_chromosome_length(chrom)
-            logger.debug(
-                "Chromosome '%s' has length %s",
-                chrom, chrom_len)
-            i = 1
-            while i < chrom_len - region_size:
-                yield chrom, i, i + region_size - 1
-                i += region_size
-            yield chrom, i, None
 
     def calc_info_hash(self):
         """Compute and return the info hash."""

--- a/dae/dae/genomic_resources/tests/test_cli_stats.py
+++ b/dae/dae/genomic_resources/tests/test_cli_stats.py
@@ -225,7 +225,7 @@ def test_stats_position_score(tmp_path):
         1      22         25       0.46  EMPTY
         2      5          80       0.01  3
         2      10         11       0.02  3
-        """, seq_col=0, start_col=1, end_col=1)
+        """, seq_col=0, start_col=1, end_col=2)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -326,7 +326,7 @@ def test_stats_np_score(tmp_path):
         2      16         19       C          A            0.03  3
         2      16         19       C          T            0.04  3
         2      16         19       C          G            0.05  4
-        """, seq_col=0, start_col=1, end_col=1)
+        """, seq_col=0, start_col=1, end_col=2)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -410,7 +410,7 @@ def test_minmax(tmp_path):
         2      10         11       1.0
         3      5          17       1.0
         3      18         20       0.01
-        """, seq_col=0, start_col=1, end_col=1)
+        """, seq_col=0, start_col=1, end_col=2)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -492,7 +492,7 @@ def test_reference_genome_usage(tmp_path, mocker):
         2      10         11       1.0
         3      5          17       1.0
         3      18         20       0.01
-        """, seq_col=0, start_col=1, end_col=1)
+        """, seq_col=0, start_col=1, end_col=2)
 
     repo = build_filesystem_test_repository(tmp_path)
 

--- a/dae/dae/genomic_resources/tests/test_cli_stats.py
+++ b/dae/dae/genomic_resources/tests/test_cli_stats.py
@@ -9,7 +9,7 @@ from dae.genomic_resources.repository import GR_CONF_FILE_NAME
 from dae.genomic_resources.histogram import Histogram
 from dae.genomic_resources.testing import \
     setup_directories, convert_to_tab_separated, \
-    build_filesystem_test_repository
+    build_filesystem_test_repository, setup_tabix
 from dae.genomic_resources.resource_implementation import \
     GenomicResourceImplementation, ResourceStatistics
 
@@ -117,7 +117,8 @@ def test_stats_allele_score(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: allele_score
                 table:
-                    filename: data.mem
+                    filename: data.txt.gz
+                    format: tabix
                 scores:
                     - id: freq
                       type: float
@@ -130,21 +131,23 @@ def test_stats_allele_score(tmp_path):
                       max: 1
                       x_scale: linear
                       y_scale: log
-                """,
-            "data.mem": convert_to_tab_separated("""
-                chrom  pos_begin  reference  alternative  freq
-                1      10         A          G            0.02
-                1      10         A          C            0.03
-                1      10         A          A            0.04
-                1      16         CA         G            0.03
-                1      16         C          T            0.04
-                1      16         C          A            0.05
-                2      16         CA         G            0.03
-                2      16         C          T            EMPTY
-                2      16         C          A            0.05
-            """)
+                """
         }
     })
+    setup_tabix(
+        tmp_path / "one" / "data.txt.gz",
+        """
+        #chrom  pos_begin  reference  alternative  freq
+        1      10         A          G            0.02
+        1      10         A          C            0.03
+        1      10         A          A            0.04
+        1      16         CA         G            0.03
+        1      16         C          T            0.04
+        1      16         C          A            0.05
+        2      16         CA         G            0.03
+        2      16         C          T            EMPTY
+        2      16         C          A            0.05
+        """, seq_col=0, start_col=1, end_col=1)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -182,7 +185,8 @@ def test_stats_position_score(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: position_score
                 table:
-                    filename: data.mem
+                    filename: data.txt.gz
+                    format: tabix
                 scores:
                     - id: phastCons100way
                       type: float
@@ -209,17 +213,19 @@ def test_stats_position_score(tmp_path):
                       max: 4
                       x_scale: linear
                       y_scale: linear
-                """,
-            "data.mem": convert_to_tab_separated("""
-                chrom  pos_begin  pos_end  s1    s2
-                1      10         15       0.02  -1
-                1      17         19       0.03  0
-                1      22         25       0.46  EMPTY
-                2      5          80       0.01  3
-                2      10         11       0.02  3
-                """)
-        },
+                """
+        }
     })
+    setup_tabix(
+        tmp_path / "one" / "data.txt.gz",
+        """
+        #chrom  pos_begin  pos_end  s1    s2
+        1      10         15       0.02  -1
+        1      17         19       0.03  0
+        1      22         25       0.46  EMPTY
+        2      5          80       0.01  3
+        2      10         11       0.02  3
+        """, seq_col=0, start_col=1, end_col=1)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -277,7 +283,8 @@ def test_stats_np_score(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: np_score
                 table:
-                    filename: data.mem
+                    filename: data.txt.gz
+                    format: tabix
                 scores:
                     - id: cadd_raw
                       type: float
@@ -303,21 +310,23 @@ def test_stats_np_score(tmp_path):
                       max: 4
                       x_scale: linear
                       y_scale: linear
-            """,
-            "data.mem": convert_to_tab_separated("""
-                chrom  pos_begin  pos_end  reference  alternative  s1    s2
-                1      10         15       A          G            0.02  2
-                1      10         15       A          C            0.03  -1
-                1      10         15       A          T            0.04  4
-                1      16         19       C          G            0.03  3
-                1      16         19       C          T            0.04  EMPTY
-                1      16         19       C          A            0.05  0
-                2      16         19       C          A            0.03  3
-                2      16         19       C          T            0.04  3
-                2      16         19       C          G            0.05  4
-            """)
+            """
         }
     })
+    setup_tabix(
+        tmp_path / "one" / "data.txt.gz",
+        """
+        #chrom  pos_begin  pos_end  reference  alternative  s1    s2
+        1      10         15       A          G            0.02  2
+        1      10         15       A          C            0.03  -1
+        1      10         15       A          T            0.04  4
+        1      16         19       C          G            0.03  3
+        1      16         19       C          T            0.04  EMPTY
+        1      16         19       C          A            0.05  0
+        2      16         19       C          A            0.03  3
+        2      16         19       C          T            0.04  3
+        2      16         19       C          G            0.05  4
+        """, seq_col=0, start_col=1, end_col=1)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -374,7 +383,8 @@ def test_minmax(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: position_score
                 table:
-                    filename: data.mem
+                    filename: data.txt.gz
+                    format: tabix
                 scores:
                     - id: phastCons100way
                       type: float
@@ -386,19 +396,21 @@ def test_minmax(tmp_path):
                       bins: 100
                       x_scale: linear
                       y_scale: linear
-            """,
-            "data.mem": convert_to_tab_separated("""
-                chrom  pos_begin  pos_end  s1
-                1      10         15       0.0
-                1      17         19       0.03
-                1      22         25       0.46
-                2      5          80       0.01
-                2      10         11       1.0
-                3      5          17       1.0
-                3      18         20       0.01
-            """)
+            """
         }
     })
+    setup_tabix(
+        tmp_path / "one" / "data.txt.gz",
+        """
+        #chrom  pos_begin  pos_end  s1
+        1      10         15       0.0
+        1      17         19       0.03
+        1      22         25       0.46
+        2      5          80       0.01
+        2      10         11       1.0
+        3      5          17       1.0
+        3      18         20       0.01
+        """, seq_col=0, start_col=1, end_col=1)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -424,7 +436,8 @@ def test_reference_genome_usage(tmp_path, mocker):
             GR_CONF_FILE_NAME: """
                 type: position_score
                 table:
-                    filename: data.mem
+                    filename: data.txt.gz
+                    format: tabix
                 scores:
                     - id: phastCons100way
                       type: float
@@ -439,17 +452,7 @@ def test_reference_genome_usage(tmp_path, mocker):
                 meta:
                     labels:
                         reference_genome: genome
-            """,
-            "data.mem": convert_to_tab_separated("""
-                chrom  pos_begin  pos_end  s1
-                1      10         15       0.0
-                1      17         19       0.03
-                1      22         25       0.46
-                2      5          8        0.01
-                2      10         11       1.0
-                3      5          17       1.0
-                3      18         20       0.01
-            """)
+            """
         },
         "genome": {
             GR_CONF_FILE_NAME: """
@@ -478,6 +481,18 @@ def test_reference_genome_usage(tmp_path, mocker):
 
         }
     })
+    setup_tabix(
+        tmp_path / "one" / "data.txt.gz",
+        """
+        #chrom  pos_begin  pos_end  s1
+        1      10         15       0.0
+        1      17         19       0.03
+        1      22         25       0.46
+        2      5          8        0.01
+        2      10         11       1.0
+        3      5          17       1.0
+        3      18         20       0.01
+        """, seq_col=0, start_col=1, end_col=1)
 
     repo = build_filesystem_test_repository(tmp_path)
 
@@ -504,8 +519,7 @@ def test_reference_genome_usage(tmp_path, mocker):
 
     genomic_table_length_mock = mocker.Mock(return_value=30)
     mocker.patch(
-        "dae.genomic_resources.genomic_position_table.table"
-        ".GenomicPositionTable.get_chromosome_length",
+        "dae.genomic_resources.genomic_scores.get_chromosome_length",
         new=genomic_table_length_mock
     )
 

--- a/dae/dae/genomic_resources/tests/test_cli_stats.py
+++ b/dae/dae/genomic_resources/tests/test_cli_stats.py
@@ -519,7 +519,7 @@ def test_reference_genome_usage(tmp_path, mocker):
 
     genomic_table_length_mock = mocker.Mock(return_value=30)
     mocker.patch(
-        "dae.genomic_resources.genomic_scores.get_chromosome_length",
+        "dae.genomic_resources.genomic_scores.get_chromosome_length_tabix",
         new=genomic_table_length_mock
     )
 

--- a/dae/dae/genomic_resources/tests/test_genomic_position_table.py
+++ b/dae/dae/genomic_resources/tests/test_genomic_position_table.py
@@ -11,7 +11,7 @@ from dae.genomic_resources.genomic_position_table import \
     VCFGenomicPositionTable, \
     build_genomic_position_table
 
-from dae.utils.regions import get_chromosome_length
+from dae.utils.regions import get_chromosome_length_tabix
 
 from dae.genomic_resources.testing import \
     build_inmemory_test_resource, build_filesystem_test_resource, \
@@ -1095,7 +1095,7 @@ def test_contig_length():
 
 
 def test_contig_length_tabix_table(tabix_table):
-    assert get_chromosome_length(tabix_table.pysam_file, "1") >= 13
+    assert get_chromosome_length_tabix(tabix_table.pysam_file, "1") >= 13
 
 
 def test_vcf_autodetect_format(vcf_res_autodetect_format):

--- a/dae/dae/genomic_resources/tests/test_genomic_position_table.py
+++ b/dae/dae/genomic_resources/tests/test_genomic_position_table.py
@@ -11,6 +11,8 @@ from dae.genomic_resources.genomic_position_table import \
     VCFGenomicPositionTable, \
     build_genomic_position_table
 
+from dae.utils.regions import get_chromosome_length
+
 from dae.genomic_resources.testing import \
     build_inmemory_test_resource, build_filesystem_test_resource, \
     setup_directories, convert_to_tab_separated, setup_tabix, setup_vcf
@@ -1070,6 +1072,7 @@ def test_tabix_max_buffer(
         )
 
 
+@pytest.mark.xfail(reason="Unsupported method")
 def test_contig_length():
     res = build_inmemory_test_resource({
         "genomic_resource.yaml": """
@@ -1092,7 +1095,7 @@ def test_contig_length():
 
 
 def test_contig_length_tabix_table(tabix_table):
-    assert tabix_table.get_chromosome_length("1") >= 13
+    assert get_chromosome_length(tabix_table.pysam_file, "1") >= 13
 
 
 def test_vcf_autodetect_format(vcf_res_autodetect_format):

--- a/dae/dae/genomic_resources/tests/test_reference_genome_resource.py
+++ b/dae/dae/genomic_resources/tests/test_reference_genome_resource.py
@@ -210,6 +210,44 @@ def test_reference_genome_fetch(genome_fixture):
         ]
 
 
+def test_reference_genome_fetch_corner_case(genome_fixture):
+    res = build_filesystem_test_resource(genome_fixture)
+    reference_genome = build_reference_genome_from_resource(res)
+
+    with reference_genome.open():
+        result = list(reference_genome.fetch("pesho", 1, 9))
+        assert result == [
+            "N",
+            "N",
+            "A",
+            "C",
+            "C",
+            "C",
+            "A",
+            "A",
+            "A",
+        ]
+
+
+def test_reference_genome_fetch_small_buffer(genome_fixture):
+    res = build_filesystem_test_resource(genome_fixture)
+    reference_genome = build_reference_genome_from_resource(res)
+
+    with reference_genome.open():
+        result = list(reference_genome.fetch("pesho", 1, 9, 1))
+        assert result == [
+            "N",
+            "N",
+            "A",
+            "C",
+            "C",
+            "C",
+            "A",
+            "A",
+            "A",
+        ]
+
+
 def test_reference_genome_pair_iter(genome_fixture):
     res = build_filesystem_test_resource(genome_fixture)
     reference_genome = build_reference_genome_from_resource(res)

--- a/dae/dae/utils/regions.py
+++ b/dae/dae/utils/regions.py
@@ -34,10 +34,10 @@ def split_into_regions(
     regions = []
 
     current_start = 1
-    while current_start < chrom_length:
-        end = min(chrom_length, current_start + region_size)
+    while current_start < chrom_length + 1:
+        end = min(chrom_length, current_start + region_size - 1)
         regions.append(Region(chrom, current_start, end))
-        current_start = end
+        current_start = current_start + region_size
 
     return regions
 

--- a/dae/dae/utils/regions.py
+++ b/dae/dae/utils/regions.py
@@ -36,7 +36,7 @@ def split_into_regions(
     current_start = 1
     while current_start < chrom_length:
         end = min(chrom_length, current_start + region_size)
-        regions.append(Region(chrom, current_start))
+        regions.append(Region(chrom, current_start, end))
         current_start = end
 
     return regions

--- a/dae/dae/utils/regions.py
+++ b/dae/dae/utils/regions.py
@@ -42,7 +42,7 @@ def split_into_regions(
     return regions
 
 
-def get_chromosome_length(
+def get_chromosome_length_tabix(
     tabix_file: pysam.TabixFile, chrom: str,
     step=100_000_000, precision=5_000_000
 ):

--- a/dae/dae/utils/tests/test_region.py
+++ b/dae/dae/utils/tests/test_region.py
@@ -1,5 +1,9 @@
 import pytest
-from dae.utils.regions import Region, collapse, collapse_no_chrom
+import pysam
+from dae.utils.regions import Region, collapse, collapse_no_chrom, \
+    split_into_regions, get_chromosome_length
+
+from dae.genomic_resources.testing import setup_tabix
 
 
 @pytest.mark.parametrize(
@@ -56,3 +60,67 @@ def test_collapse_no_chrom_simple(regions, expected):
     assert len(result) == len(expected)
     for res, exp in zip(result, expected):
         assert res == exp
+
+
+@pytest.mark.parametrize(
+    "chrom,chrom_length,region_size,expected",
+    [
+        ("1", 10, 5, [Region("1", 1, 6), Region("1", 6, 10)]),
+        ("1", 10, 100, [Region("1", 1, 10)]),
+        ("1", 4, 1, [
+            Region("1", 1, 2),
+            Region("1", 2, 3),
+            Region("1", 3, 4),
+            #Region("1", 4, 5)
+        ]),
+    ]
+)
+def test_split_into_regions(chrom, chrom_length, region_size, expected):
+    result = split_into_regions(chrom, chrom_length, region_size)
+
+    assert len(result) == len(expected)
+
+    for i in range(len(result)):
+        assert result[i] == expected[i], f"{result[i]} != {expected[i]}"
+
+
+@pytest.fixture()
+def sample_tabix(tmp_path):
+    filepath = tmp_path / "data.txt.gz"
+    setup_tabix(
+        filepath,
+        """
+            #chrom pos_begin pos_end
+            1     10        12
+            1     11        11
+            1     12        13
+            1     13        14
+            2     1         2
+            2     1         4
+            3     500000    500010
+        """, seq_col=0, start_col=1, end_col=2
+    )
+    return pysam.TabixFile(str(filepath))
+
+
+@pytest.mark.parametrize(
+    "precision",
+    [
+        5_000_000,
+        1000,
+        100,
+        1,
+    ]
+)
+def test_get_chrom_length(sample_tabix, precision):
+    one_length = get_chromosome_length(sample_tabix, "1", precision=precision)
+    assert one_length > 14
+    assert one_length - 14 <= precision
+    two_length = get_chromosome_length(sample_tabix, "2", precision=precision)
+    assert two_length > 4
+    assert two_length - 14 <= precision
+    three_length = get_chromosome_length(
+        sample_tabix, "3", precision=precision
+    )
+    assert three_length > 500_010
+    assert three_length - 500_010 <= precision

--- a/dae/dae/utils/tests/test_region.py
+++ b/dae/dae/utils/tests/test_region.py
@@ -81,8 +81,8 @@ def test_split_into_regions(chrom, chrom_length, region_size, expected):
 
     assert len(result) == len(expected)
 
-    for i in range(len(result)):
-        assert result[i] == expected[i], f"{result[i]} != {expected[i]}"
+    for i, res in enumerate(result):
+        assert res == expected[i], f"{res} != {expected[i]}"
 
 
 @pytest.fixture()
@@ -114,10 +114,12 @@ def sample_tabix(tmp_path):
     ]
 )
 def test_get_chrom_length(sample_tabix, precision):
-    one_length = get_chromosome_length_tabix(sample_tabix, "1", precision=precision)
+    one_length = get_chromosome_length_tabix(
+        sample_tabix, "1", precision=precision)
     assert one_length > 14
     assert one_length - 14 <= precision
-    two_length = get_chromosome_length_tabix(sample_tabix, "2", precision=precision)
+    two_length = get_chromosome_length_tabix(
+        sample_tabix, "2", precision=precision)
     assert two_length > 4
     assert two_length - 14 <= precision
     three_length = get_chromosome_length_tabix(

--- a/dae/dae/utils/tests/test_region.py
+++ b/dae/dae/utils/tests/test_region.py
@@ -65,13 +65,13 @@ def test_collapse_no_chrom_simple(regions, expected):
 @pytest.mark.parametrize(
     "chrom,chrom_length,region_size,expected",
     [
-        ("1", 10, 5, [Region("1", 1, 6), Region("1", 6, 10)]),
+        ("1", 10, 5, [Region("1", 1, 5), Region("1", 6, 10)]),
         ("1", 10, 100, [Region("1", 1, 10)]),
         ("1", 4, 1, [
-            Region("1", 1, 2),
-            Region("1", 2, 3),
-            Region("1", 3, 4),
-            #Region("1", 4, 5)
+            Region("1", 1, 1),
+            Region("1", 2, 2),
+            Region("1", 3, 3),
+            Region("1", 4, 4)
         ]),
     ]
 )

--- a/dae/dae/utils/tests/test_region.py
+++ b/dae/dae/utils/tests/test_region.py
@@ -1,7 +1,8 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 import pytest
 import pysam
 from dae.utils.regions import Region, collapse, collapse_no_chrom, \
-    split_into_regions, get_chromosome_length
+    split_into_regions, get_chromosome_length_tabix
 
 from dae.genomic_resources.testing import setup_tabix
 
@@ -113,13 +114,13 @@ def sample_tabix(tmp_path):
     ]
 )
 def test_get_chrom_length(sample_tabix, precision):
-    one_length = get_chromosome_length(sample_tabix, "1", precision=precision)
+    one_length = get_chromosome_length_tabix(sample_tabix, "1", precision=precision)
     assert one_length > 14
     assert one_length - 14 <= precision
-    two_length = get_chromosome_length(sample_tabix, "2", precision=precision)
+    two_length = get_chromosome_length_tabix(sample_tabix, "2", precision=precision)
     assert two_length > 4
     assert two_length - 14 <= precision
-    three_length = get_chromosome_length(
+    three_length = get_chromosome_length_tabix(
         sample_tabix, "3", precision=precision
     )
     assert three_length > 500_010


### PR DESCRIPTION
## Background

Regions were handled individually in different modules, resulting in duplicate code.

## Aim

Add new generic utilities for chromosome splitting and acquiring length to be used in said modules.

## Implementation
Newly added utilities are `get_chromosome_length` and `split_into_regions`. They are used in genomic scores and genomic position table. This PR also includes a fix for the bugged get_sequence method

## Related issues

Closes #419.
Closes #439.
