### PR TITLE
Add django linting

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -43,4 +43,4 @@ dependencies:
     - sphinx-autorun==1.1.1
     - rangehttpserver==1.2.0
     - sphinxcontrib-video==0.0.1.dev3
-    - pylint-django==2.5
+    - pylint-django==2.5.3

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -43,3 +43,4 @@ dependencies:
     - sphinx-autorun==1.1.1
     - rangehttpserver==1.2.0
     - sphinxcontrib-video==0.0.1.dev3
+    - pylint-django==2.5

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,7 +27,10 @@ exclude = (?x)(
     | ^wdae/wdae/docs/conf\.py$
   )
 
-plugins = numpy.typing.mypy_plugin
+plugins = numpy.typing.mypy_plugin, mypy_django_plugin.main
+
+[mypy.plugins.django-stubs]
+django_settings_module = "wdae.test_settings"
 
 [mypy-matplotlib.*]
 ignore_missing_imports = True

--- a/pylintrc
+++ b/pylintrc
@@ -45,7 +45,9 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_django
+
+django-settings-module=wdae.test_settings
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
## Background
Our linting tools lacked support for Django's custom classes and often gave false positives.

## Aim
Remove the false positives in the lint warnings.

## Implementation
Implemented the unused mypy django-stubs module and added pylint-django 2.5.3
