### PR TITLE
Reduce default region length cutoff back to 500_000bp.

### DIFF
--- a/dae/dae/annotation/score_annotator.py
+++ b/dae/dae/annotation/score_annotator.py
@@ -41,7 +41,7 @@ class VariantScoreAnnotatorBase(Annotator):
         "region_length_cutoff": {
             "type": "integer",
             "nullable": True,
-            "default": 25_000_000,
+            "default": 500_000,
         },
         "attributes": {
             "type": "list",
@@ -59,7 +59,7 @@ class VariantScoreAnnotatorBase(Annotator):
         self.score_queries: list[ScoreQuery] = self._collect_score_queries()
         self._annotation_schema = None
         self._region_length_cutoff = self.config.get(
-            "region_length_cutoff", 25_000_000)
+            "region_length_cutoff", 500_000)
 
     def open(self):
         self.score.open()

--- a/dae/dae/effect_annotation/annotator.py
+++ b/dae/dae/effect_annotation/annotator.py
@@ -87,17 +87,21 @@ class EffectAnnotator:
             raise ValueError("bad gene models")
         region = Region(chrom, pos_start, pos_end)
         effects = []
+        length = pos_end - pos_start + 1
         for (start, stop), tms in \
                 self.gene_models.utr_models[chrom].items():
             if region.intersection(
                     Region(chrom, start, stop)):
                 for transcript_model in tms:
-                    effects.append(
-                        EffectFactory.create_effect_with_tm(
-                            effect_type, transcript_model))
+                    effect = EffectFactory.create_effect_with_tm(
+                        effect_type, transcript_model)
+                    effect.length = length
+                    effects.append(effect)
 
         if len(effects) == 0:
-            effects.append(EffectFactory.create_effect(effect_type))
+            effect = EffectFactory.create_effect(effect_type)
+            effect.length = pos_end - pos_start + 1
+            effects.append(effect)
 
         return effects
 

--- a/dae/dae/effect_annotation/effect.py
+++ b/dae/dae/effect_annotation/effect.py
@@ -69,12 +69,28 @@ class AnnotationEffect:  # pylint: disable=too-many-instance-attributes
             f"Effect gene:{self.gene} trID:{self.transcript_id} " \
             f"strand:{self.strand} effect:{self.effect} " \
             f"protein pos:{self.prot_pos}/{self.prot_length} " \
-            f"aa: {self.aa_change}"
+            f"aa: {self.aa_change} " \
+            f"len: {self.length}"
 
     def create_effect_details(self):
         """Build effect details."""
         eff_data = [
-            (["noStart", "noEnd", "CDS", "all"], str(self.prot_length)),
+            (
+                [
+                    "CNV+",
+                    "CNV-",
+                ],
+                str(self.length)
+            ),
+            (
+                [
+                    "noStart",
+                    "noEnd",
+                    "CDS",
+                    "all"
+                ],
+                str(self.prot_length)
+            ),
             (
                 [
                     "intron",
@@ -118,7 +134,14 @@ class AnnotationEffect:  # pylint: disable=too-many-instance-attributes
             ),
             (["no-mutation"], "no-mutation"),
             (["5'UTR", "3'UTR"], str(self.dist_from_coding)),
-            (["non-coding", "unknown", "tRNA:ANTICODON"], str(self.length)),
+            (
+                [
+                    "non-coding",
+                    "unknown",
+                    "tRNA:ANTICODON"
+                ],
+                str(self.length)
+            ),
             (["promoter"], str(self.dist_from_5utr)),
         ]
 


### PR DESCRIPTION
## Background

While working on support for `Region` annotatable and configurable region length cutoff, I have changed the default value to region length cutoff to 25_000_000. This makes the `gpf_validation_data` build extremely slow and memory hungry.

## Aim

Reduce the default `region_length_cutoff` back to 500_000bp.

## Implementation

The default value for `region_length_cutoff` is changed to 500_000bp in score and effect annotators.

The effect details produced by the effect annotator for the `Region` and `CNVAllele` annotatable are changed to include the length of the annotatable.