### PR TITLE
Improve genotype browser query performance

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -115,3 +115,6 @@ ignore_missing_imports = True
 
 [mypy-versioneer.*]
 ignore_missing_imports = True
+
+[mypy-ijson.*]
+ignore_missing_imports = True

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -158,8 +158,9 @@ class ResponseTransformer:
         self.study_wrapper = cast(StudyWrapper, study_wrapper)
         self._pheno_columns = study_wrapper.config_columns.phenotype
 
-        if not study_wrapper.is_remote:
-            self.gene_scores_dicts = {}
+        self.gene_scores_dicts = {}
+        if not study_wrapper.is_remote \
+                and self.study_wrapper.gene_scores_db is not None:
             gene_scores_db = self.study_wrapper.gene_scores_db
             for score_id, score_desc in gene_scores_db.score_descs.items():
                 gene_score = gene_scores_db.get_gene_score(

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -158,11 +158,16 @@ class ResponseTransformer:
         self.study_wrapper = cast(StudyWrapper, study_wrapper)
         self._pheno_columns = study_wrapper.config_columns.phenotype
 
-        self.gene_scores_dicts = {}
-        gene_scores_db = self.study_wrapper.gene_scores_db
-        for score_id, score_desc in gene_scores_db.score_descs.items():
-            gene_score = gene_scores_db.get_gene_score(score_desc.resource_id)
-            self.gene_scores_dicts[score_id] = gene_score._to_dict(score_id)
+        if not study_wrapper.is_remote:
+            self.gene_scores_dicts = {}
+            gene_scores_db = self.study_wrapper.gene_scores_db
+            for score_id, score_desc in gene_scores_db.score_descs.items():
+                gene_score = gene_scores_db.get_gene_score(
+                    score_desc.resource_id
+                )
+                self.gene_scores_dicts[score_id] = gene_score._to_dict(
+                    score_id
+                )
 
     @property
     def families(self) -> FamiliesData:

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -298,7 +298,7 @@ class StudyWrapper(StudyWrapperBase):
                 self.config.phenotype_data
             )
 
-    def _validate_column_groups(self):
+    def _validate_column_groups(self) -> bool:
         genotype_cols = self.columns.get("genotype") or []
         phenotype_cols = self.columns.get("phenotype") or []
         for column_group_name, column_group in self.column_groups.items():
@@ -354,6 +354,7 @@ class StudyWrapper(StudyWrapperBase):
         index = 0
         seen = set()
         unique_family_variants = kwargs.get("unique_family_variants", False)
+
         try:
             started = time.time()
             variants_result = \
@@ -368,12 +369,10 @@ class StudyWrapper(StudyWrapperBase):
                 self.name, elapsed)
 
             with closing(variants_result) as variants:
-
                 for variant in variants:
                     if variant is None:
                         yield None
                         continue
-
                     v = transform(variant)
 
                     matched = True
@@ -399,8 +398,7 @@ class StudyWrapper(StudyWrapperBase):
                                 f"reached"
                             ]
                         break
-                    # pylint: disable=protected-access
-                    row_variant = self.response_transformer._build_variant_row(
+                    row_variant = self.response_transformer.build_variant_row(
                         v, sources,
                         person_set_collection=kwargs.get(
                             "person_set_collection", (None, None))[0]
@@ -561,7 +559,7 @@ class RemoteStudyWrapper(StudyWrapperBase):
             fv = RemoteFamilyVariant(
                 variant, family, list(map(get_source, sources)))
             # pylint: disable=protected-access
-            row_variant = self.response_transformer._build_variant_row(
+            row_variant = self.response_transformer.build_variant_row(
                 fv, sources, person_set_collection=person_set_collection_id)
 
             yield row_variant


### PR DESCRIPTION
## Background

Genotype browser queries at some point became very slow.

## Aim

Fix the bottleneck.

## Implementation

The response transformers were collecting gene score dataframes for every allele passing through. This was creating a massive bottleneck, which has been fixed by collecting dataframes when a response transformer is created.

