### PR TITLE
VCF reannotation

### DIFF
--- a/dae/dae/annotation/annotate_columns.py
+++ b/dae/dae/annotation/annotate_columns.py
@@ -198,7 +198,8 @@ def annotate(
                         record_to_annotatable.build(record)
                     )
 
-                record.update(annotation)
+                for col in annotation_columns:
+                    record[col] = annotation[col]
                 result = list(map(str, record.values()))
                 out_file.write(args.output_separator.join(result) + "\n")
             except Exception as ex:  # pylint: disable=broad-except
@@ -206,12 +207,6 @@ def annotate(
                     "unexpected input data format at line %s: %s",
                     lnum, line, exc_info=True)
                 errors.append((lnum, line, str(ex)))
-
-    if len(errors) > 0:
-        logger.error("there were errors during the import")
-        for lnum, line, error in errors:
-            logger.error("line %s: %s", lnum, line)
-            logger.error("\t%s", error)
 
     if len(errors) > 0:
         logger.error("there were errors during the import")

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -79,21 +79,21 @@ def update_header(variant_file, pipeline):
                     and info_key not in new_annotation_columns:
                 variant_file.header.info.remove_header(info_key)
 
+        attributes = []
         for attr in pipeline.get_attributes():
             if attr.internal:
                 continue
 
             if attr.name not in variant_file.header.info:
-                description = attr.description
-                description = description.replace("\n", " ")
-                description = description.replace('"', '\\"')
-                header.info.add(attr.name, "A", "String", description)
+                attributes.append(attr)
     else:
-        for attribute in pipeline.get_attributes():
-            description = attribute.description
-            description = description.replace("\n", " ")
-            description = description.replace('"', '\\"')
-            header.info.add(attribute.name, "A", "String", description)
+        attributes = pipeline.get_attributes()
+
+    for attribute in attributes:
+        description = attribute.description
+        description = description.replace("\n", " ")
+        description = description.replace('"', '\\"')
+        header.info.add(attribute.name, "A", "String", description)
 
 
 def annotate(

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -167,7 +167,10 @@ def annotate(
                         if isinstance(attr, list):
                             attr = ";".join(map(str, attr))
                         elif isinstance(attr, dict):
-                            attr = ";".join(map(str, attr.values()))
+                            attr = ";".join(
+                                f"{k}:{v}"
+                                for k, v in attr.items()
+                            )
                         attr = str(attr).replace(";", "|")\
                                         .replace(",", "|")\
                                         .replace(" ", "_")

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -13,6 +13,8 @@ from pysam import VariantFile, TabixFile, \
 from dae.annotation.context import CLIAnnotationContext
 from dae.annotation.annotatable import VCFAllele
 from dae.annotation.annotation_factory import build_annotation_pipeline
+from dae.annotation.annotation_pipeline import AnnotationPipeline, \
+    ReannotationPipeline
 
 from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.utils.fs_utils import tabix_index_filename
@@ -48,6 +50,8 @@ def configure_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("-o", "--output",
                         help="Filename of the output VCF result",
                         default=None)
+    parser.add_argument("--reannotate", default=None,
+                        help="Old pipeline config to reannotate over")
     CLIAnnotationContext.add_context_arguments(parser)
     TaskGraphCli.add_arguments(parser)
     VerbosityConfiguration.set_argumnets(parser)
@@ -59,21 +63,58 @@ def update_header(variant_file, pipeline):
     header = variant_file.header
     header.add_meta("pipeline_annotation_tool", "GPF variant annotation.")
     header.add_meta("pipeline_annotation_tool", f"{' '.join(sys.argv)}")
-    for attribute in pipeline.get_attributes():
-        description = attribute.description
-        description = description.replace("\n", " ")
-        description = description.replace('"', '\\"')
-        header.info.add(attribute.name, "A", "String", description)
+    if isinstance(pipeline, ReannotationPipeline):
+        header_info_keys = variant_file.header.info.keys()
+        old_annotation_columns = {
+            attr.name for attr in pipeline.pipeline_old.get_attributes()
+            if not attr.internal
+        }
+        new_annotation_columns = {
+            attr.name for attr in pipeline.get_attributes()
+            if not attr.internal
+        }
+
+        for info_key in header_info_keys:
+            if info_key in old_annotation_columns \
+                    and info_key not in new_annotation_columns:
+                variant_file.header.info.remove_header(info_key)
+
+        for attr in pipeline.get_attributes():
+            if attr.internal:
+                continue
+
+            if attr.name not in variant_file.header.info:
+                description = attr.description
+                description = description.replace("\n", " ")
+                description = description.replace('"', '\\"')
+                header.info.add(attr.name, "A", "String", description)
+    else:
+        for attribute in pipeline.get_attributes():
+            description = attribute.description
+            description = description.replace("\n", " ")
+            description = description.replace('"', '\\"')
+            header.info.add(attribute.name, "A", "String", description)
 
 
 def annotate(
-        input_file, region, pipeline_config, grr_definition, out_file_path):
+        input_file, region, pipeline_config,
+        grr_definition, out_file_path,
+        reannotate=None
+):
     """Annotate a region from a given input VCF file using a pipeline."""
     grr = build_genomic_resource_repository(definition=grr_definition)
 
     pipeline = build_annotation_pipeline(
         pipeline_config=pipeline_config,
         grr_repository=grr)
+
+    if reannotate:
+        pipeline_old = build_annotation_pipeline(
+            pipeline_config_file=reannotate,
+            grr_repository=grr
+        )
+        pipeline_new = pipeline
+        pipeline = ReannotationPipeline(pipeline_new, pipeline_old)
 
     # cache pipeline
     resources: set[str] = set()
@@ -99,16 +140,34 @@ def annotate(
                     continue
 
                 has_value = {}
+
+                if isinstance(pipeline, ReannotationPipeline):
+                    for col in pipeline.attributes_deleted:
+                        del vcf_var.info[col]
+
                 for alt in vcf_var.alts:
-                    annotation = pipeline.annotate(
-                        VCFAllele(vcf_var.chrom, vcf_var.pos, vcf_var.ref, alt)
-                    )
+                    if isinstance(pipeline, ReannotationPipeline):
+                        annotation = pipeline.annotate(
+                            VCFAllele(
+                                vcf_var.chrom, vcf_var.pos, vcf_var.ref, alt
+                            ), dict(vcf_var.info)
+                        )
+                    else:
+                        annotation = pipeline.annotate(
+                            VCFAllele(
+                                vcf_var.chrom, vcf_var.pos, vcf_var.ref, alt
+                            )
+                        )
 
                     for buff, attribute in zip(buffers, annotation_attributes):
                         attr = annotation.get(attribute.name)
                         attr = attr if attr is not None else "."
                         if attr != ".":
                             has_value[attribute.name] = True
+                        if isinstance(attr, list):
+                            attr = ";".join(map(str, attr))
+                        elif isinstance(attr, dict):
+                            attr = ";".join(map(str, attr.values()))
                         attr = str(attr).replace(";", "|")\
                                         .replace(",", "|")\
                                         .replace(" ", "_")
@@ -244,7 +303,8 @@ def cli(raw_args: Optional[list[str]] = None) -> None:
                 f"part-{index}",
                 annotate,
                 [args.input, region,
-                 pipeline.get_info(), grr.definition, file_path],
+                 pipeline.get_info(), grr.definition,
+                 file_path, args.reannotate],
                 []
             ))
 
@@ -265,7 +325,7 @@ def cli(raw_args: Optional[list[str]] = None) -> None:
     def run_sequentially():
         assert grr is not None
         annotate(args.input, tuple(), pipeline.get_info(),
-                 grr.definition, output)
+                 grr.definition, output, args.reannotate)
 
     if tabix_index_filename(args.input):
         run_parallelized()

--- a/dae/dae/annotation/annotation_pipeline.py
+++ b/dae/dae/annotation/annotation_pipeline.py
@@ -254,7 +254,8 @@ class ReannotationPipeline(AnnotationPipeline):
         self.attributes_deleted: list[str] = []
         for deleted_info in [i for i in infos_old if i not in infos_new]:
             for attr in deleted_info.attributes:
-                self.attributes_deleted.append(attr.name)
+                if not attr.internal:
+                    self.attributes_deleted.append(attr.name)
 
         self.annotators_new: set[AnnotatorInfo] = {
             i for i in infos_new if i not in infos_old

--- a/dae/dae/annotation/effect_annotator.py
+++ b/dae/dae/annotation/effect_annotator.py
@@ -60,9 +60,12 @@ class EffectAnnotatorAdapter(AnnotatorBase):
 
         info.resources += [genome.resource, gene_models.resource]
         if not info.attributes:
-            info.attributes = AnnotationConfigParser.parse_raw_attributes(
-                ["worst_effect", "gene_effects", "effect_details",
-                 "gene_list"])
+            info.attributes = AnnotationConfigParser.parse_raw_attributes([
+                "worst_effect",
+                "effect_details",
+                {"destination": "gene_effects", "internal": True},
+                {"destination": "gene_list", "internal": True}
+            ])
         super().__init__(pipeline, info, {
             "worst_effect": ("str", "Worst effect accross all transcripts."),
             "gene_effects": ("str", "Effects types for genes. Format: "

--- a/dae/dae/annotation/tests/test_annotate_columns_cnv_pipeline.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_cnv_pipeline.py
@@ -253,5 +253,4 @@ def test_bad_cnv_gene_score_annotation(infile: str, annotate_cnv_fixture):
 
     df = pd.read_csv(root_path / "result.tsv", sep="\t")
     assert list(df.worst_effect.values) == ["CNV+"]
-    assert list(df.gene_effects.values) == ["None:CNV+"]
     assert list(df.gene_score1.values) == ["None"]

--- a/dae/dae/annotation/tests/test_annotate_columns_cnv_pipeline.py
+++ b/dae/dae/annotation/tests/test_annotate_columns_cnv_pipeline.py
@@ -190,7 +190,6 @@ def test_cnv_gene_score_annotation(infile: str, annotate_cnv_fixture):
 
     df = pd.read_csv(root_path / "result.tsv", sep="\t")
     assert list(df.worst_effect.values) == ["CNV+", "CNV-"]
-    assert list(df.gene_effects.values) == ["g1:CNV+", "g2:CNV-"]
     assert list(df.gene_score1.values) == [10.1, 20.2]
 
 

--- a/dae/dae/annotation/tests/test_reannotation.py
+++ b/dae/dae/annotation/tests/test_reannotation.py
@@ -302,7 +302,7 @@ def test_deleted_attributes(reannotation_grr) -> None:
     assert len(reannotation.annotators_rerun) == 0
     assert len(reannotation.attributes_reused) == 0
     assert reannotation.attributes_deleted == [
-        "worst_effect", "gene_effects", "effect_details", "gene_list"
+        "worst_effect", "effect_details",
     ]
 
 
@@ -517,8 +517,8 @@ def test_annotate_columns_reannotation(
     root_path, reannotation_grr  # pylint: disable=unused-argument
 ):
     in_content = (
-        "chrom\tpos\tscore\tworst_effect\tgene_effects\teffect_details\tgene_list\tgene_score1\tgene_score2\n"  # noqa
-        "chr1\t23\t0.1\tbla\tbla\tbla\tbla\tbla\tbla\n"
+        "chrom\tpos\tscore\tworst_effect\teffect_details\tgene_score1\tgene_score2\n"  # noqa
+        "chr1\t23\t0.1\tbla\tbla\tbla\tbla\n"
     )
     out_expected_header = [
         "chrom", "pos", "score", "worst_effect", "gene_list", "gene_score1"
@@ -546,8 +546,8 @@ def test_annotate_columns_reannotation_internal(
     root_path, reannotation_grr  # pylint: disable=unused-argument
 ):
     in_content = (
-        "chrom\tpos\tscore\tworst_effect\tgene_effects\teffect_details\tgene_list\tgene_score1\n"  # noqa
-        "chr1\t23\t0.1\tbla\tbla\tbla\tbla\tbla\n"
+        "chrom\tpos\tscore\tworst_effect\teffect_details\tgene_score1\n"  # noqa
+        "chr1\t23\t0.1\tbla\tbla\tbla\n"
     )
     out_expected_header = [
         "chrom", "pos", "score", "worst_effect", "gene_list", "gene_score1"
@@ -578,15 +578,14 @@ def test_annotate_vcf_reannotation(
         ##fileformat=VCFv4.2
         ##INFO=<ID=score,Number=A,Type=Float,Description="">
         ##INFO=<ID=worst_effect,Number=A,Type=String,Description="">
-        ##INFO=<ID=gene_effects,Number=A,Type=String,Description="">
         ##INFO=<ID=effect_details,Number=A,Type=String,Description="">
         ##INFO=<ID=gene_list,Number=A,Type=String,Description="">
         ##INFO=<ID=gene_score1,Number=A,Type=String,Description="">
         ##INFO=<ID=gene_score2,Number=A,Type=String,Description="">
         ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
         ##contig=<ID=foo>
-        #CHROM POS ID REF ALT QUAL FILTER INFO                                                                                                                  FORMAT m1  d1  c1
-        foo    12  .  C   T   .    .      score=0.1;worst_effect=splice-site;gene_effects=bla;effect_details=bla;gene_list=g1;gene_score1=10.1;gene_score2=20.2 GT     0/1 0/0 0/0
+        #CHROM POS ID REF ALT QUAL FILTER INFO                                                                                                 FORMAT m1  d1  c1
+        foo    12  .  C   T   .    .      score=0.1;worst_effect=splice-site;effect_details=bla;gene_list=g1;gene_score1=10.1;gene_score2=20.2 GT     0/1 0/0 0/0
     """)
 
     in_file = root_path / "in.vcf"
@@ -604,6 +603,9 @@ def test_annotate_vcf_reannotation(
         ]
     ])
     out_vcf = pysam.VariantFile(out_file)
+
+    with open(out_file, "r") as output_txt:
+        print(output_txt.read())
 
     assert set(out_vcf.header.info.keys()) == {  # pylint: disable=no-member
         "score", "worst_effect", "gene_list", "gene_score1"

--- a/dae/dae/genomic_resources/aggregators.py
+++ b/dae/dae/genomic_resources/aggregators.py
@@ -332,4 +332,4 @@ def validate_aggregator(aggregator_type: str) -> None:
         build_aggregator(aggregator_type)
     except Exception as ex:
         raise ValueError(
-            f"Incorrenct aggregator '{aggregator_type}'", ex) from ex
+            f"Incorrect aggregator '{aggregator_type}'", ex) from ex


### PR DESCRIPTION
## Background

Reannotation support was necessary for the `annotate_vcf.py` tool after it was done in the `annotate_columns.py` tool.

## Aim
Add support for `--reannotation` flag in `annotate_vcf.py`.

## Implementation

Reannotation in `annotate_vcf.py` was made similarly to the way it works in `annotate_columns.py`. This PR also fixes a bug with `annotate_columns.py`, where if an annotator with internal attributes in the old pipeline is deleted in the new pipeline, it will attempt to access them where it cannot and crash. Also included is a change to the default attributes of `EffectAnnotator`, which used to be internal by default, but were changed at some point (most likely by accident).
