### PR TITLE
Switch families loader to use layout generation by default

### DIFF
--- a/dae/dae/configuration/gpf_config_parser.py
+++ b/dae/dae/configuration/gpf_config_parser.py
@@ -143,7 +143,9 @@ class GPFConfigParser:
         return cast(dict, config)
 
     @classmethod
-    def parse_and_interpolate_file(cls, filename: str) -> dict:
+    def parse_and_interpolate_file(
+        cls, filename: str, conf_dir: Optional[str] = None
+    ) -> dict:
         """Open a file and interpolate it's contents."""
         try:
             ext = os.path.splitext(filename)[1]
@@ -152,7 +154,8 @@ class GPFConfigParser:
             parser = cls.filetype_parsers[ext]
 
             file_contents = cls._get_file_contents(filename)
-            conf_dir = os.path.abspath(os.path.dirname(filename))
+            if conf_dir is None:
+                conf_dir = os.path.abspath(os.path.dirname(filename))
             return cls.parse_and_interpolate(
                 file_contents, parser, conf_dir=conf_dir)
 

--- a/dae/dae/duckdb_storage/duckdb_variants.py
+++ b/dae/dae/duckdb_storage/duckdb_variants.py
@@ -239,6 +239,7 @@ class DuckDbVariants(SqlSchema2Variants):
             ped_df.role = ped_df.role.apply(Role)  # type: ignore
             ped_df.sex = ped_df.sex.apply(Sex)  # type: ignore
             ped_df.status = ped_df.status.apply(Status)  # type: ignore
+            ped_df.loc[ped_df.layout.isna(), "layout"] = None
 
             return ped_df
 

--- a/dae/dae/duckdb_storage/duckdb_variants.py
+++ b/dae/dae/duckdb_storage/duckdb_variants.py
@@ -44,7 +44,7 @@ class DuckDbRunner(QueryRunner):
             "bigquery runner (%s) started", self.study_id)
 
         try:
-            if self.closed():
+            if self.is_closed():
                 logger.info(
                     "runner (%s) closed before execution",
                     self.study_id)
@@ -57,7 +57,7 @@ class DuckDbRunner(QueryRunner):
                     if val is None:
                         continue
                     self._put_value_in_result_queue(val)
-                    if self.closed():
+                    if self.is_closed():
                         logger.debug(
                             "query runner (%s) closed while iterating",
                             self.study_id)
@@ -87,7 +87,7 @@ class DuckDbRunner(QueryRunner):
                     "runner (%s) nobody interested",
                     self.study_id)
 
-                if self.closed():
+                if self.is_closed():
                     break
                 no_interest += 1
                 if no_interest % 1_000 == 0:

--- a/dae/dae/impala_storage/helpers/tests/test_impala_query_runner.py
+++ b/dae/dae/impala_storage/helpers/tests/test_impala_query_runner.py
@@ -42,8 +42,8 @@ def test_impala_runner_simple(impala_helpers):
     runner.close()
     time.sleep(1)
 
-    assert runner.closed()
-    assert runner.done()
+    assert runner.is_closed()
+    assert runner.is_done()
 
     executor.shutdown(wait=True)
 
@@ -70,7 +70,7 @@ def test_impala_runner_result_with_exception(impala_helpers):
         result.close()
     time.sleep(0.5)
 
-    assert runner.closed()
+    assert runner.is_closed()
 
 
 def test_impala_runner_result_experimental_1(impala_helpers):
@@ -146,4 +146,4 @@ def test_impala_runner_result_experimental(impala_helpers):
         result.close()
     time.sleep(0.5)
 
-    assert runner.closed()
+    assert runner.is_closed()

--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -91,8 +91,9 @@ class ImportProject():
         :param import_config: The config to use for the import.
         :base_input_dir: Default input dir. Use cwd by default.
         """
-        import_config = GPFConfigParser.validate_config(import_config,
-                                                        import_config_schema)
+        import_config = GPFConfigParser.validate_config(
+            import_config,
+            import_config_schema)
         normalizer = ImportConfigNormalizer()
         base_config_dir = base_input_dir
         import_config, base_input_dir, external_files = \
@@ -114,7 +115,7 @@ class ImportProject():
         """
         base_input_dir = fs_utils.containing_path(import_filename)
         import_config = GPFConfigParser.parse_and_interpolate_file(
-            import_filename)
+            import_filename, conf_dir=base_input_dir)
         project = ImportProject.build_from_config(
             import_config, base_input_dir, gpf_instance=gpf_instance)
         # the path to the import filename should be the first config file

--- a/dae/dae/inmemory_storage/raw_variants.py
+++ b/dae/dae/inmemory_storage/raw_variants.py
@@ -35,7 +35,7 @@ class RawVariantsQueryRunner(QueryRunner):
     def run(self):
         assert self._result_queue is not None
         try:
-            if self.closed():
+            if self.is_closed():
                 return
 
             while True:
@@ -51,10 +51,10 @@ class RawVariantsQueryRunner(QueryRunner):
                         self._put_value_in_result_queue(val)
                         break
                     except queue.Full:
-                        if self.closed():
+                        if self.is_closed():
                             break
 
-                if self.closed():
+                if self.is_closed():
                     break
 
         except StopIteration:

--- a/dae/dae/pedigrees/family.py
+++ b/dae/dae/pedigrees/family.py
@@ -207,9 +207,9 @@ class Person:
 
     def has_missing_parent(self):
         return \
-            (self.has_dad()
+            (self.dad is not None
              and (self.dad.generated or self.dad.not_sequenced)) \
-            or (self.has_mom()
+            or (self.mom is not None
                 and (self.mom.generated or self.mom.not_sequenced))
 
     def has_attr(self, key):
@@ -331,7 +331,10 @@ class Family:
         }
 
     def get_columns(self):
-        column_names = set(self.members_in_order[0]._attributes.keys())
+        """Collect list of columns for representing a family as data frame."""
+        column_names = set(
+            self.members_in_order[0]  # pylint: disable=protected-access
+                ._attributes.keys())
         columns = [
             col
             for col in PEDIGREE_COLUMN_NAMES.values()
@@ -627,12 +630,14 @@ class FamiliesData(Mapping[str, Family]):
 
     @staticmethod
     def from_families(families: Dict[str, Family]) -> FamiliesData:
+        """Build families data from dictionary of families."""
         families_data = FamiliesData.from_family_persons(
             {fam.family_id: fam.full_members for fam in families.values()}
         )
         # FIXME: Avoid this workaround
         for family_id, family in families.items():
-            families_data[family_id]._tags = family.tags
+            families_data[family_id]\
+                ._tags = family.tags  # pylint: disable=protected-access
 
         return families_data
 
@@ -742,22 +747,13 @@ class FamiliesData(Mapping[str, Family]):
                     result.append(person)
         return result
 
-    # def person_ids_with_parents(self):
-    #     if self._person_ids_with_parents is None:
-    #         self._person_ids_with_parents = set()
-    #         for fam in list(self._families.values()):
-    #             for p in fam.members_in_order:
-    #                 if p.has_both_parents() and (not p.has_missing_parent()):
-    #                     self._person_ids_with_parents.add(p.person_id)
-    #     return self._person_ids_with_parents
-
     def persons_with_roles(self, roles=None, family_ids=None):
         """Return list of persons matching the specified roles."""
         if family_ids is None:
             persons = self.persons.values()
         else:
             family_ids = set(family_ids)
-            persons = filter(
+            persons = filter(  # type: ignore
                 lambda p: p.family_id in family_ids,
                 self.persons.values())
 

--- a/dae/dae/pedigrees/layout.py
+++ b/dae/dae/pedigrees/layout.py
@@ -293,12 +293,13 @@ class Layout:
                 )
             )
 
-        individual_positions = [[]] * len(layout_positions)
+        individual_positions: list[list] = [[]] * len(layout_positions)
         for level, iwc in layout_positions.items():
             individual_positions[level - 1] = iwc
 
         individual_positions = [
-            sorted(level, key=lambda x: x.x) for level in individual_positions
+            sorted(level, key=lambda x: x.x)  # type: ignore
+            for level in individual_positions
         ]
 
         layout = Layout()
@@ -468,7 +469,7 @@ class Layout:
                 i += 1
 
     def _align_left(self, x_offset=10):
-        min_x = min([i.x for i in list(self._id_to_position.values())])
+        min_x = min(i.x for i in list(self._id_to_position.values()))
 
         for individual in list(self._id_to_position.values()):
             individual.x = individual.x - min_x + x_offset
@@ -712,7 +713,7 @@ class Layout:
 
             if to_move != set():
                 to_move_offset = max(
-                    [new_end - i.x + min_gap * 2.0 + i.size for i in to_move]
+                    new_end - i.x + min_gap * 2.0 + i.size for i in to_move
                 )
         else:
             new_start = min_individual.x + offset
@@ -727,7 +728,7 @@ class Layout:
 
             if to_move != set():
                 to_move_offset = min(
-                    [new_start - i.x - min_gap * 2.0 - i.size for i in to_move]
+                    new_start - i.x - min_gap * 2.0 - i.size for i in to_move
                 )
 
         for individual in individuals:
@@ -750,7 +751,8 @@ class Layout:
     def _get_first_and_last_children_positions(self, mating_unit):
         children = mating_unit.children.individuals
         children_positions = [self._id_to_position[x] for x in children]
-        children_positions = sorted(children_positions, key=lambda x: x.x)
+        children_positions = sorted(
+            children_positions, key=lambda x: x.x)  # type: ignore
 
         return [
             children_positions[0],

--- a/dae/dae/pedigrees/loader.py
+++ b/dae/dae/pedigrees/loader.py
@@ -227,7 +227,7 @@ class FamiliesLoader(CLILoader):
         ))
         arguments.append(CLIArgument(
             "--ped-layout-mode",
-            default_value="load",
+            default_value="generate",
             help_text="Layout mode specifies how pedigrees "
             "drawing of each family is handled."
             " Available options are `generate` and `load`. When "
@@ -339,6 +339,7 @@ class FamiliesLoader(CLILoader):
         **kwargs,  # pylint: disable=unused-argument
     ):
         """Read a pedigree from file."""
+        # pylint: disable=too-many-arguments, too-many-locals
         if isinstance(ped_no_role, str):
             ped_no_role = str2bool(ped_no_role)
         if isinstance(ped_no_header, str):

--- a/dae/dae/pedigrees/loader.py
+++ b/dae/dae/pedigrees/loader.py
@@ -41,35 +41,44 @@ class FamiliesLoader(CLILoader):
 
     @staticmethod
     def load_pedigree_file(
-            pedigree_filename, pedigree_format=None) -> FamiliesData:
+            pedigree_filename, pedigree_params=None) -> FamiliesData:
         """Load a pedigree files and return FamiliesData object."""
-        if pedigree_format is None:
-            pedigree_format = {}
-
-        pedigree_format["ped_no_role"] = str2bool(
-            pedigree_format.get("ped_no_role", False)
-        )
-        pedigree_format["ped_no_header"] = str2bool(
-            pedigree_format.get("ped_no_header", False)
-        )
-        pedigree_format["ped_tags"] = str2bool(
-            pedigree_format.get("ped_tags", False)
-        )
-
+        if pedigree_params is None:
+            pedigree_params = {}
         ped_df = FamiliesLoader.flexible_pedigree_read(
-            pedigree_filename, **pedigree_format
+            pedigree_filename, **pedigree_params
+        )
+        return FamiliesLoader.build_families_data_from_pedigree(
+            ped_df, pedigree_params)
+
+    @staticmethod
+    def build_families_data_from_pedigree(
+        ped_df, pedigree_params=None
+    ) -> FamiliesData:
+        """Build a families data object from a pedigree data frame."""
+        if pedigree_params is None:
+            pedigree_params = {}
+
+        pedigree_params["ped_no_role"] = str2bool(
+            pedigree_params.get("ped_no_role", False)
+        )
+        pedigree_params["ped_no_header"] = str2bool(
+            pedigree_params.get("ped_no_header", False)
+        )
+        pedigree_params["ped_tags"] = str2bool(
+            pedigree_params.get("ped_tags", False)
         )
         families = FamiliesData.from_pedigree_df(ped_df)
 
-        FamiliesLoader._build_families_layouts(families, pedigree_format)
-        FamiliesLoader._build_families_roles(families, pedigree_format)
-        FamiliesLoader._build_families_tags(families, pedigree_format)
+        FamiliesLoader._build_families_layouts(families, pedigree_params)
+        FamiliesLoader._build_families_roles(families, pedigree_params)
+        FamiliesLoader._build_families_tags(families, pedigree_params)
 
         return families
 
     @staticmethod
-    def _build_families_tags(families, pedigree_format):
-        ped_tags = pedigree_format.get("ped_tags", False)
+    def _build_families_tags(families, pedigree_params):
+        ped_tags = pedigree_params.get("ped_tags", False)
         if not ped_tags:
             return
 
@@ -77,8 +86,8 @@ class FamiliesLoader(CLILoader):
         tagger.tag_families_data(families)
 
     @staticmethod
-    def _build_families_layouts(families, pedigree_format):
-        ped_layout_mode = pedigree_format.get("ped_layout_mode", "load")
+    def _build_families_layouts(families, pedigree_params):
+        ped_layout_mode = pedigree_params.get("ped_layout_mode", "load")
         if ped_layout_mode == "generate":
             for family in families.values():
                 logger.debug(
@@ -108,17 +117,12 @@ class FamiliesLoader(CLILoader):
                 role_build.build_roles()
             families._ped_df = None  # pylint: disable=protected-access
 
-    # @staticmethod
-    # def load_simple_families_file(families_filename):
-    #     ped_df = FamiliesLoader.load_simple_family_file(families_filename)
-    #     return FamiliesData.from_pedigree_df(ped_df)
-
     def load(self) -> FamiliesData:
         if self.file_format == "simple":
             return self.load_simple_families_file(self.filename)
         assert self.file_format == "pedigree"
         return self.load_pedigree_file(
-            self.filename, pedigree_format=self.params
+            self.filename, pedigree_params=self.params
         )
 
     @classmethod

--- a/dae/dae/query_variants/sql/schema2/base_variants.py
+++ b/dae/dae/query_variants/sql/schema2/base_variants.py
@@ -6,7 +6,6 @@ from typing import Any, Tuple, Set
 import pandas as pd
 
 from dae.person_sets import PersonSetCollection
-from dae.pedigrees.family import FamiliesData
 from dae.pedigrees.loader import FamiliesLoader
 from dae.query_variants.query_runners import QueryResult, QueryRunner
 from dae.inmemory_storage.raw_variants import RawFamilyVariants
@@ -51,11 +50,8 @@ class SqlSchema2Variants(abc.ABC):
 
         self.pedigree_schema = self._fetch_schema(self.pedigree_table)
         self.ped_df = self._fetch_pedigree()
-        self.families = FamiliesData.from_pedigree_df(self.ped_df)
-        # Temporary workaround for studies that are imported without tags
-        FamiliesLoader._build_families_tags(
-            self.families, {"ped_tags": True}
-        )
+        self.families = FamiliesLoader\
+            .build_families_data_from_pedigree(self.ped_df)
 
         self.partition_descriptor = PartitionDescriptor.parse_string(
             self._fetch_tblproperties())

--- a/dae/dae/variants/attributes.py
+++ b/dae/dae/variants/attributes.py
@@ -272,6 +272,27 @@ class Inheritance(enum.Enum):
         return self.name
 
 
+def bitmask2inheritance(bitmask: int) -> set[Inheritance]:
+    """Convert a bitmask to set of inheritance."""
+    all_inheritance = set([
+        Inheritance.reference,
+        Inheritance.mendelian,
+        Inheritance.denovo,
+        Inheritance.omission,
+        Inheritance.possible_denovo,
+        Inheritance.possible_omission,
+        Inheritance.other,
+        Inheritance.missing,
+        Inheritance.unknown,
+    ])
+    result: set[Inheritance] = set()
+    for inh in all_inheritance:
+        if bitmask & inh.value:
+            result.add(inh)
+
+    return result
+
+
 class GeneticModel(enum.Enum):
     # pylint: disable=invalid-name
     autosomal = 1

--- a/dae/dae/variants/tests/test_attributes_utils.py
+++ b/dae/dae/variants/tests/test_attributes_utils.py
@@ -1,0 +1,33 @@
+# pylint: disable=redefined-outer-name,C0114,C0116,protected-access,fixme
+
+import pytest
+
+from dae.variants.attributes import bitmask2inheritance, Inheritance
+
+
+@pytest.mark.parametrize("bitmask, expected", [
+    (388, set([
+        Inheritance.denovo, Inheritance.missing, Inheritance.unknown])),
+    (386, set([
+        Inheritance.mendelian, Inheritance.missing, Inheritance.unknown])),
+    (384, set([
+        Inheritance.missing, Inheritance.unknown])),
+    (258, set([
+        Inheritance.mendelian, Inheritance.unknown])),
+    (260, set([
+        Inheritance.denovo, Inheritance.unknown])),
+    (290, set([
+        Inheritance.possible_omission, Inheritance.mendelian,
+        Inheritance.unknown])),
+    (8, set([
+        Inheritance.possible_denovo, ])),
+    (32, set([
+        Inheritance.possible_omission, ])),
+    (150, set([
+        Inheritance.omission, Inheritance.denovo,
+        Inheritance.missing, Inheritance.mendelian, ])),
+    (290 & 32, set([
+        Inheritance.possible_omission, ])),
+])
+def test_bitmask2inheritance(bitmask, expected):
+    assert bitmask2inheritance(bitmask) == expected

--- a/gcp_genotype_storage/gcp_genotype_storage/bigquery_query_runner.py
+++ b/gcp_genotype_storage/gcp_genotype_storage/bigquery_query_runner.py
@@ -22,7 +22,7 @@ class BigQueryQueryRunner(QueryRunner):
             "bigquery runner (%s) started", self.study_id)
 
         try:
-            if self.closed():
+            if self.is_closed():
                 logger.info(
                     "runner (%s) closed before execution",
                     self.study_id)
@@ -34,7 +34,7 @@ class BigQueryQueryRunner(QueryRunner):
                 if val is None:
                     continue
                 self._put_value_in_result_queue(val)
-                if self.closed():
+                if self.is_closed():
                     logger.debug(
                         "query runner (%s) closed while iterating",
                         self.study_id)
@@ -45,10 +45,10 @@ class BigQueryQueryRunner(QueryRunner):
                 "exception in runner (%s) run: %s",
                 self.study_id, type(ex), exc_info=True)
             self._put_value_in_result_queue(ex)
-        finally:
-            logger.debug(
-                "runner (%s) closing connection", self.study_id)
 
+        logger.debug(
+            "runner (%s) closing connection", self.study_id)
+        self.close()
         self._finalize(started)
 
     def _put_value_in_result_queue(self, val):
@@ -64,7 +64,7 @@ class BigQueryQueryRunner(QueryRunner):
                     "runner (%s) nobody interested",
                     self.study_id)
 
-                if self.closed():
+                if self.is_closed():
                     break
                 no_interest += 1
                 if no_interest % 1_000 == 0:


### PR DESCRIPTION
## Background

Running GPF wdae using DuckDb genotype storage shows no family variants in the user interface. It occurred that the problem is that family variants are not rendered properly by the UI because the family pedigrees have no layout.

## Aim

Switch the family data loader to use layout generation by default.

## Implementation

The CLI argument `--ped-layout-mode` default value is switched to `generate`.
Schema2 variants query classes generate the layout of the pedigree when they load the pedigree.

Initially, I suspected that the problem was connected to the inheritance filters and started looking into it. Because of this, I have added a helper function to parse inheritance bitmasks.

`GPFConfigParser` interpolation of the working directory was tweaked a bit.
