### PR TITLE
Fix for gene sets downloads in remote download

### DIFF
--- a/wdae/wdae/genotype_browser/views.py
+++ b/wdae/wdae/genotype_browser/views.py
@@ -139,9 +139,9 @@ class GenotypeBrowserQueryView(QueryDatasetView):
         if dataset is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         if not dataset.is_remote:
-            data = expand_gene_set(request.data, request.user)
+            data = expand_gene_set(data, user)
         elif "geneSet" in data:
-            gene_set = expand_gene_syms(request.data, request.user)
+            gene_set = expand_gene_syms(data, user)
             data["geneSymbols"] = list(gene_set["syms"])
             del data["geneSet"]
 

--- a/wdae/wdae/utils/expand_gene_set.py
+++ b/wdae/wdae/utils/expand_gene_set.py
@@ -1,13 +1,11 @@
-from typing import Any
 from gpf_instance.gpf_instance import get_wgpf_instance
 
 from datasets_api.permissions import IsDatasetAllowed
 
 
-def expand_gene_set(data: Any, user: dict) -> dict:
+def expand_gene_set(data: dict, user: dict) -> dict:
     """Expand gene set to list of gene symbols."""
     if "geneSet" in data:
-        data = dict(data)
         gene_sets_collection_id = None
 
         query = data.get("geneSet")
@@ -28,10 +26,8 @@ def expand_gene_set(data: Any, user: dict) -> dict:
     return data
 
 
-def expand_gene_syms(data: Any, user: dict) -> dict:
+def expand_gene_syms(data: dict, user: dict) -> dict:
     """Expand gene set symbols."""
-    data = dict(data)
-
     gene_set = None
     query = data.get("geneSet")
     if query is None:
@@ -55,4 +51,4 @@ def expand_gene_syms(data: Any, user: dict) -> dict:
             gene_sets_collection, gene_set
         )
 
-    return gene_set
+    return dict(gene_set)

--- a/wdae/wdae/utils/expand_gene_set.py
+++ b/wdae/wdae/utils/expand_gene_set.py
@@ -1,3 +1,4 @@
+from typing import cast
 from gpf_instance.gpf_instance import get_wgpf_instance
 
 from datasets_api.permissions import IsDatasetAllowed
@@ -51,4 +52,4 @@ def expand_gene_syms(data: dict, user: dict) -> dict:
             gene_sets_collection, gene_set
         )
 
-    return dict(gene_set)
+    return cast(dict, gene_set)

--- a/wdae/wdae/utils/expand_gene_set.py
+++ b/wdae/wdae/utils/expand_gene_set.py
@@ -4,7 +4,7 @@ from gpf_instance.gpf_instance import get_wgpf_instance
 from datasets_api.permissions import IsDatasetAllowed
 
 
-def expand_gene_set(data: dict, user: dict) -> dict:
+def expand_gene_set(data: Any, user: dict) -> dict:
     """Expand gene set to list of gene symbols."""
     if "geneSet" in data:
         data = dict(data)
@@ -28,8 +28,10 @@ def expand_gene_set(data: dict, user: dict) -> dict:
     return data
 
 
-def expand_gene_syms(data: dict, user: dict) -> Any:
+def expand_gene_syms(data: Any, user: dict) -> dict:
     """Expand gene set symbols."""
+    data = dict(data)
+
     gene_set = None
     query = data.get("geneSet")
     if query is None:


### PR DESCRIPTION
## Background

Previously, when retrieving gene sets from a remote source, the "queryData" parameter was being set incorrectly on the root object passed to the expand_gene_set utility. This was causing issues when trying to download gene sets from remote sources.

## Aim

This PR fixes the bug where queryData was being set incorrectly. Now, expand_gene_set will receive the proper "queryData" when processing gene sets from remote sources.

## Implementation

Identified where queryData was being set on the root object instead of the appropriate child object
Updated the code to set queryData on the correct child object before passing data to expand_gene_set