### PR TITLE
Enable stricter options

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 warn_return_any = True
-warn_redundant_casts = True
 # disable notes messages for not checking untyped defs. Remove this if you set check_untyped_defs to True.
 disable_error_code = annotation-unchecked
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,7 +13,7 @@ strict_concatenate = True
 check_untyped_defs = True
 
 ; disallow_untyped_calls = True
-disallow_incomplete_defs = True
+; disallow_incomplete_defs = True
 disallow_untyped_defs = True
 
 # files = dae/dae, wdae/wdae

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,17 @@
 [mypy]
 warn_return_any = True
 warn_redundant_casts = True
-check_untyped_defs = False
 # disable notes messages for not checking untyped defs. Remove this if you set check_untyped_defs to True.
 disable_error_code = annotation-unchecked
+
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+
+strict_equality = True
+strict_concatenate = True
+
+check_untyped_defs = True
 
 # files = dae/dae, wdae/wdae
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,10 @@ strict_concatenate = True
 
 check_untyped_defs = True
 
+; disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+
 # files = dae/dae, wdae/wdae
 
 exclude = (?x)(


### PR DESCRIPTION
## Background

We want to begin introducing stricter mypy checks to standardize type annotations in new code.

## Implementation

I have began adding sections from [this](https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options).
We can also try adding the following 3 directly now but I am not sure about this:
```
disallow_untyped_calls = True
disallow_incomplete_defs = True
disallow_untyped_defs = True
```