### PR TITLE
Federation token api update

### DIFF
--- a/wdae/wdae/users_api/tests/test_federation_credentials_api.py
+++ b/wdae/wdae/users_api/tests/test_federation_credentials_api.py
@@ -5,36 +5,36 @@ from pprint import pprint
 from rest_framework import status  # type: ignore
 from oauth2_provider.models import get_application_model  # type: ignore
 
-from utils.email_regex import email_regex, is_email_valid
-from utils.password_requirements import is_password_valid
 
-
-def test_create_federation_credentials_with_unauthorized_user(db, anonymous_client):
+def test_create_federation_credentials_with_unauthorized_user(
+    db, anonymous_client
+):
     url = "/api/v3/users/federation_credentials"
     body = {
         "name": "name1"
     }
-    createRes = anonymous_client.post(
+    create_res = anonymous_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
-    assert createRes.status_code is status.HTTP_401_UNAUTHORIZED
-    assert createRes.data is None
-    assert get_application_model().objects.filter(name="name1").exists() is False
+    assert create_res.status_code is status.HTTP_401_UNAUTHORIZED
+    assert create_res.data is None
+    assert (get_application_model().objects
+            .filter(name="name1").exists()) is False
 
 
 def test_create_duplicate_name_federation_credentials(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
-    createRes = user_client.post(
+    body = {"name": "name1"}
+    create_res = user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
-    assert createRes.status_code is status.HTTP_200_OK
+    assert create_res.status_code is status.HTTP_200_OK
 
-    createDuplicateRes = user_client.post(
+    create_duplicate_res = user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
-    assert createDuplicateRes.status_code is status.HTTP_400_BAD_REQUEST
+    assert create_duplicate_res.status_code is status.HTTP_400_BAD_REQUEST
 
     response = user_client.get(url)
     
@@ -53,11 +53,17 @@ def test_create_federation_credentials_with_authorized_user(db, user_client):
     )
 
     assert credentials_res.status_code is status.HTTP_200_OK
-    assert get_application_model().objects.filter(name="name1").exists() is True
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
 
     token_res = user_client.post(
         "/o/token/",
-        headers={"Authorization": f"Basic {credentials_res.data['credentials'].decode()}"},
+        headers={
+            "Authorization":
+                f"Basic {credentials_res.data['credentials'].decode()}"
+        },
         data={"grant_type": "client_credentials"},
         content_type="application/json", format="json"
     )
@@ -76,12 +82,12 @@ def test_get_federation_credentials_with_unauthorized_user(anonymous_client):
 def test_get_federation_credentials_with_authorized_user(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
 
-    body = { "name": "name2" }
+    body = {"name": "name2"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -91,10 +97,12 @@ def test_get_federation_credentials_with_authorized_user(db, user_client):
     assert str(response.data) == "[{'name': 'name1'}, {'name': 'name2'}]"
 
 
-def test_update_federation_credentials_with_unauthorized_user(db, user_client, anonymous_client):
+def test_update_federation_credentials_with_unauthorized_user(
+    db, user_client, anonymous_client
+):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -109,13 +117,16 @@ def test_update_federation_credentials_with_unauthorized_user(db, user_client, a
 
     assert response.data is None
     assert response.status_code is status.HTTP_401_UNAUTHORIZED
-    assert get_application_model().objects.filter(name="name1").exists() is True
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
 
 
 def test_update_federation_credentials_with_false_name(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -124,23 +135,26 @@ def test_update_federation_credentials_with_false_name(db, user_client):
         "name": "name2",
         "new_name": "name3"
     }
-    responseWithoutNameRes = user_client.put(
+    response_without_name_res = user_client.put(
         url, json.dumps(body), content_type="application/json", format="json"
     )
 
-    assert responseWithoutNameRes.data is None
-    assert responseWithoutNameRes.status_code is status.HTTP_400_BAD_REQUEST
-    assert get_application_model().objects.filter(name="name1").exists() is True
+    assert response_without_name_res.data is None
+    assert response_without_name_res.status_code is status.HTTP_400_BAD_REQUEST
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
 
 
 def test_update_federation_credentials_with_duplicate_name(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
-    body = { "name": "name2" }
+    body = {"name": "name2"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -149,24 +163,31 @@ def test_update_federation_credentials_with_duplicate_name(db, user_client):
         "name": "name1",
         "new_name": "name2",
     }
-    responseWithoutNewNameRes = user_client.put(
+    response_without_new_name_res = user_client.put(
         url, json.dumps(body), content_type="application/json", format="json"
     )
 
-    assert responseWithoutNewNameRes.data is None
-    assert responseWithoutNewNameRes.status_code is status.HTTP_400_BAD_REQUEST
-    assert get_application_model().objects.filter(name="name1").exists() is True
-    assert get_application_model().objects.filter(name="name2").exists() is True
+    assert response_without_new_name_res.data is None
+    assert response_without_new_name_res.status_code is \
+        status.HTTP_400_BAD_REQUEST
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
+    assert get_application_model() \
+        .objects \
+        .filter(name="name2") \
+        .exists() is True
 
 
 def test_update_federation_credentials_with_authorized_user(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
-    body = { "name": "name2" }
+    body = {"name": "name2"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -175,20 +196,28 @@ def test_update_federation_credentials_with_authorized_user(db, user_client):
         "name": "name1",
         "new_name": "name3",
     }
-    responseWithoutNewNameRes = user_client.put(
+    response_without_new_name_res = user_client.put(
         url, json.dumps(body), content_type="application/json", format="json"
     )
 
-    assert responseWithoutNewNameRes.status_code is status.HTTP_200_OK
-    assert str(responseWithoutNewNameRes.data) == "{'new_name': 'name3'}"
-    assert get_application_model().objects.filter(name="name1").exists() is False
-    assert get_application_model().objects.filter(name="name3").exists() is True
+    assert response_without_new_name_res.status_code is status.HTTP_200_OK
+    assert str(response_without_new_name_res.data) == "{'new_name': 'name3'}"
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is False
+    assert get_application_model() \
+        .objects \
+        .filter(name="name3") \
+        .exists() is True
 
 
-def test_delete_federation_credentials_with_unauthorized_user(db, user_client, anonymous_client):
+def test_delete_federation_credentials_with_unauthorized_user(
+    db, user_client, anonymous_client
+):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -202,7 +231,10 @@ def test_delete_federation_credentials_with_unauthorized_user(db, user_client, a
 
     assert response.data is None
     assert response.status_code is status.HTTP_401_UNAUTHORIZED
-    assert get_application_model().objects.filter(name="name1").exists() is True
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
 
 
 def test_delete_absent_federation_credentials(db, user_client):
@@ -222,7 +254,7 @@ def test_delete_absent_federation_credentials(db, user_client):
 def test_delete_federation_credentials_with_authorized_user(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
-    body = { "name": "name1" }
+    body = {"name": "name1"}
     user_client.post(
         url, json.dumps(body), content_type="application/json", format="json"
     )
@@ -235,4 +267,7 @@ def test_delete_federation_credentials_with_authorized_user(db, user_client):
     )
 
     assert response.status_code is status.HTTP_200_OK
-    assert get_application_model().objects.filter(name="name1").exists() is False
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is False

--- a/wdae/wdae/users_api/tests/test_federation_credentials_api.py
+++ b/wdae/wdae/users_api/tests/test_federation_credentials_api.py
@@ -1,0 +1,238 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import json
+from pprint import pprint
+
+from rest_framework import status  # type: ignore
+from oauth2_provider.models import get_application_model  # type: ignore
+
+from utils.email_regex import email_regex, is_email_valid
+from utils.password_requirements import is_password_valid
+
+
+def test_create_federation_credentials_with_unauthorized_user(db, anonymous_client):
+    url = "/api/v3/users/federation_credentials"
+    body = {
+        "name": "name1"
+    }
+    createRes = anonymous_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+    assert createRes.status_code is status.HTTP_401_UNAUTHORIZED
+    assert createRes.data is None
+    assert get_application_model().objects.filter(name="name1").exists() is False
+
+
+def test_create_duplicate_name_federation_credentials(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    createRes = user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+    assert createRes.status_code is status.HTTP_200_OK
+
+    createDuplicateRes = user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+    assert createDuplicateRes.status_code is status.HTTP_400_BAD_REQUEST
+
+    response = user_client.get(url)
+    
+    assert len(response.data) == 1
+    assert str(response.data) == "[{'name': 'name1'}]"
+    assert len(get_application_model().objects.filter(name="name1")) == 1
+
+
+def test_create_federation_credentials_with_authorized_user(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+    body = {
+        "name": "name1"
+    }
+    credentials_res = user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert credentials_res.status_code is status.HTTP_200_OK
+    assert get_application_model().objects.filter(name="name1").exists() is True
+
+    token_res = user_client.post(
+        "/o/token/",
+        headers={"Authorization": f"Basic {credentials_res.data['credentials'].decode()}"},
+        data={"grant_type": "client_credentials"},
+        content_type="application/json", format="json"
+    )
+    assert token_res.status_code is status.HTTP_200_OK
+    assert token_res.json().get("access_token") is not None
+
+
+def test_get_federation_credentials_with_unauthorized_user(anonymous_client):
+    url = "/api/v3/users/federation_credentials"
+    response = anonymous_client.get(url)
+
+    assert response.data is None
+    assert response.status_code is status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_federation_credentials_with_authorized_user(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = { "name": "name2" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    response = user_client.get(url)
+    assert response.status_code is status.HTTP_200_OK
+    assert str(response.data) == "[{'name': 'name1'}, {'name': 'name2'}]"
+
+
+def test_update_federation_credentials_with_unauthorized_user(db, user_client, anonymous_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "name": "name1",
+        "new_name": "name2"
+    }
+    response = anonymous_client.put(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert response.data is None
+    assert response.status_code is status.HTTP_401_UNAUTHORIZED
+    assert get_application_model().objects.filter(name="name1").exists() is True
+
+
+def test_update_federation_credentials_with_false_name(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "name": "name2",
+        "new_name": "name3"
+    }
+    responseWithoutNameRes = user_client.put(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert responseWithoutNameRes.data is None
+    assert responseWithoutNameRes.status_code is status.HTTP_400_BAD_REQUEST
+    assert get_application_model().objects.filter(name="name1").exists() is True
+
+
+def test_update_federation_credentials_with_duplicate_name(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+    body = { "name": "name2" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "name": "name1",
+        "new_name": "name2",
+    }
+    responseWithoutNewNameRes = user_client.put(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert responseWithoutNewNameRes.data is None
+    assert responseWithoutNewNameRes.status_code is status.HTTP_400_BAD_REQUEST
+    assert get_application_model().objects.filter(name="name1").exists() is True
+    assert get_application_model().objects.filter(name="name2").exists() is True
+
+
+def test_update_federation_credentials_with_authorized_user(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+    body = { "name": "name2" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "name": "name1",
+        "new_name": "name3",
+    }
+    responseWithoutNewNameRes = user_client.put(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert responseWithoutNewNameRes.status_code is status.HTTP_200_OK
+    assert str(responseWithoutNewNameRes.data) == "{'new_name': 'name3'}"
+    assert get_application_model().objects.filter(name="name1").exists() is False
+    assert get_application_model().objects.filter(name="name3").exists() is True
+
+
+def test_delete_federation_credentials_with_unauthorized_user(db, user_client, anonymous_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "name": "name1",
+    }
+    response = anonymous_client.delete(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert response.data is None
+    assert response.status_code is status.HTTP_401_UNAUTHORIZED
+    assert get_application_model().objects.filter(name="name1").exists() is True
+
+
+def test_delete_absent_federation_credentials(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = {
+        "name": "name1",
+    }
+    response = user_client.delete(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert response.data is None
+    assert response.status_code is status.HTTP_400_BAD_REQUEST
+
+
+def test_delete_federation_credentials_with_authorized_user(db, user_client):
+    url = "/api/v3/users/federation_credentials"
+
+    body = { "name": "name1" }
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "name": "name1",
+    }
+    response = user_client.delete(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert response.status_code is status.HTTP_200_OK
+    assert get_application_model().objects.filter(name="name1").exists() is False

--- a/wdae/wdae/users_api/tests/test_federation_credentials_api.py
+++ b/wdae/wdae/users_api/tests/test_federation_credentials_api.py
@@ -123,6 +123,45 @@ def test_update_federation_credentials_with_unauthorized_user(
         .exists() is True
 
 
+def test_update_federation_credentials_with_incorrect_request_data(
+    db, user_client
+):
+    url = "/api/v3/users/federation_credentials"
+
+    body = {"name": "name1"}
+    user_client.post(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    body = {
+        "new_name": "name3"
+    }
+    response_without_name_res = user_client.put(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert response_without_name_res.data is None
+    assert response_without_name_res.status_code is status.HTTP_400_BAD_REQUEST
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
+
+    body = {
+        "name": "name1",
+    }
+    response_without_name_res = user_client.put(
+        url, json.dumps(body), content_type="application/json", format="json"
+    )
+
+    assert response_without_name_res.data is None
+    assert response_without_name_res.status_code is status.HTTP_400_BAD_REQUEST
+    assert get_application_model() \
+        .objects \
+        .filter(name="name1") \
+        .exists() is True
+
+
 def test_update_federation_credentials_with_false_name(db, user_client):
     url = "/api/v3/users/federation_credentials"
 
@@ -135,12 +174,12 @@ def test_update_federation_credentials_with_false_name(db, user_client):
         "name": "name2",
         "new_name": "name3"
     }
-    response_without_name_res = user_client.put(
+    response_with_bad_name_res = user_client.put(
         url, json.dumps(body), content_type="application/json", format="json"
     )
 
-    assert response_without_name_res.data is None
-    assert response_without_name_res.status_code is status.HTTP_400_BAD_REQUEST
+    assert response_with_bad_name_res.data is None
+    assert response_with_bad_name_res.status_code is status.HTTP_400_BAD_REQUEST
     assert get_application_model() \
         .objects \
         .filter(name="name1") \
@@ -196,12 +235,12 @@ def test_update_federation_credentials_with_authorized_user(db, user_client):
         "name": "name1",
         "new_name": "name3",
     }
-    response_without_new_name_res = user_client.put(
+    response = user_client.put(
         url, json.dumps(body), content_type="application/json", format="json"
     )
 
-    assert response_without_new_name_res.status_code is status.HTTP_200_OK
-    assert str(response_without_new_name_res.data) == "{'new_name': 'name3'}"
+    assert response.status_code is status.HTTP_200_OK
+    assert str(response.data) == "{'new_name': 'name3'}"
     assert get_application_model() \
         .objects \
         .filter(name="name1") \

--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -514,11 +514,11 @@ class FederationCredentials(views.APIView):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         application = get_application_model()
-        if application.objects.filter(name=request.data.get("name")).exists():
+        if application.objects.filter(name=request.data["name"]).exists():
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         new_application = application(**{
-            "name": request.data.get("name"),
+            "name": request.data["name"],
             "user_id": user.id,
             "client_type": "confidential",
             "authorization_grant_type": "client-credentials"
@@ -543,11 +543,11 @@ class FederationCredentials(views.APIView):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         if not get_application_model() \
                 .objects \
-                .filter(name=request.data.get("name")) \
+                .filter(name=request.data["name"]) \
                 .exists():
             return Response(status=status.HTTP_400_BAD_REQUEST)
         app = get_application_model().objects.get(
-            name=request.data.get("name")
+            name=request.data["name"]
         )
         if not user.id == app.user_id:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
@@ -560,22 +560,27 @@ class FederationCredentials(views.APIView):
         user = request.user
         if not user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
+        if "name" not in request.data or \
+                "new_name" not in request.data or \
+                request.data["name"] is None or \
+                request.data["new_name"] is None:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
         if not get_application_model() \
                 .objects \
-                .filter(name=request.data.get("name")) \
+                .filter(name=request.data["name"]) \
                 .exists():
             return Response(status=status.HTTP_400_BAD_REQUEST)
-        if (get_application_model()
-                .objects
-                .filter(name=request.data.get("new_name"))
-                .exists()):
+        if get_application_model() \
+                .objects \
+                .filter(name=request.data["new_name"]) \
+                .exists():
             return Response(status=status.HTTP_400_BAD_REQUEST)
         app = get_application_model().objects.get(
-            name=request.data.get("name")
+            name=request.data["name"]
         )
         if not user.id == app.user_id:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
-        app.name = request.data.get("new_name")
+        app.name = request.data["new_name"]
         app.save()
         return Response(
             {"new_name": app.name},

--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -568,4 +568,7 @@ class FederationCredentials(views.APIView):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         app.name = request.data.get("new_name")
         app.save()
-        return Response(status=status.HTTP_200_OK)
+        return Response(
+            {"new_name": app.name},
+            status=status.HTTP_200_OK
+        )

--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -541,7 +541,10 @@ class FederationCredentials(views.APIView):
         user = request.user
         if not user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
-        if not get_application_model().objects.filter(name=request.data.get("name")).exists():
+        if not get_application_model() \
+                .objects \
+                .filter(name=request.data.get("name")) \
+                .exists():
             return Response(status=status.HTTP_400_BAD_REQUEST)
         app = get_application_model().objects.get(
             name=request.data.get("name")
@@ -557,9 +560,15 @@ class FederationCredentials(views.APIView):
         user = request.user
         if not user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
-        if not get_application_model().objects.filter(name=request.data.get("name")).exists():
+        if not get_application_model() \
+                .objects \
+                .filter(name=request.data.get("name")) \
+                .exists():
             return Response(status=status.HTTP_400_BAD_REQUEST)
-        if get_application_model().objects.filter(name=request.data.get("new_name")).exists():
+        if (get_application_model()
+                .objects
+                .filter(name=request.data.get("new_name"))
+                .exists()):
             return Response(status=status.HTTP_400_BAD_REQUEST)
         app = get_application_model().objects.get(
             name=request.data.get("name")


### PR DESCRIPTION
## Background

update federation credentials api to support updating existing credentials and remove some of the sent information

## Aim

add put request for singular credential name update
remove credential secret and id from get request body
add unit tests for the whole api

Closes #480 