### PR TITLE
Fix `wdae` integration testing `wdae_django_server` fixture

### DIFF
--- a/integration/remote/entrypoint.sh
+++ b/integration/remote/entrypoint.sh
@@ -62,7 +62,7 @@ rm -rf $DAE_DB_DIR/wdae/wdae_django_default.cache
     /wd/wdae/wdae/wdae_create_dev_federation_app.sh
 
 /opt/conda/bin/conda run --no-capture-output -n gpf \
-    grr_cache_repo --definition /wd/integration/grr_definition.yaml\
+    grr_cache_repo --grr /wd/integration/grr_definition.yaml\
         --instance $DAE_DB_DIR/gpf_instance.yaml
 
 while true; do

--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -16,7 +16,7 @@ from datasets_api.models import Dataset
 
 from remote.rest_api_client import RESTClient
 
-from gpf_instance.gpf_instance import WGPFInstance, get_gpf_instance,\
+from gpf_instance.gpf_instance import WGPFInstance, get_wgpf_instance,\
     reload_datasets
 
 from users_api.models import WdaeUser
@@ -154,7 +154,7 @@ def admin_client(admin, tokens):
 
 @pytest.fixture
 def datasets(db):
-    reload_datasets(get_gpf_instance())
+    reload_datasets(get_wgpf_instance())
 
 
 @pytest.fixture(scope="session")
@@ -211,19 +211,19 @@ def wdae_gpf_instance(
 ):
     reload_datasets(fixtures_wgpf_instance)
     mocker.patch(
-        "query_base.query_base.get_gpf_instance",
+        "query_base.query_base.get_wgpf_instance",
         return_value=fixtures_wgpf_instance,
     )
     mocker.patch(
-        "gpf_instance.gpf_instance.get_gpf_instance",
+        "gpf_instance.gpf_instance.get_wgpf_instance",
         return_value=fixtures_wgpf_instance,
     )
     mocker.patch(
-        "gene_sets.expand_gene_set_decorator.get_gpf_instance",
+        "gene_sets.expand_gene_set_decorator.get_wgpf_instance",
         return_value=fixtures_wgpf_instance,
     )
     mocker.patch(
-        "datasets_api.permissions.get_gpf_instance",
+        "datasets_api.permissions.get_wgpf_instance",
         return_value=fixtures_wgpf_instance,
     )
     wdae_gpf_instance._autism_gene_profile_config = None
@@ -242,19 +242,19 @@ def wdae_gpf_instance_agp(  # pylint: disable=too-many-arguments
 
     reload_datasets(wdae_gpf_instance)
     mocker.patch(
-        "query_base.query_base.get_gpf_instance",
+        "query_base.query_base.get_wgpf_instance",
         return_value=wdae_gpf_instance,
     )
     mocker.patch(
-        "gpf_instance.gpf_instance.get_gpf_instance",
+        "gpf_instance.gpf_instance.get_wgpf_instance",
         return_value=wdae_gpf_instance,
     )
     mocker.patch(
-        "gene_sets.expand_gene_set_decorator.get_gpf_instance",
+        "gene_sets.expand_gene_set_decorator.get_wgpf_instance",
         return_value=wdae_gpf_instance,
     )
     mocker.patch(
-        "datasets_api.permissions.get_gpf_instance",
+        "datasets_api.permissions.get_wgpf_instance",
         return_value=wdae_gpf_instance,
     )
 

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.utils.encoding import force_str
 
-from gpf_instance.gpf_instance import get_gpf_instance
+from gpf_instance.gpf_instance import get_wgpf_instance
 from utils.datasets import find_dataset_id_in_request
 from dae.studies.study import GenotypeData
 
@@ -35,7 +35,7 @@ class IsDatasetAllowed(permissions.BasePermission):
 
     @staticmethod
     def permitted_datasets(user):
-        dataset_ids = get_gpf_instance().get_genotype_data_ids()
+        dataset_ids = get_wgpf_instance().get_genotype_data_ids()
 
         return list(
             filter(
@@ -56,7 +56,7 @@ def get_wdae_dataset(dataset):
     """
     if isinstance(dataset, Dataset):
         return dataset
-    elif isinstance(dataset, GenotypeData):
+    if isinstance(dataset, GenotypeData):
         dataset_id = dataset.study_id
     else:
         dataset_id = force_str(dataset)
@@ -82,7 +82,7 @@ def get_genotype_data(dataset):
     else:
         dataset_id = force_str(dataset)
 
-    gpf_instance = get_gpf_instance()
+    gpf_instance = get_wgpf_instance()
     return gpf_instance.get_genotype_data(dataset_id)
 
 
@@ -239,17 +239,17 @@ def get_allowed_genotype_studies(user, dataset):
     allowed_datasets = _get_allowed_datasets_for_user(user, dataset)
 
     result = []
-    for dataset in allowed_datasets:
-        children = get_wdae_children(dataset, leaves=True)
+    for allowed_dataset in allowed_datasets:
+        children = get_wdae_children(allowed_dataset, leaves=True)
         if not children:
-            result.append(dataset)
+            result.append(allowed_dataset)
         result.extend([child.dataset_id for child in children])
     return set(result)
 
 
 def get_dataset_info(dataset_id):
     """Return a dictionary describing a Dataset object."""
-    gpf_instance = get_gpf_instance()
+    gpf_instance = get_wgpf_instance()
     study_wrapper = gpf_instance.get_wdae_wrapper(dataset_id)
     if study_wrapper is None:
         raise ValueError(f"Could not find study wrapper for {dataset_id}")
@@ -265,7 +265,7 @@ def get_dataset_info(dataset_id):
 
 def get_directly_allowed_genotype_data(user):
     """Return list of genotype data the user has direct permissions to."""
-    gpf_instance = get_gpf_instance()
+    gpf_instance = get_wgpf_instance()
     dataset_ids = gpf_instance.get_genotype_data_ids()
     user_groups = get_user_groups(user)
 

--- a/wdae/wdae/gene_sets/expand_gene_set_decorator.py
+++ b/wdae/wdae/gene_sets/expand_gene_set_decorator.py
@@ -1,9 +1,10 @@
-from gpf_instance.gpf_instance import get_gpf_instance
+from gpf_instance.gpf_instance import get_wgpf_instance
 
 from datasets_api.permissions import IsDatasetAllowed
 
 
 def expand_gene_set(request_function):
+    """Expand gene set to list of gene symbols."""
     def decorated(self, request):
         if "geneSet" in request.data:
 
@@ -13,7 +14,7 @@ def expand_gene_set(request_function):
 
             query = request.data.get("geneSet", None)
             if query is None:
-                query = dict()
+                query = {}
             gene_sets_collection = query.get("geneSetsCollection", None)
             gene_set = query.get("geneSet", None)
 
@@ -22,8 +23,8 @@ def expand_gene_set(request_function):
                 gene_set_id = gene_set
                 denovo_gene_set_spec = query.get("geneSetsTypes", [])
 
-            gpf_instance = get_gpf_instance()
-
+            gpf_instance = get_wgpf_instance()
+            assert gene_sets_collection_id is not None
             if gene_sets_collection_id.endswith("denovo"):
                 denovo_gene_sets_db = gpf_instance.denovo_gene_sets_db
 

--- a/wdae/wdae/gpf_instance/apps.py
+++ b/wdae/wdae/gpf_instance/apps.py
@@ -5,7 +5,7 @@ import pathlib
 from django.apps import AppConfig
 from django.conf import settings
 
-from gpf_instance.gpf_instance import build_wgpf_instance
+from gpf_instance.gpf_instance import get_wgpf_instance
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class WDAEConfig(AppConfig):
 
             logger.error("GPF instance config: %s", config_filename)
 
-        gpf_instance = build_wgpf_instance(config_filename)
+        gpf_instance = get_wgpf_instance(config_filename)
 
         if not settings.STUDIES_EAGER_LOADING:
             logger.info("skip preloading gpf instance...")

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -27,7 +27,7 @@ from dae.common_reports.common_report import CommonReport
 
 
 logger = logging.getLogger(__name__)
-__all__ = ["get_gpf_instance"]
+__all__ = ["get_wgpf_instance"]
 
 
 _GPF_INSTANCE: Optional[WGPFInstance] = None
@@ -283,8 +283,8 @@ class WGPFInstance(GPFInstance):
             gene_set_id, types, datasets, collection_id)
 
 
-def get_gpf_instance(config_filename=None) -> WGPFInstance:
-    build_wgpf_instance(config_filename)
+def get_wgpf_instance(config_filename=None, **kwargs) -> WGPFInstance:
+    build_wgpf_instance(config_filename, **kwargs)
     _recreated_dataset_perm()
     if _GPF_INSTANCE is None:
         raise ValueError("can't create an WGPFInstance")
@@ -319,7 +319,7 @@ def get_wgpf_instance_path(config_filename=None):
     return dae_dir
 
 
-def build_wgpf_instance(config_filename=None) -> WGPFInstance:
+def build_wgpf_instance(config_filename=None, **kwargs) -> WGPFInstance:
     """Load and return a WGPFInstance."""
     # pylint: disable=global-statement
     global _GPF_INSTANCE
@@ -327,7 +327,7 @@ def build_wgpf_instance(config_filename=None) -> WGPFInstance:
     if _GPF_INSTANCE is None:
         with _GPF_INSTANCE_LOCK:
             if _GPF_INSTANCE is None:
-                gpf_instance = WGPFInstance.build(config_filename)
+                gpf_instance = WGPFInstance.build(config_filename, **kwargs)
                 gpf_instance.load_remotes()
 
                 _GPF_INSTANCE = gpf_instance

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -283,14 +283,6 @@ class WGPFInstance(GPFInstance):
             gene_set_id, types, datasets, collection_id)
 
 
-def get_wgpf_instance(config_filename=None, **kwargs) -> WGPFInstance:
-    build_wgpf_instance(config_filename, **kwargs)
-    _recreated_dataset_perm()
-    if _GPF_INSTANCE is None:
-        raise ValueError("can't create an WGPFInstance")
-    return _GPF_INSTANCE
-
-
 def get_wgpf_instance_path(config_filename=None):
     """Return the path to the GPF instance in use."""
     if _GPF_INSTANCE is not None:
@@ -319,7 +311,7 @@ def get_wgpf_instance_path(config_filename=None):
     return dae_dir
 
 
-def build_wgpf_instance(config_filename=None, **kwargs) -> WGPFInstance:
+def get_wgpf_instance(config_filename=None, **kwargs) -> WGPFInstance:
     """Load and return a WGPFInstance."""
     # pylint: disable=global-statement
     global _GPF_INSTANCE
@@ -331,6 +323,9 @@ def build_wgpf_instance(config_filename=None, **kwargs) -> WGPFInstance:
                 gpf_instance.load_remotes()
 
                 _GPF_INSTANCE = gpf_instance
+
+    if _GPF_INSTANCE is None:
+        raise ValueError("can't create the singleton WGPFInstance")
 
     return _GPF_INSTANCE
 
@@ -356,7 +351,8 @@ def reload_datasets(gpf_instance):
             Dataset.recreate_dataset_perm(study_id)
 
 
-def _recreated_dataset_perm():
+def recreated_dataset_perm(gpf_instance):
+    """Recreate dataset permisions for a GPF instance."""
     # pylint: disable=global-statement
     global _GPF_RECREATED_DATASET_PERM
 
@@ -367,5 +363,5 @@ def _recreated_dataset_perm():
         assert _GPF_INSTANCE is not None
 
         if not _GPF_RECREATED_DATASET_PERM:
-            reload_datasets(_GPF_INSTANCE)
+            reload_datasets(gpf_instance)
             _GPF_RECREATED_DATASET_PERM = True

--- a/wdae/wdae/query_base/query_base.py
+++ b/wdae/wdae/query_base/query_base.py
@@ -1,7 +1,7 @@
 """Module containing the base view for data-related views."""
 from rest_framework import views  # type: ignore
 
-from gpf_instance.gpf_instance import get_wgpf_instance
+from gpf_instance.gpf_instance import get_wgpf_instance, recreated_dataset_perm
 from datasets_api.permissions import IsDatasetAllowed
 
 from utils.authentication import GPFOAuth2Authentication
@@ -20,6 +20,7 @@ class QueryBaseView(views.APIView):
     def __init__(self):
         super().__init__()
         self.gpf_instance = get_wgpf_instance()
+        recreated_dataset_perm(self.gpf_instance)
         self.variants_db = self.gpf_instance._variants_db
         self.pheno_db = self.gpf_instance._pheno_db
 

--- a/wdae/wdae/query_base/query_base.py
+++ b/wdae/wdae/query_base/query_base.py
@@ -1,7 +1,7 @@
 """Module containing the base view for data-related views."""
 from rest_framework import views  # type: ignore
 
-from gpf_instance.gpf_instance import get_gpf_instance
+from gpf_instance.gpf_instance import get_wgpf_instance
 from datasets_api.permissions import IsDatasetAllowed
 
 from utils.authentication import GPFOAuth2Authentication
@@ -19,7 +19,7 @@ class QueryBaseView(views.APIView):
 
     def __init__(self):
         super().__init__()
-        self.gpf_instance = get_gpf_instance()
+        self.gpf_instance = get_wgpf_instance()
         self.variants_db = self.gpf_instance._variants_db
         self.pheno_db = self.gpf_instance._pheno_db
 
@@ -29,7 +29,4 @@ class QueryBaseView(views.APIView):
 
 
 class QueryDatasetView(QueryBaseView):
-    permission_classes = (IsDatasetAllowed,)
-
-    def __init__(self):
-        super().__init__()
+    permission_classes = [IsDatasetAllowed]

--- a/wdae/wdae/users_api/management/commands/dataset_check.py
+++ b/wdae/wdae/users_api/management/commands/dataset_check.py
@@ -2,13 +2,16 @@ import logging
 
 from django.core.management.base import BaseCommand
 
+from gpf_instance.gpf_instance import get_wgpf_instance
+
 from .dataset_mixin import DatasetBaseMixin
-from gpf_instance.gpf_instance import get_gpf_instance
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand, DatasetBaseMixin):
+    """Check dataset HDFS directories."""
+
     help = "Check an existing dataset"
 
     def add_arguments(self, parser):
@@ -22,14 +25,14 @@ class Command(BaseCommand, DatasetBaseMixin):
         dataset = self.get_dataset(dataset_id)
         assert dataset is not None
 
-        logger.debug(f"dataset found: {dataset.dataset_id}")
+        logger.debug("dataset found: %s", dataset.dataset_id)
 
         assert dataset is not None
 
-        config = get_gpf_instance().get_genotype_data_config(dataset_id)
+        config = get_wgpf_instance().get_genotype_data_config(dataset_id)
         assert config is not None
 
-        genotype_data = get_gpf_instance().get_genotype_data(dataset_id)
+        genotype_data = get_wgpf_instance().get_genotype_data(dataset_id)
         print(type(genotype_data), genotype_data)
 
         if genotype_data.is_group:
@@ -38,5 +41,5 @@ class Command(BaseCommand, DatasetBaseMixin):
             assert self.is_impala_genotype_storage(config), \
                 f"genotype storage {config.genotype_storage.id} is not Impala"
 
-            self.check_dataset_hdfs_directories(config)
+            self.check_dataset_hdfs_directories(config, dataset_id)
             self.check_dataset_impala_tables(config)

--- a/wdae/wdae/users_api/management/commands/dataset_delete.py
+++ b/wdae/wdae/users_api/management/commands/dataset_delete.py
@@ -3,7 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from gpf_instance.gpf_instance import get_gpf_instance
+from gpf_instance.gpf_instance import get_wgpf_instance
 from .dataset_mixin import DatasetBaseMixin
 
 
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand, DatasetBaseMixin):
+    """Delete a dataset."""
+
     help = "Rename an existing dataset"
 
     def add_arguments(self, parser):
@@ -25,12 +27,12 @@ class Command(BaseCommand, DatasetBaseMixin):
         assert dataset is not None, \
             f"dataset {dataset_id} should exists"
 
-        logger.debug(f"dataset found: {dataset.dataset_id}")
+        logger.debug("dataset found: %s", dataset.dataset_id)
 
-        config = get_gpf_instance().get_genotype_data_config(dataset_id)
+        config = get_wgpf_instance().get_genotype_data_config(dataset_id)
         assert config is not None
 
-        genotype_data = get_gpf_instance().get_genotype_data(dataset_id)
+        genotype_data = get_wgpf_instance().get_genotype_data(dataset_id)
 
         if genotype_data.is_group:
             self.remove_study_config(dataset_id)

--- a/wdae/wdae/wdae/wgpf.py
+++ b/wdae/wdae/wdae/wgpf.py
@@ -165,7 +165,7 @@ def cli(argv=None):
 
     # pylint: disable=import-outside-toplevel
     from gpf_instance import gpf_instance
-    wgpf_instance = gpf_instance.build_wgpf_instance(args.gpf_instance)
+    wgpf_instance = gpf_instance.get_wgpf_instance(args.gpf_instance)
     logger.info("using GPF instance at %s", wgpf_instance.dae_dir)
 
     if command not in {"init", "run"}:

--- a/wdae/wdae_tests/integration/conftest.py
+++ b/wdae/wdae_tests/integration/conftest.py
@@ -125,7 +125,7 @@ def wdae_django_setup(mocker, tmp_path):
             "_GPF_INSTANCE",
             gpf)
         mocker.patch(
-            "gpf_instance.gpf_instance.build_wgpf_instance",
+            "gpf_instance.gpf_instance.get_wgpf_instance",
             return_value=gpf)
         mocker.patch.dict(
             os.environ, {
@@ -159,19 +159,17 @@ def wdae_django_setup(mocker, tmp_path):
                 "groups_api",
                 "gpfjs",
                 "query_state_save",
-                "user_queries", ]:
+                "user_queries",
+                "wdae.urls", ]:
             _module_cleaner(app_name)
 
-        _module_cleaner("django")
         _module_cleaner(test_settings)
-        _module_cleaner("wdae.test_settings")
-        _module_cleaner("wdae.settings")
-        _module_cleaner("wdae.default_settings")
         _module_cleaner("oauth2_provider")
         _module_cleaner("gpf_instance")
+        _module_cleaner("corsheaders")
+        _module_cleaner("rest_framework")
         _module_cleaner("django")
-        _module_cleaner("wdae_tests.integration")
-        _module_cleaner("pytest_django")
+
     return builder
 
 

--- a/wdae/wdae_tests/integration/test_wdae_config/test_eager_loading.py
+++ b/wdae/wdae_tests/integration/test_wdae_config/test_eager_loading.py
@@ -81,7 +81,6 @@ def test_no_eager_loading(mocker, wgpf_fixture, wdae_django_server):
         assert not wgpf_fixture.get_all_genotype_data.called
 
 
-@pytest.mark.skip(reason="django live server fixture reloading problems")
 def test_example_request(mocker, wgpf_fixture, wdae_django_server):
 
     with wdae_django_server(

--- a/wdae/wdae_tests/integration/test_wgpf_instance/test_empty_wgpf_instance.py
+++ b/wdae/wdae_tests/integration/test_wgpf_instance/test_empty_wgpf_instance.py
@@ -60,7 +60,6 @@ def alla_wgpf(tmp_path_factory):
     return gpf
 
 
-@pytest.mark.skip(reason="django live server fixture reloading problems")
 def test_empty_wgpf_instance_study(alla_wgpf, wdae_django_server):
 
     with wdae_django_server(

--- a/wdae/wdae_tests/integration/test_wgpf_instance/wgpf_settings.py
+++ b/wdae/wdae_tests/integration/test_wgpf_instance/wgpf_settings.py
@@ -2,5 +2,6 @@
 # flake8: noqa
 
 # pylint: disable=wildcard-import,unused-wildcard-import
+# type: ignore
 
 from wdae.test_settings import *


### PR DESCRIPTION
## Background

While bumping the version of Django, it becomes obvious that the `wdae_django_server` integration testing fixture has problems.

## Aim

We need a stable `wdae_django_server` testing fixture to spawn a live django server with tweaked settings.

## Implementation

I updated the `wdae_django_setup` testing fixture that is used by the `wdae_django_server`. The most important change is the list of modules removed in the fixture's tear-down phase.

Small reorganization of the access to the `wdae` singleton GPF instance using only `get_wgpf_instance`. I removed the other function (`build_wgpf_instance`) that was used for access to the singleton GPF instance.
