### PR TITLE
Fix enrichment desc bug and add test

### DIFF
--- a/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
+++ b/wdae/wdae/enrichment_api/tests/test_enrichment_api.py
@@ -212,6 +212,31 @@ def test_enrichment_test_gene_scores(admin_client, wdae_gpf_instance):
     assert response.status_code == 200
 
 
+def test_enrichment_test_gene_scores_with_zero_range(
+        admin_client, wdae_gpf_instance
+):
+    url = "/api/v3/enrichment/test"
+    query = {
+        "datasetId": "f1_trio",
+        "enrichmentBackgroundModel": "coding_len_background_model",
+        "enrichmentCountingModel": "enrichment_gene_counting",
+        "geneScores": {
+            "score": "LGD_rank",
+            "rangeStart": 0,
+            "rangeEnd": 1000
+        },
+    }
+    response = admin_client.post(
+        url, json.dumps(query), content_type="application/json", format="json"
+    )
+
+    assert response
+    assert response.status_code == 200
+
+    assert response.data["desc"] == \
+        "Gene Scores: LGD_rank from 0 upto 1000 (1024)"
+
+
 def test_enrichment_test_gene_set(admin_client, wdae_gpf_instance):
     url = "/api/v3/enrichment/test"
     query = {

--- a/wdae/wdae/enrichment_api/views.py
+++ b/wdae/wdae/enrichment_api/views.py
@@ -77,14 +77,14 @@ class EnrichmentTestView(QueryDatasetView):
             range_end = gene_score_request.get("rangeEnd", None)
         if gene_scores_id is not None and \
                 gene_scores_id in self.gene_scores_db:
-            if range_start and range_end:
+            if range_start is not None and range_end is not None:
                 desc = (
                     f"Gene Scores: {gene_scores_id} "
                     f"from {range_start} upto {range_end}"
                 )
-            elif range_start:
+            elif range_start is not None:
                 desc = f"Gene Scores: {gene_scores_id} from {range_start}"
-            elif range_end:
+            elif range_end is not None:
                 desc = f"Gene Scores: {gene_scores_id} upto {range_end}"
             else:
                 desc = f"Gene Scores: {gene_scores_id}"


### PR DESCRIPTION
## Background

Enrichment tool API response data includes a description, which for gene scores is formed using the selected ranges of the histogram. This had a bug for a long time, due to implicitly checking for None, therefore ignoring zeroes too.

## Aim

Fix the gene scores range bug in the description.
