### PR TITLE
Change tab order login form

### DIFF
--- a/wdae/wdae/users_api/forms.py
+++ b/wdae/wdae/users_api/forms.py
@@ -50,11 +50,11 @@ class WdaeRegisterPasswordForm(WdaeResetPasswordForm):
 
 class WdaeLoginForm(forms.Form):
 
-    username = UsernameField(widget=forms.TextInput(attrs={"autofocus": True}))
+    username = UsernameField(widget=forms.TextInput(attrs={"autofocus": True, "tabindex": 1}))
     password = forms.CharField(
         label=gettext_lazy("Password"),
         strip=False,
-        widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
+        widget=forms.PasswordInput(attrs={"autocomplete": "current-password", "tabindex": 2}),
     )
 
     error_messages = {

--- a/wdae/wdae/users_api/forms.py
+++ b/wdae/wdae/users_api/forms.py
@@ -50,11 +50,16 @@ class WdaeRegisterPasswordForm(WdaeResetPasswordForm):
 
 class WdaeLoginForm(forms.Form):
 
-    username = UsernameField(widget=forms.TextInput(attrs={"autofocus": True, "tabindex": 1}))
+    username = UsernameField(widget=forms.TextInput(
+            attrs={"autofocus": True, "tabindex": 1}
+        )
+    )
     password = forms.CharField(
         label=gettext_lazy("Password"),
         strip=False,
-        widget=forms.PasswordInput(attrs={"autocomplete": "current-password", "tabindex": 2}),
+        widget=forms.PasswordInput(
+            attrs={"autocomplete": "current-password", "tabindex": 2}
+        ),
     )
 
     error_messages = {

--- a/wdae/wdae/users_api/forms.py
+++ b/wdae/wdae/users_api/forms.py
@@ -50,7 +50,8 @@ class WdaeRegisterPasswordForm(WdaeResetPasswordForm):
 
 class WdaeLoginForm(forms.Form):
 
-    username = UsernameField(widget=forms.TextInput(
+    username = UsernameField(
+        widget=forms.TextInput(
             attrs={"autofocus": True, "tabindex": 1}
         )
     )


### PR DESCRIPTION
## Background

When loaded the username field is focused but when clicking tab button instead of focusing the password field, it focuses the forgotten password link.

## Aim

To change the order.

## Implementation

Changed the tab order with tabindex.

closes #505 