### PR TITLE
Add default permission denied prompt

### DIFF
--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -154,15 +154,21 @@ class PermissionDeniedPromptView(QueryBaseView):
         super(PermissionDeniedPromptView, self).__init__()
 
         dae_config = self.gpf_instance.dae_config
+        default_config = (
+            "The Genotype and Phenotype in Families (GPF) data is"
+            " accessible by registered users. Contact the system"
+            " administrator of the GPF system to get an account in"
+            " the system and get permission to access the data."
+        )
         if dae_config.gpfjs is None or \
                 dae_config.gpfjs.permission_denied_prompt_file is None:
-            self.permission_denied_prompt = ""
+            self.permission_denied_prompt = default_config
         else:
             prompt_filepath = dae_config.gpfjs.permission_denied_prompt_file
 
             if not os.path.exists(prompt_filepath) or\
                     not os.path.isfile(prompt_filepath):
-                self.permission_denied_prompt = ""
+                self.permission_denied_prompt = default_config
             else:
                 with open(prompt_filepath, "r") as infile:
                     self.permission_denied_prompt = infile.read()

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -154,7 +154,7 @@ class PermissionDeniedPromptView(QueryBaseView):
         super(PermissionDeniedPromptView, self).__init__()
 
         dae_config = self.gpf_instance.dae_config
-        default_config = (
+        default_prompt = (
             "The Genotype and Phenotype in Families (GPF) data is"
             " accessible by registered users. Contact the system"
             " administrator of the GPF system to get an account in"
@@ -162,13 +162,13 @@ class PermissionDeniedPromptView(QueryBaseView):
         )
         if dae_config.gpfjs is None or \
                 dae_config.gpfjs.permission_denied_prompt_file is None:
-            self.permission_denied_prompt = default_config
+            self.permission_denied_prompt = default_prompt
         else:
             prompt_filepath = dae_config.gpfjs.permission_denied_prompt_file
 
             if not os.path.exists(prompt_filepath) or\
                     not os.path.isfile(prompt_filepath):
-                self.permission_denied_prompt = default_config
+                self.permission_denied_prompt = default_prompt
             else:
                 with open(prompt_filepath, "r") as infile:
                     self.permission_denied_prompt = infile.read()


### PR DESCRIPTION
## Background

Currently, if the permission denied prompt config file is missing - it displays a blank page, without any warning or error.

## Aim

The aim is to provide a default permission denied config if one is missing. 