### PR TITLE
Don't stream summary variants to gene browser

### DIFF
--- a/wdae/wdae/gene_view/tests/test_gene_view.py
+++ b/wdae/wdae/gene_view/tests/test_gene_view.py
@@ -48,9 +48,7 @@ def test_gene_view_summary_variants_query(db, admin_client):
         content_type="application/json"
     )
     assert response.status_code == status.HTTP_200_OK
-    res = response.streaming_content
-    res = json.loads("".join(map(lambda x: x.decode("utf-8"), res)))
-
+    res = response.data
     assert len(res) == 7
     for sv in res:
         assert len(sv["alleles"]) == 2

--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -1,12 +1,9 @@
 import logging
 from rest_framework import status
 from rest_framework.response import Response
-from django.http.response import StreamingHttpResponse, FileResponse
-
+from django.http.response import FileResponse
 from query_base.query_base import QueryDatasetView
-
 from utils.logger import request_logging
-from utils.streaming_response_util import iterator_to_json
 from utils.query_params import parse_query_params
 from gene_sets.expand_gene_set_decorator import expand_gene_set
 
@@ -57,16 +54,9 @@ class QueryVariantsView(QueryDatasetView):
         config = dataset.config.gene_browser
         freq_col = config.frequency_column
 
-        variants = dataset.get_gene_view_summary_variants(freq_col, **data)
-
-        response = StreamingHttpResponse(
-            iterator_to_json(variants),
-            status=status.HTTP_200_OK,
-            content_type="text/event-stream"
+        return Response(
+            list(dataset.get_gene_view_summary_variants(freq_col, **data))
         )
-        response["Cache-Control"] = "no-cache"
-
-        return response
 
 
 class DownloadSummaryVariantsView(QueryDatasetView):


### PR DESCRIPTION
Streaming the summary variants to the gene browser significantly complicates the logic behind filtering and making requests for family variants, introducing potential for bugs with desyncing of summary and family variants. Moving to non-streaming responses for summary variants allows for much cleaner logic.