### PR TITLE
Remote study wrapper now doesn't round the response download

### DIFF
--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -347,6 +347,14 @@ class ResponseTransformer:
                         if val is None:
                             return "-"
                         try:
+                            if val is None:
+                                return "-"
+                            if col_format.endswith("d"):
+                                val = int(val)
+                            elif col_format.endswith("s"):
+                                val = str(val)
+                            elif col_format.endswith("f"):
+                                val = float(val)
                             return col_format % val
                         except Exception:  # pylint: disable=broad-except
                             logging.warning(

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -347,14 +347,6 @@ class ResponseTransformer:
                         if val is None:
                             return "-"
                         try:
-                            if val is None:
-                                return "-"
-                            if col_format.endswith("d"):
-                                val = int(val)
-                            elif col_format.endswith("s"):
-                                val = str(val)
-                            elif col_format.endswith("f"):
-                                val = float(val)
                             return col_format % val
                         except Exception:  # pylint: disable=broad-except
                             logging.warning(

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -589,6 +589,10 @@ class RemoteStudyWrapper(StudyWrapperBase):
             kwargs, reduce_alleles=False
         )
 
+        for source in sources:
+            if "format" in source:
+                del source["format"]
+
         def get_source(col: dict[str, Any]) -> Any:
             res = col["source"]
             if "role" in col:

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -575,9 +575,6 @@ class RemoteStudyWrapper(StudyWrapperBase):
             if not any(query_s["source"] == s["source"] for s in sources):
                 new_sources.append(query_s)
         sources.extend(new_sources)
-        for source in sources:
-            if "format" in source:
-                del source["format"]
         kwargs["sources"] = sources
 
         fam_id_idx = -1


### PR DESCRIPTION
## Background

Currently, when the Genotype browser download is made, the scores it downloads are not properly truncated. This makes the behavior inconsistent with the non-remote instance which rounds the float values up to the third number.

## Aim

To provide more consistent behavior.

## Implementation

Note: Tests have to be split on another issue due to the fixtures missing scores.
