### PR TITLE
Fix pheno tool download precision

### DIFF
--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -133,6 +133,10 @@ class PhenoToolDownload(PhenoToolView):
                 tool.measure_id, tool.normalize_by
             )
             result_df = result_df.rename(columns={"normalized": column_name})
+            result_df[column_name] = result_df[column_name].round(decimals=5)
+        else:
+            result_df[tool.measure_id] = \
+                result_df[tool.measure_id].round(decimals=5)
 
         # Select & sort columns for output
         effect_types_count = len(data["effect_types"])

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -134,9 +134,9 @@ class PhenoToolDownload(PhenoToolView):
             )
             result_df = result_df.rename(columns={"normalized": column_name})
             result_df[column_name] = result_df[column_name].round(decimals=5)
-        else:
-            result_df[tool.measure_id] = \
-                result_df[tool.measure_id].round(decimals=5)
+
+        result_df[tool.measure_id] = \
+            result_df[tool.measure_id].round(decimals=5)
 
         # Select & sort columns for output
         effect_types_count = len(data["effect_types"])


### PR DESCRIPTION
## Background
When downloading a pheno tool dataframe where the measure is normalized, values were full floats and could differ in between different downloads due to rounding errors.

## Aim
Add a rounding to the column in the dataframe.

## Implementation
A rounding has been added to the normalize_by column and the measure_id column with precision up to 5 decimal places.
