### PR TITLE
Fix missing datasets breaking groups and permissions API

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -252,20 +252,16 @@ def get_dataset_info(dataset_id):
     gpf_instance = get_wgpf_instance()
     study_wrapper = gpf_instance.get_wdae_wrapper(dataset_id)
     if study_wrapper is None:
-        logger.warning("Could not find study wrapper for %s", dataset_id)
-        dataset_name = f"Missing dataset ({dataset_id})"
-    else:
-        dataset_name = study_wrapper.name
+        logger.error("Could not find study wrapper for %s", dataset_id)
+        return None
     dataset = get_wdae_dataset(dataset_id)
     if dataset is None:
-        logger.warning("Could not find WDAE dataset for %s", dataset_id)
-        is_broken = True
-    else:
-        is_broken = dataset.broken
+        logger.error("Could not find WDAE dataset for %s", dataset_id)
+        return None
     return {
-        "datasetName": dataset_name,
+        "datasetName": study_wrapper.name,
         "datasetId": dataset_id,
-        "broken": is_broken
+        "broken": dataset.broken
     }
 
 

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -252,14 +252,20 @@ def get_dataset_info(dataset_id):
     gpf_instance = get_wgpf_instance()
     study_wrapper = gpf_instance.get_wdae_wrapper(dataset_id)
     if study_wrapper is None:
-        raise ValueError(f"Could not find study wrapper for {dataset_id}")
+        logger.warning("Could not find study wrapper for %s", dataset_id)
+        dataset_name = f"Missing dataset ({dataset_id})"
+    else:
+        dataset_name = study_wrapper.name
     dataset = get_wdae_dataset(dataset_id)
     if dataset is None:
-        raise ValueError(f"Could not find WDAE dataset for {dataset_id}")
+        logger.warning("Could not find WDAE dataset for %s", dataset_id)
+        is_broken = True
+    else:
+        is_broken = dataset.broken
     return {
-        "datasetName": study_wrapper.name,
+        "datasetName": dataset_name,
         "datasetId": dataset_id,
-        "broken": dataset.broken
+        "broken": is_broken
     }
 
 

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -301,7 +301,7 @@ class BaseDatasetPermissionsView(QueryBaseView):
             )
             return {
                 "dataset_id": dataset.dataset_id,
-                "dataset_name": "Missing dataset",
+                "dataset_name": f"Missing dataset ({dataset.dataset_id})",
                 "users": [],
                 "groups": []
             }

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -295,16 +295,11 @@ class BaseDatasetPermissionsView(QueryBaseView):
         )
 
         if dataset_gd is None:
-            logger.warning(
+            logger.error(
                 "Dataset %s missing in GPF instance!",
                 dataset.dataset_id
             )
-            return {
-                "dataset_id": dataset.dataset_id,
-                "dataset_name": f"Missing dataset ({dataset.dataset_id})",
-                "users": [],
-                "groups": []
-            }
+            return None
 
         name = dataset_gd.name
         if name is None:
@@ -343,7 +338,12 @@ class DatasetPermissionsView(BaseDatasetPermissionsView):
 
         dataset_details = []
         for dataset in datasets:
-            dataset_details.append(self._get_dataset_info(dataset))
+            info = self._get_dataset_info(dataset)
+
+            if info is None:
+                continue
+
+            dataset_details.append(info)
 
         if len(dataset_details) == 0:
             return Response(status=status.HTTP_204_NO_CONTENT)
@@ -362,6 +362,9 @@ class DatasetPermissionsSingleView(BaseDatasetPermissionsView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         dataset_details = self._get_dataset_info(dataset)
+
+        if dataset_details is None:
+            return Response({}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(dataset_details)
 

--- a/wdae/wdae/groups_api/serializers.py
+++ b/wdae/wdae/groups_api/serializers.py
@@ -40,9 +40,9 @@ class GroupRetrieveSerializer(GroupSerializer):
         fields = ("id", "name", "users", "datasets")
 
     def get_datasets(self, group):
-        return sorted([
+        return sorted(filter(None, [
             get_dataset_info(d.dataset_id) for d in group.dataset_set.all()
-        ], key=lambda d: d["datasetName"].lower())
+        ]), key=lambda d: d["datasetName"].lower())
 
     def to_representation(self, instance):
         response = super().to_representation(instance)


### PR DESCRIPTION
## Background
When querying for groups and dataset permissions when a single dataset is missing (not loaded in variants db, but in the WDAE database), the groups request would completely break and return 500 and the permissions request would give them all a generic name "Missing dataset" which was not very descriptive.

## Aim
Fix the groups request crash and make the missing dataset name more precise

## Implementation

When getting a dataset's WDAE info, there were checks implemented which would raise errors when the dataset is missing for some reason. These errors have been replaced with warnings. The name format for missing datasets is now changed to `"Missing dataset {dataset_id}"`
