### PR TITLE
Some fixes to annotate_vcf and fsspec_protocol

### DIFF
--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -62,6 +62,7 @@ def update_header(variant_file, pipeline):
     for attribute in pipeline.annotation_schema.names:
         description = pipeline.annotation_schema[attribute].description
         description = description.replace("\n", " ")
+        description = description.replace('"', '\\"')
         header.info.add(attribute, "A", "String", description)
 
 

--- a/dae/dae/genomic_resources/fsspec_protocol.py
+++ b/dae/dae/genomic_resources/fsspec_protocol.py
@@ -191,7 +191,7 @@ class FsspecReadOnlyProtocol(ReadOnlyRepositoryProtocol):
 
         import pysam  # pylint: disable=import-outside-toplevel
         return pysam.TabixFile(  # pylint: disable=no-member
-            file_url, index=index_url)
+            file_url, index=index_url, encoding="utf-8")
 
     def open_vcf_file(self, resource, filename, index_filename=None):
 


### PR DESCRIPTION
- Escape double quote symbol in VCF header descriptions, otherwise it would break the output file
- Open TabixFile using "utf-8" encoding to fix issues with Unicode characters