### PR TITLE
Support for case insensitive gene symbols for the Gene models and AGP…

### DIFF
--- a/wdae/wdae/genomes_api/tests/test_gene_models_api.py
+++ b/wdae/wdae/genomes_api/tests/test_gene_models_api.py
@@ -40,11 +40,14 @@ def test_get_nonexistant_gene_transcripts(anonymous_client):
     assert response
     assert response.status_code == 404
 
+
 def test_get_case_insensitive_gene(anonymous_client):
     response = anonymous_client.get("/api/v3/genome/gene_models/default/cHd8")
 
     assert response
+    assert response.data["gene"] == "CHD8"
     assert response.status_code == 200
+
 
 def test_search_gene_symbols(anonymous_client):
     response = anonymous_client.get("/api/v3/genome/gene_models/search/CHD8")

--- a/wdae/wdae/genomes_api/tests/test_gene_models_api.py
+++ b/wdae/wdae/genomes_api/tests/test_gene_models_api.py
@@ -40,6 +40,11 @@ def test_get_nonexistant_gene_transcripts(anonymous_client):
     assert response
     assert response.status_code == 404
 
+def test_get_case_insensitive_gene(anonymous_client):
+    response = anonymous_client.get("/api/v3/genome/gene_models/default/cHd8")
+
+    assert response
+    assert response.status_code == 200
 
 def test_search_gene_symbols(anonymous_client):
     response = anonymous_client.get("/api/v3/genome/gene_models/search/CHD8")

--- a/wdae/wdae/genomes_api/views.py
+++ b/wdae/wdae/genomes_api/views.py
@@ -1,5 +1,4 @@
 from itertools import islice
-import re
 
 from rest_framework.response import Response
 from rest_framework import status
@@ -16,9 +15,10 @@ class DefaultGeneModelsId(QueryBaseView):
 
 class GeneModels(QueryBaseView):
     def get(self, request, gene_symbol):
+        gene_symbol = gene_symbol.lower()
         gene_models = self.gpf_instance.gene_models.gene_models
         for k, v in gene_models.items():
-            if re.fullmatch(gene_symbol, k, re.IGNORECASE):
+            if gene_symbol == k.lower():
                 transcripts = v
                 response_data = {
                     "gene": k,
@@ -76,10 +76,11 @@ class GeneSymbolsSearch(QueryBaseView):
     RESPONSE_LIMIT = 20
 
     def get(self, request, search_term):
+        search_term = search_term.lower()
         gene_models = self.gpf_instance.gene_models.gene_models
 
         matching_gene_symbols = filter(
-            lambda gs: gs.lower().startswith(search_term.lower()),
+            lambda gs: gs.lower().startswith(search_term),
             gene_models.keys()
         )
 


### PR DESCRIPTION
… DB #486

## Background

The backend currently is case sensitive for gene symbols in a lot of places such as the gene models and the AGP.

## Aim

Make it as case-insensitive as possible, there is a possible issue that may be related to the impala(?).

## Implementation

Closes #486.