### PR TITLE
Fix chrom mapping through genomic scores.

### DIFF
--- a/dae/dae/genomic_resources/genomic_position_table/table.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table.py
@@ -160,14 +160,14 @@ class GenomicPositionTable(abc.ABC):
 
     def map_chromosome(self, chromosome):
         if self.rev_chrom_map is not None:
-            assert chromosome in self.rev_chrom_map.keys()
+            assert chromosome in self.rev_chrom_map
             return self.rev_chrom_map[chromosome]
 
         return chromosome
 
     def unmap_chromosome(self, chromosome):
         if self.chrom_map is not None:
-            assert chromosome in self.chrom_map.keys()
+            assert chromosome in self.chrom_map
             return self.chrom_map[chromosome]
 
         return chromosome

--- a/dae/dae/genomic_resources/genomic_position_table/table.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table.py
@@ -22,7 +22,6 @@ class GenomicPositionTable(abc.ABC):
         self.definition = Box(table_definition)
         self.chrom_map: Optional[Dict[str, str]] = None
         self.chrom_order: Optional[List[str]] = None
-        self.chrom_order_unmapped: Optional[List[str]] = None
         self.rev_chrom_map: Optional[Dict[str, str]] = None
 
         self.chrom_key: Optional[int] = None
@@ -59,7 +58,6 @@ class GenomicPositionTable(abc.ABC):
             mapping = self.definition.chrom_mapping
             if "filename" in mapping:
                 self.chrom_map = {}
-                self.chrom_order_unmapped = self.chrom_order
                 self.chrom_order = []
                 with self.genomic_resource.open_raw_file(
                         mapping["filename"], "rt") as infile:
@@ -94,7 +92,6 @@ class GenomicPositionTable(abc.ABC):
                     new_chromosomes = [
                         f"{pref}{chrom}" for chrom in new_chromosomes]
                 self.chrom_map = dict(zip(new_chromosomes, chromosomes))
-                self.chrom_order_unmapped = chromosomes
                 self.chrom_order = new_chromosomes
             self.rev_chrom_map = {
                 fch: ch for ch, fch in self.chrom_map.items()}
@@ -161,15 +158,17 @@ class GenomicPositionTable(abc.ABC):
     def get_chromosomes(self):
         return self.chrom_order
 
-    def get_chromosomes_unmapped(self):
-        if self.chrom_order_unmapped is not None:
-            return self.chrom_order_unmapped
-        return self.chrom_order
-
     def map_chromosome(self, chromosome):
         if self.rev_chrom_map is not None:
             assert chromosome in self.rev_chrom_map.keys()
             return self.rev_chrom_map[chromosome]
+
+        return chromosome
+
+    def unmap_chromosome(self, chromosome):
+        if self.chrom_map is not None:
+            assert chromosome in self.chrom_map.keys()
+            return self.chrom_map[chromosome]
 
         return chromosome
 

--- a/dae/dae/genomic_resources/genomic_position_table/table.py
+++ b/dae/dae/genomic_resources/genomic_position_table/table.py
@@ -22,6 +22,7 @@ class GenomicPositionTable(abc.ABC):
         self.definition = Box(table_definition)
         self.chrom_map: Optional[Dict[str, str]] = None
         self.chrom_order: Optional[List[str]] = None
+        self.chrom_order_unmapped: Optional[List[str]] = None
         self.rev_chrom_map: Optional[Dict[str, str]] = None
 
         self.chrom_key: Optional[int] = None
@@ -58,6 +59,7 @@ class GenomicPositionTable(abc.ABC):
             mapping = self.definition.chrom_mapping
             if "filename" in mapping:
                 self.chrom_map = {}
+                self.chrom_order_unmapped = self.chrom_order
                 self.chrom_order = []
                 with self.genomic_resource.open_raw_file(
                         mapping["filename"], "rt") as infile:
@@ -92,6 +94,7 @@ class GenomicPositionTable(abc.ABC):
                     new_chromosomes = [
                         f"{pref}{chrom}" for chrom in new_chromosomes]
                 self.chrom_map = dict(zip(new_chromosomes, chromosomes))
+                self.chrom_order_unmapped = chromosomes
                 self.chrom_order = new_chromosomes
             self.rev_chrom_map = {
                 fch: ch for ch, fch in self.chrom_map.items()}
@@ -157,6 +160,18 @@ class GenomicPositionTable(abc.ABC):
 
     def get_chromosomes(self):
         return self.chrom_order
+
+    def get_chromosomes_unmapped(self):
+        if self.chrom_order_unmapped is not None:
+            return self.chrom_order_unmapped
+        return self.chrom_order
+
+    def map_chromosome(self, chromosome):
+        if self.rev_chrom_map is not None:
+            assert chromosome in self.rev_chrom_map.keys()
+            return self.rev_chrom_map[chromosome]
+
+        return chromosome
 
     @abc.abstractmethod
     def get_file_chromosomes(self) -> List[str]:

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -403,7 +403,7 @@ class GenomicScoreImplementation(
         regions = []
         ref_genome_id = self.resource.get_labels().get("reference_genome")
         ref_genome = self._get_reference_genome_cached(grr, ref_genome_id)
-        for chrom in self.score.get_all_chromosomes():
+        for chrom in self.score.get_all_chromosomes_unmapped():
             if ref_genome is not None:
                 chrom_length = ref_genome.get_chrom_length(chrom)
             else:
@@ -413,7 +413,11 @@ class GenomicScoreImplementation(
                     self.score.table.pysam_file, chrom
                 )
             regions.extend(
-                split_into_regions(chrom, chrom_length, region_size)
+                split_into_regions(
+                    self.score.map_chromosome(chrom),
+                    chrom_length,
+                    region_size
+                )
             )
         return regions
 
@@ -1029,6 +1033,15 @@ class GenomicScore(ResourceConfigValidationMixin):
             raise ValueError(f"genomic score <{self.score_id}> is not open")
 
         return self.table.get_chromosomes()
+
+    def get_all_chromosomes_unmapped(self):
+        if not self.is_open():
+            raise ValueError(f"genomic score <{self.score_id}> is not open")
+
+        return self.table.get_chromosomes_unmapped()
+
+    def map_chromosome(self, chromosome):
+        return self.table.map_chromosome(chromosome)
 
     def get_all_scores(self):
         return list(self.score_definitions)

--- a/dae/dae/genomic_resources/genomic_scores.py
+++ b/dae/dae/genomic_resources/genomic_scores.py
@@ -411,7 +411,7 @@ class GenomicScoreImplementation(
                     raise ValueError("In memory tables are not supported")
                 chrom_length = get_chromosome_length_tabix(
                     self.score.table.pysam_file,
-                    self.score.unmap_chromosome(chrom)
+                    self.score.table.unmap_chromosome(chrom)
                 )
             regions.extend(
                 split_into_regions(
@@ -1034,12 +1034,6 @@ class GenomicScore(ResourceConfigValidationMixin):
             raise ValueError(f"genomic score <{self.score_id}> is not open")
 
         return self.table.get_chromosomes()
-
-    def map_chromosome(self, chromosome):
-        return self.table.map_chromosome(chromosome)
-
-    def unmap_chromosome(self, chromosome):
-        return self.table.unmap_chromosome(chromosome)
 
     def get_all_scores(self):
         return list(self.score_definitions)


### PR DESCRIPTION
## Background
The new utility for getting chromosome lengths interfaces directly with pysam files. The tables in the genomic scores can be configured to map chromosomes internally. The score is dependent on the table to receive an accurate list of chromosomes, but it receives a transformed list. This creates an error when using chrom mapping because the utility is unaware of the mapped chromosomes

## Aim
We should be able to use the utility with a chrom mapping set.

## Implementation
I have implemented new methods to the table and score for mapping a specific chromosome and a new getter for the original, unmodified list of chromosomes. This is a bit of a band aid solution to the problem and further improvements are open to discussion.