### PR TITLE
Add pedigree tags for combined families in study groups

### DIFF
--- a/dae/dae/pedigrees/family.py
+++ b/dae/dae/pedigrees/family.py
@@ -801,38 +801,3 @@ class FamiliesData(Mapping[str, Family]):
                 logger.warning("second family overwrites family definition")
 
         return FamiliesData.from_families(combined_dict)
-
-    # @staticmethod
-    # def combine_studies(studies, forced=True) -> FamiliesData:
-    #     """Combine families from two studies."""
-    #     assert len(studies) > 0, studies
-
-    #     logger.info(
-    #         "building combined families from studies: %s",
-    #         [st.id for st in studies])
-
-    #     if len(studies) == 1:
-    #         return FamiliesData.copy(studies[0].families)
-
-    #     logger.info(
-    #         "combining families from study %s and from study %s",
-    #         studies[0].id, studies[1].id)
-    #     result = FamiliesData.combine(
-    #         studies[0].families,
-    #         studies[1].families)
-
-    #     if len(studies) > 2:
-    #         for sind in range(2, len(studies)):
-    #             logger.debug(
-    #                 "processing study (%s): %s", sind, studies[sind].id)
-    #             logger.info(
-    #                 "combining families from studies (%s) %s with families "
-    #                 "from study %s",
-    #                 sind, [st.study_id for st in studies[:sind]],
-    #                 studies[sind].id)
-    #             result = FamiliesData.combine(
-    #                 result,
-    #                 studies[sind].families,
-    #                 forced=forced)
-
-    #     return result

--- a/dae/dae/studies/study.py
+++ b/dae/dae/studies/study.py
@@ -628,6 +628,10 @@ class GenotypeDataGroup(GenotypeData):
                     result,
                     self.studies[sind].families,
                     forced=True)
+        # pylint: disable=import-outside-toplevel
+        from dae.pedigrees.family_tag_builder import FamilyTagsBuilder
+        tagger = FamilyTagsBuilder()
+        tagger.tag_families_data(result)
 
         return result
 


### PR DESCRIPTION
## Background

When combining families in study groups, the resulting `FamiliesData` contains newly built families. These families have no pedigree tags needed for the pedigree queries in common reports.

## Aim

Add pedigree tags to combined families in study groups.

## Implementation

An explicit call to the families tagger was added in the `GenotypeDataGroup._build_families`.
