### PR TITLE
Fix management sorting

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -288,7 +288,12 @@ def get_directly_allowed_genotype_data(user):
                 "broken": dataset.broken
             })
 
-    return result
+    return sorted(
+        result,
+        key=lambda ds: ds["datasetName"] if ds["datasetName"] is not None
+        else ds["datasetId"]
+
+    )
 
 
 def add_group_perm_to_user(group_name, user):

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -271,7 +271,7 @@ class DatasetDescriptionView(QueryBaseView):
 class BaseDatasetPermissionsView(QueryBaseView):
     def _get_dataset_info(self, dataset):
         groups = dataset.groups.all()
-        group_names = [group.name for group in groups]
+        group_names = sorted([group.name for group in groups])
 
         user_model = get_user_model()
         users_list = []

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -285,7 +285,6 @@ class BaseDatasetPermissionsView(QueryBaseView):
                     users_list += [
                         {"name": user.name, "email": user.email}
                     ]
-                else:
                     users_found.add(user.email)
         users_list = sorted(users_list, key=lambda d: d["email"])
 

--- a/wdae/wdae/groups_api/serializers.py
+++ b/wdae/wdae/groups_api/serializers.py
@@ -43,3 +43,8 @@ class GroupRetrieveSerializer(GroupSerializer):
         return sorted([
             get_dataset_info(d.dataset_id) for d in group.dataset_set.all()
         ], key=lambda d: d["datasetName"].lower())
+
+    def to_representation(self, instance):
+        response = super().to_representation(instance)
+        response["users"] = sorted(response["users"])
+        return response

--- a/wdae/wdae/users_api/serializers.py
+++ b/wdae/wdae/users_api/serializers.py
@@ -136,6 +136,14 @@ class UserSerializer(serializers.ModelSerializer):
 
         return instance
 
+    def to_representation(self, instance):
+        response = super().to_representation(instance)
+        response["groups"] = sorted(
+            response["groups"],
+            key=lambda grp: "" if grp in ["admin", "any_user"] else grp
+        )
+        return response
+
 
 class UserWithoutEmailSerializer(UserSerializer):
     class Meta(object):


### PR DESCRIPTION
## Background
A few requests were missed when previously updating responses on the management API.

## Aim
Most of the management requests should return data with lists which are alphabetically sorted.

## Implementation
This PR features sorting for datasets and groups in datasets permissions route and groups in users route. Also included is a fix for the user duplication issue.

