### PR TITLE
Fix missing denovo reports

### DIFF
--- a/dae/dae/common_reports/common_report.py
+++ b/dae/dae/common_reports/common_report.py
@@ -125,8 +125,6 @@ class CommonReport:
             "families_report": families_report.to_dict(full=True),
             "denovo_report": (
                 denovo_report.to_dict()
-                if not denovo_report.is_empty()
-                else None
             ),
             "study_name": genotype_data_study.name,
             "phenotype": phenotype,
@@ -148,8 +146,6 @@ class CommonReport:
             "families_report": self.families_report.to_dict(full=full),
             "denovo_report": (
                 self.denovo_report.to_dict()
-                if not self.denovo_report.is_empty()
-                else None
             ),
             "study_name": self.study_name,
             "phenotype": self.phenotype,

--- a/dae/dae/common_reports/tests/test_common_report.py
+++ b/dae/dae/common_reports/tests/test_common_report.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 from dae.common_reports.common_report import CommonReport
+from dae.common_reports.denovo_report import DenovoReport
 
 
 def test_common_report(study4):
@@ -21,4 +22,34 @@ def test_common_report(study4):
     assert common_report.study_description is None
 
     assert len(common_report.to_dict()) == 15
+    print(common_report.to_dict())
+
+
+def test_common_report_empty_denovo(study4, mocker):
+    denovo_report_mock = mocker.Mock(return_value=DenovoReport({"tables": []}))
+    mocker.patch(
+        "dae.common_reports.common_report."
+        "DenovoReport.from_genotype_study",
+        new=denovo_report_mock
+    )
+
+    common_report = CommonReport.build_report(study4)
+
+    assert common_report.study_id == "Study4"
+    assert common_report.families_report
+    assert common_report.denovo_report is not None
+    assert common_report.study_name == "Study4"
+    assert common_report.phenotype == ["phenotype1", "unaffected"]
+    assert common_report.study_type == "WE"
+    assert not common_report.study_year
+    assert not common_report.pub_med
+    assert common_report.families == 3
+    assert common_report.number_of_probands == 3
+    assert common_report.number_of_siblings == 9
+    assert common_report.denovo is True
+    assert common_report.transmitted is False
+    assert common_report.study_description is None
+
+    assert len(common_report.to_dict()) == 15
+    assert common_report.to_dict()["denovo_report"] is not None
     print(common_report.to_dict())


### PR DESCRIPTION
## Background
When we generate common reports, if a study has no denovo variants, the denovo report will be missing. Internally this is represented as a denovo report with empty tables, but when we convert this to the representing JSON, the denovo report is displayed as None, and when creating a denovo report from None, we convert it to a report with empty tables.
This is a problem because the frontend logic does not expect the denovo report to be missing.

## Aim
Denovo reports should be just an empty list of tables in the output JSON.
## Implementation
This can be fixed on the frontend too, but I decided that we should keep the representation of the common report and the internal structure the same, as it already is with every other property. This way it will be more consistent.

## Related issues
Closes #465 