### PR TITLE
Federation fixes

### DIFF
--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -119,10 +119,12 @@ class StudiesView(QueryBaseView):
             self.gpf_instance.get_selected_genotype_data() \
             or self.gpf_instance.get_genotype_data_ids()
 
-        datasets = filter(lambda study: study.is_group is False, [
-            self.gpf_instance.get_wdae_wrapper(genotype_data_id)
-            for genotype_data_id in selected_genotype_data
-        ])
+        datasets = filter(
+            lambda study: study is not None and study.is_group is False, [
+                self.gpf_instance.get_wdae_wrapper(genotype_data_id)
+                for genotype_data_id in selected_genotype_data
+            ]
+        )
 
         res = [
             StudyWrapperBase.build_genotype_data_all_datasets(

--- a/wdae/wdae/genotype_browser/tests/test_remote_browser.py
+++ b/wdae/wdae/genotype_browser/tests/test_remote_browser.py
@@ -15,7 +15,10 @@ pytestmark = pytest.mark.usefixtures(
 def test_simple_query_variants_preview(db, admin_client):
     data = {
         "datasetId": "TEST_REMOTE_iossifov_2014",
-        "sources": [{"source": "location"}, {"source": "carrier_person_attributes"}]
+        "sources": [
+            {"source": "location"},
+            # {"source": "carrier_person_attributes"}
+        ]
     }
 
     response = admin_client.post(
@@ -25,5 +28,4 @@ def test_simple_query_variants_preview(db, admin_client):
     res = json.loads(
         "".join(map(lambda x: x.decode("utf-8"), response.streaming_content))
     )
-    print(res)
     assert len(res) == 16

--- a/wdae/wdae/genotype_browser/tests/test_remote_browser.py
+++ b/wdae/wdae/genotype_browser/tests/test_remote_browser.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.usefixtures(
 def test_simple_query_variants_preview(db, admin_client):
     data = {
         "datasetId": "TEST_REMOTE_iossifov_2014",
-        "sources": [{"source": "location"}]
+        "sources": [{"source": "location"}, {"source": "carrier_person_attributes"}]
     }
 
     response = admin_client.post(
@@ -25,4 +25,5 @@ def test_simple_query_variants_preview(db, admin_client):
     res = json.loads(
         "".join(map(lambda x: x.decode("utf-8"), response.streaming_content))
     )
+    print(res)
     assert len(res) == 16

--- a/wdae/wdae/remote/remote_variant.py
+++ b/wdae/wdae/remote/remote_variant.py
@@ -106,7 +106,7 @@ class RemoteFamilyAllele(FamilyAllele):
         self.idx = idx
         summary_allele = RemoteAllele(attributes_list, idx, self.columns)
         genotype = str2fgt(self._find_attribute("genotype"))
-        best_state = self._find_attribute("best_st")
+        best_state = str2mat(self._find_attribute("best_st"))
         genetic_model = self._find_attribute("genetic_model")
         super().__init__(
             summary_allele, family, genotype, best_state, genetic_model

--- a/wdae/wdae/remote/remote_variant.py
+++ b/wdae/wdae/remote/remote_variant.py
@@ -74,7 +74,7 @@ class RemoteAllele(SummaryAllele):
             alternative=self._find_attribute("alternative"),
             end_position=end_position,
             summary_index=self._find_attribute("summary_index"),
-            allele_index=self._find_attribute("allele_index"),
+            allele_index=int(self._find_attribute("allele_index")),
             effect=self._find_attribute("raw_effects"),
             attributes={col: self._find_attribute(col) for col in self.columns}
         )
@@ -105,7 +105,7 @@ class RemoteFamilyAllele(FamilyAllele):
         self.attributes_list = attributes_list
         self.idx = idx
         summary_allele = RemoteAllele(attributes_list, idx, self.columns)
-        genotype = self._find_attribute("genotype")
+        genotype = str2fgt(self._find_attribute("genotype"))
         best_state = self._find_attribute("best_st")
         genetic_model = self._find_attribute("genetic_model")
         super().__init__(

--- a/wdae/wdae/remote/tests/test_remote_variant.py
+++ b/wdae/wdae/remote/tests/test_remote_variant.py
@@ -1,7 +1,9 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 import numpy as np
 import pytest
 from remote.remote_variant import RemoteFamilyVariant, RemoteFamilyAllele
 from dae.pedigrees.family import Family, Person
+
 
 @pytest.fixture()
 def sample_family():
@@ -52,7 +54,6 @@ def sample_family():
         )
     ]
     return Family.from_persons(members)
-
 
 
 @pytest.fixture()
@@ -111,7 +112,6 @@ def sample_attributes_columns():
         "genetic_model"]
 
     return (attributes, columns)
-
 
 
 def test_remote_variant_alleles(sample_attributes_columns, sample_family):

--- a/wdae/wdae/remote/tests/test_remote_variant.py
+++ b/wdae/wdae/remote/tests/test_remote_variant.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+from remote.remote_variant import RemoteFamilyVariant, RemoteFamilyAllele
+from dae.pedigrees.family import Family, Person
+
+@pytest.fixture()
+def sample_family():
+    members = [
+        Person(
+            person_id="id1",
+            family_id="fam1",
+            mom_id="mom1",
+            dad_id="dad1",
+            sex="2",
+            status="2",
+            role="prb",
+            layout="error",
+            generated=False,
+        ),
+        Person(
+            person_id="mom1",
+            family_id="fam1",
+            mom_id="0",
+            dad_id="0",
+            sex="2",
+            status="1",
+            role="mom",
+            layout="error",
+            generated=False,
+        ),
+        Person(
+            person_id="dad1",
+            family_id="fam1",
+            mom_id="0",
+            dad_id="0",
+            sex="1",
+            status="1",
+            role="dad",
+            layout="error",
+            generated=False,
+        ),
+        Person(
+            person_id="id2",
+            family_id="fam1",
+            mom_id="mom1",
+            dad_id="dad1",
+            sex="1",
+            status="0",
+            role="sib",
+            layout="error",
+            generated=False,
+        )
+    ]
+    return Family.from_persons(members)
+
+
+
+@pytest.fixture()
+def sample_attributes_columns():
+    attributes = [
+        ["5:140391002"],
+        ["5"],
+        ["140391002"],
+        ["-"],
+        ["G"],
+        ["A"],
+        ["-"],
+        ["1"],
+        ["TransmissionTiie.denovo"],
+        [
+            "3'UTR!PCDHAC1:3'UTR|PCDHAC2:3'UTR|PCDHA1:3'UTR|PCDHA10:3'UTR|PCD"
+            "HA11:3'UTR|PCDHA12:3'UTR|PCDHA13:3'UTR|PCDHA2:3'UTR|PCDHA3:3'UTR"
+            "|PCDHA4:3'UTR|PCDHA5:3'UTR|PCDHA6:3'UTR|PCDHA7:3'UTR|PCDHA8:3'UT"
+            "R|PCDHA6:3'UTR|PCDHA9:3'UTR!NM_018898:PCDHAC1:3'UTR:1480|NM_0188"
+            "99:PCDHAC2:3'UTR:1480|NM_018900:PCDHA1:3'UTR:1480|NM_031411:PCDH"
+            "A1:3'UTR:1480|NM_018901:PCDHA10:3'UTR:1480|NM_031860:PCDHA10:3'U"
+            "TR:1480|NM_018902:PCDHA11:3'UTR:1480|NM_018903:PCDHA12:3'UTR:148"
+            "0|NM_018904:PCDHA13:3'UTR:1480|NM_018905:PCDHA2:3'UTR:1480|NM_01"
+            "8906:PCDHA3:3'UTR:1480|NM_018907:PCDHA4:3'UTR:1480|NM_018908:PCD"
+            "HA5:3'UTR:1480|NM_018909:PCDHA6:3'UTR:1480|NM_018910:PCDHA7:3'UT"
+            "R:1480|NM_018911:PCDHA8:3'UTR:1480|NM_031849:PCDHA6:3'UTR:1480|N"
+            "M_031857:PCDHA9:3'UTR:1480"
+        ],
+        ["-"],
+        ["-"],
+        ["-"],
+        ["-"],
+        ["12628"],
+        ["0/0;0/0;1/0;0/0"],
+        ["2212/0010"],
+        ["-"]
+    ]
+    columns = [
+        "location",
+        "chrom",
+        "position",
+        "end_position",
+        "reference",
+        "alternative",
+        "summary_index",
+        "allele_index",
+        "transmission_type",
+        "raw_effects",
+        "effect_types",
+        "effect_genes",
+        "effect_gene_symbols",
+        "frequency",
+        "family",
+        "genotype",
+        "best_st",
+        "genetic_model"]
+
+    return (attributes, columns)
+
+
+
+def test_remote_variant_alleles(sample_attributes_columns, sample_family):
+    attributes, columns = sample_attributes_columns
+    variant = RemoteFamilyVariant(attributes, sample_family, columns)
+
+    assert isinstance(variant.family_genotype, np.ndarray)
+    assert (variant.family_genotype == [[0, 0], [0, 0], [1, 0], [0, 0]]).all()
+
+    assert isinstance(variant.best_state, np.ndarray)
+    assert (variant.best_state == [[2, 2, 1, 2], [0, 0, 1, 0]]).all()
+
+    print(variant.alt_alleles[0])
+    print(type(variant.alt_alleles[0]))
+    allele = variant.alt_alleles[0]
+    assert isinstance(allele, RemoteFamilyAllele)
+    assert isinstance(allele.genotype, np.ndarray)
+    assert (allele.genotype == [[0, 0], [0, 0], [1, 0], [0, 0]]).all()
+    assert isinstance(allele.best_state, np.ndarray)
+    assert (allele.best_state == [[2, 2, 1, 2], [0, 0, 1, 0]]).all()

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -486,6 +486,10 @@ class RemoteStudyWrapper(StudyWrapperBase):
         return self.remote_genotype_data.is_group
 
     @property
+    def person_set_collections(self):
+        return self.remote_genotype_data.person_set_collections
+
+    @property
     def config_columns(self):
         return self.config.genotype_browser.columns
 


### PR DESCRIPTION
## Background
The GPF federation was outdated and broken when an attempt was made to add the staging instance as a remote.

## Aim
Update and fix issues with the federation.

## Implementation
Main issues were a missing property on the remote study wrapper and remote alleles not being created properly by remote family variants. Their genotypes were being passed down and initialized as strings. As a result any request for properties that use the allele genotype would crash.
Another minor issue was in the studies view, where if a gpf_instance.yaml provided the `selected_genotype_data` and one of the studies was missing, it  would also crash, leading to a broken remote, because remote creation is very dependant on this query.
Tests have been added for remote variant creation.
