### PR TITLE
Gene scores db refactor

### DIFF
--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -313,7 +313,7 @@ def build_annotation_pipeline(
         except ValueError as value_error:
             raise AnnotationConfigurationError(
                 f"The {annotator_id+1}-th annotator "
-                f"configuaraion {raw_config_copy} is incorrect: ",
+                f"configuration {raw_config_copy} is incorrect: ",
                 value_error) from value_error
 
     return pipeline

--- a/dae/dae/annotation/tests/test_annotate_columns_cnv_pipeline.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_cnv_pipeline.py
@@ -87,14 +87,14 @@ def annotate_cnv_fixture(tmp_path_factory):
                     "genomic_resource.yaml": textwrap.dedent("""
                         type: gene_score
                         filename: score.csv
-                        gene_scores:
+                        scores:
                         - id: gene_score1
                           desc: Test gene score
-                        histograms:
-                        - score: gene_score1
-                          bins: 100
-                          min: 0.0
-                          max: 56.0
+                          number_hist:
+                            number_of_bins: 100
+                            view_range:
+                              min: 0.0
+                              max: 56.0
                     """),
                     "score.csv": textwrap.dedent("""
                         gene,gene_score1

--- a/dae/dae/annotation/tests/test_gene_score_annotator.py
+++ b/dae/dae/annotation/tests/test_gene_score_annotator.py
@@ -17,14 +17,13 @@ def scores_repo(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: gene_score
                 filename: LGD.csv
-                gene_scores:
+                scores:
                   - id: LGD_rank
                     desc: LGD rank
-                histograms:
-                  - score: LGD_rank
-                    bins: 150
-                    x_scale: linear
-                    y_scale: linear
+                    number_hist:
+                      number_of_bins: 150
+                      x_log_scale: false
+                      y_log_scale: false
                 """,
             "LGD.csv": textwrap.dedent("""
                 "gene","LGD_score","LGD_rank"

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -233,21 +233,23 @@ class GeneScore(
             </a>
 
             <h3>Gene score definitions:</h2>
-            {% for score in data["gene_scores"] %}
+            {% for score in data["scores"] %}
             <div class="score-definition">
             <p>Gene score ID: {{ score["id"] }}</p>
             <p>Description: {{ score["desc"] }}
             </div>
             {% endfor %}
             <h3>Histograms:</h2>
-            {% for hist in data["histograms"] %}
+            {% for score in data["scores"] %}
+            {% if score["number_hist"] %}
             <div class="histogram">
-            <h4>{{ hist["score"] }}</h1>
+            <h4>{{ score["id"] }}</h1>
             <img src="{{ data["statistics_dir"] }}/{{ hist["img_file"] }}"
             width="200px"
             alt={{ hist["score"] }}
             title={{ hist["score"] }}>
             </div>
+            {% endif %}
             {% endfor %}
             {% endblock %}
         """))
@@ -257,10 +259,11 @@ class GeneScore(
 
         statistics = self.get_statistics()
         data["statistics_dir"] = statistics.get_statistics_folder()
-        if "histograms" in data:
-            for hist_config in data["histograms"]:
-                hist_config["img_file"] = statistics.get_histogram_image_file(
-                    hist_config["score"]
+        for score in data["scores"]:
+            if "number_hist" in score:
+                score["number_hist"]["img_file"] = \
+                    statistics.get_histogram_image_file(
+                        score["id"]
                 )
 
         return data

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -215,9 +215,15 @@ class GeneScoreImplementation(
         config = self.get_config()
         score_filename = config["filename"]
         return json.dumps({
-            "config": {
-                "scores": config["scores"],
-            },
+            "score_config": [(
+                score_id,
+                self.gene_score.get_desc(score_id),
+                self.gene_score.get_min(score_id),
+                self.gene_score.get_max(score_id),
+                self.gene_score.get_range(score_id),
+                self.gene_score.get_x_scale(score_id),
+                self.gene_score.get_y_scale(score_id)
+            ) for score_id in self.gene_score.get_scores()],
             "score_file": manifest[score_filename].md5
         }, sort_keys=True, indent=2).encode()
 

--- a/dae/dae/gene/gene_scores.py
+++ b/dae/dae/gene/gene_scores.py
@@ -322,8 +322,7 @@ class GeneScore(
         score_filename = config["filename"]
         return json.dumps({
             "config": {
-                "gene_scores": config["gene_scores"],
-                "histograms": config["histograms"]
+                "scores": config["scores"],
             },
             "score_file": manifest[score_filename].md5
         }, sort_keys=True, indent=2).encode()

--- a/dae/dae/gene/tests/test_gene_score.py
+++ b/dae/dae/gene/tests/test_gene_score.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from dae.genomic_resources.testing import build_inmemory_test_repository
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME
-from dae.gene.gene_scores import GeneScore, GeneScoreCollection
+from dae.gene.gene_scores import GeneScore, build_gene_score_from_resource
 
 
 @pytest.fixture
@@ -16,14 +16,13 @@ def scores_repo(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: gene_score
                 filename: linear.csv
-                gene_scores:
+                scores:
                 - id: linear
                   desc: linear gene score
-                histograms:
-                - score: linear
-                  bins: 3
-                  x_scale: linear
-                  y_scale: linear
+                  number_hist:
+                    number_of_bins: 3
+                    x_log_scale: false
+                    y_log_scale: false
                 """,
             "linear.csv": textwrap.dedent("""
                 gene,linear
@@ -46,12 +45,13 @@ def scores_repo(tmp_path):
                     - 2.333
                     - 3.0
                     config:
-                      bins: 10
+                      number_of_bins: 3
                       score: linear
-                      max: 3.0
-                      min: 1.0
-                      x_scale: linear
-                      y_scale: linear
+                      view_range:
+                        max: 3.0
+                        min: 1.0
+                      x_log_scale: false
+                      y_log_scale: false
                 """)
             }
         },
@@ -59,17 +59,17 @@ def scores_repo(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: gene_score
                 filename: log.csv
-                gene_scores:
+                scores:
                 - id: log
                   desc: log gene score
-                histograms:
-                - score: log
-                  bins: 5
-                  min: 0.0
-                  max: 1.0
-                  x_min_log: 0.001
-                  x_scale: log
-                  y_scale: linear
+                  number_hist:
+                    number_of_bins: 5
+                    view_range:
+                      min: 0.0
+                      max: 1.0
+                    x_min_log: 0.001
+                    x_log_scale: true
+                    y_log_scale: false
                 """,
             "log.csv": textwrap.dedent("""
                 gene,log
@@ -96,13 +96,15 @@ def scores_repo(tmp_path):
                     - 0.1778279410038923,
                     - 1.0
                     config:
-                      score: log
-                      bins: 5
-                      min: 0.0
-                      max: 1.0
+                      desc: log gene score
+                      number_hist:
+                      number_of_bins: 5
+                      view_range:
+                        min: 0.0
+                        max: 1.0
                       x_min_log: 0.001
-                      x_scale: log
-                      y_scale: linear
+                      x_log_scale: true
+                      y_log_scale: false
                 """)
             }
         },
@@ -113,7 +115,7 @@ def scores_repo(tmp_path):
             GR_CONF_FILE_NAME: """
                 type: gene_score
                 filename: oops.csv
-                gene_scores:
+                scores:
                 - id: linear
                   desc: linear gene score
                 """,
@@ -136,26 +138,6 @@ def scores_repo(tmp_path):
                 G3,3
             """)
         },
-        "OopsMissingHist": {
-            GR_CONF_FILE_NAME: """
-                type: gene_score
-                filename: linear.csv
-                gene_scores:
-                - id: linear
-                  desc: linear gene score
-                histograms:
-                - score: alabala
-                  bins: 3
-                  x_scale: linear
-                  y_scale: linear
-                """,
-            "linear.csv": textwrap.dedent("""
-                gene,alabala
-                G1,1
-                G2,2
-                G3,3
-            """)
-        },
     })
     return scores_repo
 
@@ -165,14 +147,15 @@ def test_load_linear_gene_scores_from_resource(scores_repo):
     res = scores_repo.get_resource("LinearHist")
     assert res.get_type() == "gene_score"
 
-    result = GeneScore.load_gene_scores_from_resource(res)
-    assert len(result) == 1
+    result = build_gene_score_from_resource(res)
+    scores = result.get_scores()
+    assert len(scores) == 1
+    score_id = scores[0]
 
-    gene_score = result[0]
-    assert gene_score.x_scale == "linear"
-    assert gene_score.y_scale == "linear"
+    assert result.get_x_scale(score_id) == "linear"
+    assert result.get_y_scale(score_id) == "linear"
 
-    hist = gene_score.histogram
+    hist = result.get_histogram(score_id)
     assert len(hist.bins) == 4
 
     assert np.all(hist.bars == np.array([2, 2, 2]))
@@ -183,14 +166,15 @@ def test_load_log_gene_scores_from_resource(scores_repo):
     res = scores_repo.get_resource("LogHist")
     assert res.get_type() == "gene_score"
 
-    result = GeneScore.load_gene_scores_from_resource(res)
-    assert len(result) == 1
+    result = build_gene_score_from_resource(res)
+    scores = result.get_scores()
+    assert len(scores) == 1
+    score_id = scores[0]
 
-    gene_score = result[0]
-    assert gene_score.x_scale == "log"
-    assert gene_score.y_scale == "linear"
+    assert result.get_x_scale(score_id) == "log"
+    assert result.get_y_scale(score_id) == "linear"
 
-    hist = gene_score.histogram
+    hist = result.get_histogram(score_id)
     assert len(hist.bins) == 6
 
     assert np.all(hist.bars == np.array([2, 1, 1, 1, 1]))
@@ -199,48 +183,42 @@ def test_load_log_gene_scores_from_resource(scores_repo):
 def test_load_wrong_resource_type(scores_repo):
     res = scores_repo.get_resource("Oops")
     with pytest.raises(ValueError, match="invalid resource type Oops"):
-        GeneScore.load_gene_scores_from_resource(res)
+        build_gene_score_from_resource(res)
 
 
 def test_load_gene_score_without_histogram(scores_repo):
     res = scores_repo.get_resource("OopsHist")
-    with pytest.raises(ValueError, match="missing histograms config OopsHist"):
-        GeneScore.load_gene_scores_from_resource(res)
+    with pytest.raises(
+        ValueError, 
+        match="Missing histogram config for linear in OopsHist"
+    ):
+        build_gene_score_from_resource(res)
 
 
 def test_load_gene_score_without_gene_scores(scores_repo):
     res = scores_repo.get_resource("OopsScores")
     with pytest.raises(ValueError,
-                       match="missing gene_scores config OopsScores"):
-        GeneScore.load_gene_scores_from_resource(res)
-
-
-def test_load_gene_score_with_missing_score_hist(scores_repo):
-    res = scores_repo.get_resource("OopsMissingHist")
-    with pytest.raises(ValueError,
-                       match="missing histogram config for score linear in "
-                       "resource OopsMissingHist"):
-        GeneScore.load_gene_scores_from_resource(res)
+                       match="missing scores config in OopsScores"):
+        build_gene_score_from_resource(res)
 
 
 def test_gene_score(scores_repo):
 
     res = scores_repo.get_resource("LinearHist")
-    result = GeneScore.load_gene_scores_from_resource(res)
-    assert len(result) == 1
+    gene_score = build_gene_score_from_resource(res)
 
-    gene_score = result[0]
+    assert gene_score is not None
 
-    assert gene_score.get_gene_value("G2") == 2
-    assert gene_score.get_gene_value("G3") == 3
+    assert gene_score.get_gene_value("linear", "G2") == 2
+    assert gene_score.get_gene_value("linear", "G3") == 3
 
 
 def test_calculate_histogram(scores_repo):
     res = scores_repo.get_resource("LinearHist")
-    result = GeneScore.load_gene_scores_from_resource(res)
-    assert len(result) == 1
+    result = build_gene_score_from_resource(res)
+    assert result is not None
 
-    histogram = GeneScoreCollection._calc_histogram(res, "linear")
+    histogram = GeneScore._calc_histogram(res, "linear")
     assert histogram is not None
     print(histogram.config.view_range[0])
     print(type(histogram.config.view_range[0]))

--- a/dae/dae/gene/tests/test_gene_score.py
+++ b/dae/dae/gene/tests/test_gene_score.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from dae.genomic_resources.testing import build_inmemory_test_repository
 from dae.genomic_resources.repository import GR_CONF_FILE_NAME
-from dae.gene.gene_scores import GeneScore, build_gene_score_from_resource
+from dae.gene.gene_scores import GeneScore, build_gene_score_from_resource, \
+    GeneScoreImplementation
 
 
 @pytest.fixture
@@ -218,7 +219,7 @@ def test_calculate_histogram(scores_repo):
     result = build_gene_score_from_resource(res)
     assert result is not None
 
-    histogram = GeneScore._calc_histogram(res, "linear")
+    histogram = GeneScoreImplementation._calc_histogram(res, "linear")
     assert histogram is not None
     print(histogram.config.view_range[0])
     print(type(histogram.config.view_range[0]))

--- a/dae/dae/genomic_resources/tests/test_implementation_plugins.py
+++ b/dae/dae/genomic_resources/tests/test_implementation_plugins.py
@@ -1,11 +1,11 @@
-from dae.gene.gene_scores import build_gene_score_collection_from_resource
+from dae.gene.gene_scores import build_gene_score_from_resource
 from dae.genomic_resources import get_resource_implementation_builder, \
     register_implementation
 
 
 def test_register_implementation():
     register_implementation(
-        "test_gene_score", build_gene_score_collection_from_resource
+        "test_gene_score", build_gene_score_from_resource
     )
 
     assert get_resource_implementation_builder("test_gene_score") is not None

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -159,7 +159,8 @@ class GPFInstance:
     @cached_property
     def gene_scores_db(self):
         """Load and return gene scores db."""
-        from dae.gene.gene_scores import GeneScoresDb, GeneScoreCollection
+        from dae.gene.gene_scores import GeneScoresDb, \
+            build_gene_score_from_resource
         if self.dae_config.gene_scores_db is None:
             return GeneScoresDb([])
 
@@ -170,7 +171,7 @@ class GPFInstance:
             if resource is None:
                 logger.error("unable to find gene score: %s", score)
                 continue
-            collections.append(GeneScoreCollection(resource))
+            collections.append(build_gene_score_from_resource(resource))
 
         return GeneScoresDb(collections)
 
@@ -345,8 +346,14 @@ class GPFInstance:
     def get_gene_score(self, gene_score_id):
         return self.gene_scores_db.get_gene_score(gene_score_id)
 
+    def get_gene_score_desc(self, score_id):
+        return self.gene_scores_db.get_score_desc(score_id)
+
     def get_all_gene_scores(self):
         return self.gene_scores_db.get_gene_scores()
+
+    def get_all_gene_score_descs(self):
+        return self.gene_scores_db.get_scores()
 
     # Common reports
     def get_common_report(self, study_id):

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
 
     [dae.genomic_resources.implementations]
     gene_set=dae.gene.gene_sets_db:build_gene_set_collection_from_resource
-    gene_score=dae.gene.gene_scores:build_gene_score_from_resource
+    gene_score=dae.gene.gene_scores:build_gene_score_implementation_from_resource
     position_score=dae.genomic_resources.genomic_scores:GenomicScoreImplementation
     np_score=dae.genomic_resources.genomic_scores:GenomicScoreImplementation
     allele_score=dae.genomic_resources.genomic_scores:GenomicScoreImplementation

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
 
     [dae.genomic_resources.implementations]
     gene_set=dae.gene.gene_sets_db:build_gene_set_collection_from_resource
-    gene_score=dae.gene.gene_scores:build_gene_score_collection_from_resource
+    gene_score=dae.gene.gene_scores:build_gene_score_from_resource
     position_score=dae.genomic_resources.genomic_scores:GenomicScoreImplementation
     np_score=dae.genomic_resources.genomic_scores:GenomicScoreImplementation
     allele_score=dae.genomic_resources.genomic_scores:GenomicScoreImplementation

--- a/dae_conftests/dae_conftests/tests/fixtures/test_repo/gene_scores/LGD/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/test_repo/gene_scores/LGD/genomic_resource.yaml
@@ -1,17 +1,15 @@
 type: gene_score
 filename: LGD.csv
-gene_scores:
+scores:
   - id: LGD_rank
     desc: LGD rank
+    number_hist:
+      number_of_bins: 150
+      x_log_scale: false
+      y_log_scale: false
   - id: LGD_score
     desc: LGD score
-
-histograms:
-  - score: LGD_rank
-    bins: 150
-    x_scale: linear
-    y_scale: linear
-  - score: LGD_score
-    bins: 150
-    x_scale: linear
-    y_scale: log
+    number_hist:
+      number_of_bins: 150
+      x_log_scale: false
+      y_log_scale: true

--- a/dae_conftests/dae_conftests/tests/fixtures/test_repo/gene_scores/RVIS/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/test_repo/gene_scores/RVIS/genomic_resource.yaml
@@ -1,17 +1,15 @@
 type: gene_score
 filename: RVIS.csv
-gene_scores:
+scores:
   - id: RVIS_rank
     desc: RVIS rank
+    number_hist:
+      number_of_bins: 150
+      x_log_scale: false
+      y_log_scale: false
   - id: RVIS
     desc: RVIS
-
-histograms:
-  - score: RVIS_rank
-    bins: 150
-    x_scale: linear
-    y_scale: linear
-  - score: RVIS
-    bins: 150
-    x_scale: linear
-    y_scale: log
+    number_hist:
+      number_of_bins: 150
+      x_log_scale: false
+      y_log_scale: true

--- a/dae_conftests/dae_conftests/tests/fixtures/test_repo/gene_scores/SFARI_gene_score/genomic_resource.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/test_repo/gene_scores/SFARI_gene_score/genomic_resource.yaml
@@ -1,11 +1,9 @@
 type: gene_score
 filename: SFARI.csv
-gene_scores:
+scores:
   - id: SFARI_gene_score
     desc: SFARI gene score
-
-histograms:
-  - score: SFARI_gene_score
-    bins: 8
-    x_scale: linear
-    y_scale: linear
+    number_hist:
+      number_of_bins: 8
+      x_log_scale: false
+      y_log_scale: false

--- a/wdae/wdae/enrichment_api/views.py
+++ b/wdae/wdae/enrichment_api/views.py
@@ -123,10 +123,14 @@ class EnrichmentTestView(QueryDatasetView):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
             if gene_score_id in self.gene_scores_db:
-                gene_score = self.gene_scores_db.get_gene_score(
+                score_desc = self.gpf_instance.get_gene_score_desc(
                     gene_score_id
                 )
+                gene_score = self.gene_scores_db.get_gene_score(
+                    score_desc.resource_id
+                )
                 gene_syms = gene_score.get_genes(
+                    gene_score_id,
                     score_min=range_start,
                     score_max=range_end
                 )

--- a/wdae/wdae/gene_scores/tests/test_gene_scores.py
+++ b/wdae/wdae/gene_scores/tests/test_gene_scores.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 import pytest
 
 pytestmark = pytest.mark.usefixtures(
@@ -13,19 +14,25 @@ def test_lgd_rank_available(gene_scores_db):
 
 
 def test_get_lgd_rank(gene_scores_db):
-    w = gene_scores_db["LGD_rank"]
+    score = gene_scores_db.get_gene_score("gene_scores/LGD")
 
-    assert w is not None
-    assert w.min() == pytest.approx(1.0, 0.01)
-    assert w.max() == pytest.approx(18394.5, 0.01)
+    assert score is not None
+    assert score.get_min("LGD_rank") == pytest.approx(1.0, 0.01)
+    assert score.get_max("LGD_rank") == pytest.approx(18394.5, 0.01)
 
 
 def test_get_genes_by_score(gene_scores_db):
-    g = gene_scores_db["LGD_rank"].get_genes(1.5, 5.0)
-    assert len(g) == 3
+    genes = gene_scores_db.get_gene_score("gene_scores/LGD").get_genes(
+        "LGD_rank", 1.5, 5.0
+    )
+    assert len(genes) == 3
 
-    g = gene_scores_db["LGD_rank"].get_genes(-1, 5.0)
-    assert len(g) == 4
+    genes = gene_scores_db.get_gene_score("gene_scores/LGD").get_genes(
+        "LGD_rank", -1, 5.0
+    )
+    assert len(genes) == 4
 
-    g = gene_scores_db["LGD_rank"].get_genes(1.0, 5.0)
-    assert len(g) == 4
+    genes = gene_scores_db.get_gene_score("gene_scores/LGD").get_genes(
+        "LGD_rank", 1.0, 5.0
+    )
+    assert len(genes) == 4

--- a/wdae/wdae/studies/query_transformer.py
+++ b/wdae/wdae/studies/query_transformer.py
@@ -57,11 +57,14 @@ class QueryTransformer:
         range_end = gene_scores.get("rangeEnd", None)
 
         if scores_name and scores_name in self.study_wrapper.gene_scores_db:
-            score = self.study_wrapper.gene_scores_db[
+            score_desc = self.study_wrapper.gene_scores_db[
                 scores_name
             ]
+            score = self.study_wrapper.gene_scores_db.get_gene_score(
+                score_desc.resource_id
+            )
 
-            genes = score.get_genes(range_start, range_end)
+            genes = score.get_genes(scores_name, range_start, range_end)
 
             return list(genes)
 

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -214,10 +214,16 @@ class ResponseTransformer:
             if gwc not in self.study_wrapper.gene_scores_db:
                 continue
 
-            gene_scores = self.study_wrapper.gene_scores_db[gwc]
             if gene != "":
+                score_desc = self.study_wrapper.gene_scores_db.get_score_desc(
+                    gwc
+                )
+
+                gene_scores = self.study_wrapper.gene_scores_db.get_gene_score(
+                    score_desc.resource_id
+                )
                 # pylint: disable=protected-access
-                gene_scores_values[gwc] = gene_scores._to_dict().get(
+                gene_scores_values[gwc] = gene_scores._to_dict(gwc).get(
                     gene, default
                 )
             else:


### PR DESCRIPTION
## Background

Gene scores were implemented in a slightly unintuitive way. Unlike genomic scores, which were a resource that contains scores, the resource for gene scores is a collection, which contains gene scores. This becomes slightly more awkward with the gene scores DB handling collections instead of scores.

## Aim

Update the gene scores to behave similarly to genomic scores.

## Implementation

The GeneScoreCollection class is now GeneScore. GeneScoresDB now uses a new class ScoreDesc to give information on scores and also has access to the original gene scores. The old, individual GeneScore class is removed and has no current alternative. Most of the methods of GeneScore have been relocated to the new GeneScore and take an additional parameter score_id, since GeneScore now contains all of the scores in a resource. Gene score configurations have also been refactored to fit in the new number and categorical histogram format and histograms are now configured under the same section as the scores. The `gene_scores` section of the config is now just `scores`. Info pages have been updated to reflect these changes.
