### PR TITLE
Annotation config wildcards

### DIFF
--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -118,11 +118,15 @@ class AnnotationConfigParser:
         return result
 
     @staticmethod
-    def query_resources(wildcard: str, grr: GenomicResourceRepo) -> list[str]:
-        all_resources_ids = list(
-            map(lambda r: r.get_id(), grr.get_all_resources())
-        )
-        return fnmatch.filter(all_resources_ids, wildcard)
+    def query_resources(
+        annotator_type: str, wildcard: str, grr: GenomicResourceRepo
+    ) -> list[str]:
+        result = []
+        for resource in grr.get_all_resources():
+            if (resource.get_type() == annotator_type
+               and fnmatch.fnmatch(resource.get_id(), wildcard)):
+                result.append(resource.get_id())
+        return result
 
     @staticmethod
     def parse_minimal(raw: str) -> AnnotatorInfo:
@@ -136,7 +140,7 @@ class AnnotationConfigParser:
         if "*" in ann_details:
             assert grr is not None
             matching_resources = AnnotationConfigParser.query_resources(
-                ann_details, grr
+                ann_type, ann_details, grr
             )
             return [
                 AnnotatorInfo(ann_type, [], {"resource_id": resource})

--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -253,7 +253,7 @@ class AnnotationConfigParser:
         return AnnotationConfigParser.parse_raw(pipeline_raw_config, grr=grr)
 
     @staticmethod
-    def parse_config_file(filename: str) -> List[AnnotatorInfo]:
+    def parse_config_file(filename: str, grr: Optional[GenomicResourceRepo]) -> List[AnnotatorInfo]:
         """Parse annotation pipeline configuration file."""
         logger.info("loading annotation pipeline configuration: %s", filename)
         try:
@@ -264,7 +264,7 @@ class AnnotationConfigParser:
                 f"Problem reading the contents of the {filename} file.",
                 error) from error
 
-        return AnnotationConfigParser.parse_str(content)
+        return AnnotationConfigParser.parse_str(content, grr=grr)
 
     @staticmethod
     def parse_raw_attribute_config(
@@ -333,21 +333,6 @@ def build_annotation_pipeline(
         grr_repository_definition: Optional[dict] = None
 ) -> AnnotationPipeline:
     """Build an annotation pipeline."""
-    if pipeline_config_file is not None:
-        assert pipeline_config is None
-        assert pipeline_config_raw is None
-        assert pipeline_config_str is None
-        pipeline_config = AnnotationConfigParser.parse_config_file(
-            pipeline_config_file)
-    elif pipeline_config_str is not None:
-        assert pipeline_config_raw is None
-        assert pipeline_config is None
-        pipeline_config = AnnotationConfigParser.parse_str(pipeline_config_str)
-    elif pipeline_config_raw is not None:
-        assert pipeline_config is None
-        pipeline_config = AnnotationConfigParser.parse_raw(pipeline_config_raw)
-    assert pipeline_config is not None
-
     if not grr_repository:
         grr_repository = build_genomic_resource_repository(
             definition=grr_repository_definition,
@@ -355,6 +340,21 @@ def build_annotation_pipeline(
     else:
         assert grr_repository_file is None
         assert grr_repository_definition is None
+
+    if pipeline_config_file is not None:
+        assert pipeline_config is None
+        assert pipeline_config_raw is None
+        assert pipeline_config_str is None
+        pipeline_config = AnnotationConfigParser.parse_config_file(
+            pipeline_config_file, grr=grr_repository)
+    elif pipeline_config_str is not None:
+        assert pipeline_config_raw is None
+        assert pipeline_config is None
+        pipeline_config = AnnotationConfigParser.parse_str(pipeline_config_str, grr=grr_repository)
+    elif pipeline_config_raw is not None:
+        assert pipeline_config is None
+        pipeline_config = AnnotationConfigParser.parse_raw(pipeline_config_raw, grr=grr_repository)
+    assert pipeline_config is not None
 
     pipeline = AnnotationPipeline(grr_repository)
 

--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -121,6 +121,7 @@ class AnnotationConfigParser:
     def query_resources(
         annotator_type: str, wildcard: str, grr: GenomicResourceRepo
     ) -> list[str]:
+        """Collect resources matching a given query."""
         result = []
         for resource in grr.get_all_resources():
             if (resource.get_type() == annotator_type
@@ -130,12 +131,14 @@ class AnnotationConfigParser:
 
     @staticmethod
     def parse_minimal(raw: str) -> AnnotatorInfo:
+        """Parse a minimal-form annotation config."""
         return AnnotatorInfo(raw, [], {})
 
     @staticmethod
     def parse_short(
         raw: dict[str, Any], grr: Optional[GenomicResourceRepo] = None
     ) -> list[AnnotatorInfo]:
+        """Parse a short-form annotation config."""
         ann_type, ann_details = next(iter(raw.items()))
         if "*" in ann_details:
             assert grr is not None
@@ -150,6 +153,7 @@ class AnnotationConfigParser:
 
     @staticmethod
     def parse_complete(raw: dict[str, Any]) -> AnnotatorInfo:
+        """Parse a full-form annotation config."""
         ann_type, ann_details = next(iter(raw.items()))
         attributes = []
         if "attributes" in ann_details:
@@ -180,7 +184,7 @@ class AnnotationConfigParser:
                 # the minimal annotator configuration form
                 result.append(AnnotationConfigParser.parse_minimal(raw_cfg))
                 continue
-            elif isinstance(raw_cfg, dict):
+            if isinstance(raw_cfg, dict):
                 ann_details = next(iter(raw_cfg.values()))
                 if isinstance(ann_details, str):
                     # the short annotator configuation form
@@ -188,7 +192,7 @@ class AnnotationConfigParser:
                         raw_cfg, grr
                     ))
                     continue
-                elif isinstance(ann_details, dict):
+                if isinstance(ann_details, dict):
                     # the complete annotator configuration form
                     result.append(
                         AnnotationConfigParser.parse_complete(raw_cfg)

--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -146,7 +146,7 @@ class AnnotationConfigParser:
     @staticmethod
     def parse_minimal(raw: str, idx: int) -> AnnotatorInfo:
         """Parse a minimal-form annotation config."""
-        return AnnotatorInfo(raw, [], {}, uid=f"#{idx}")
+        return AnnotatorInfo(raw, [], {}, annotator_id=f"#{idx}")
 
     @staticmethod
     def parse_short(
@@ -163,13 +163,14 @@ class AnnotationConfigParser:
             return [
                 AnnotatorInfo(
                     ann_type, [], {"resource_id": resource},
-                    uid=f"#{idx}-{resource}"
+                    annotator_id=f"#{idx}-{resource}"
                 )
                 for resource in matching_resources
             ]
         return [
             AnnotatorInfo(
-                ann_type, [], {"resource_id": ann_details}, uid=f"#{idx}"
+                ann_type, [], {"resource_id": ann_details},
+                annotator_id=f"#{idx}"
             )
         ]
 
@@ -184,7 +185,9 @@ class AnnotationConfigParser:
             )
         parameters = {k: v for k, v in ann_details.items()
                       if k != "attributes"}
-        return AnnotatorInfo(ann_type, attributes, parameters, uid=f"#{idx}")
+        return AnnotatorInfo(
+            ann_type, attributes, parameters, annotator_id=f"#{idx}"
+        )
 
     @staticmethod
     def parse_raw(
@@ -383,7 +386,7 @@ def build_annotation_pipeline(
             pipeline.add_annotator(annotator)
         except ValueError as value_error:
             raise AnnotationConfigurationError(
-                f"The {annotator_config.uid} annotator"
+                f"The {annotator_config.annotator_id} annotator"
                 f" configuration is incorrect: ",
                 value_error) from value_error
 

--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -179,6 +179,7 @@ class AnnotationConfigParser:
             if isinstance(raw_cfg, str):
                 # the minimal annotator configuration form
                 result.append(AnnotationConfigParser.parse_minimal(raw_cfg))
+                continue
             elif isinstance(raw_cfg, dict):
                 ann_details = next(iter(raw_cfg.values()))
                 if isinstance(ann_details, str):
@@ -193,8 +194,6 @@ class AnnotationConfigParser:
                         AnnotationConfigParser.parse_complete(raw_cfg)
                     )
                     continue
-                else:
-                    raise AnnotationConfigurationError()
             raise AnnotationConfigurationError(dedent(f"""
                 Incorrect annotator configuation form: {raw_cfg}.
                 The allowed forms are:

--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -123,10 +123,24 @@ class AnnotationConfigParser:
     ) -> list[str]:
         """Collect resources matching a given query."""
         result = []
+        labels_query: dict[str, str] = {}
+
+        # Handle querying by labels
+        if wildcard.endswith("]"):
+            assert "[" in wildcard
+            wildcard, raw_labels = wildcard.split("[")
+            labels = raw_labels.strip("]").split(" and ")
+            for label in labels:
+                k, v = label.split("=")
+                labels_query[k] = v
+
         for resource in grr.get_all_resources():
             if (resource.get_type() == annotator_type
-               and fnmatch.fnmatch(resource.get_id(), wildcard)):
+               and fnmatch.fnmatch(resource.get_id(), wildcard)
+               and (not labels_query
+                    or labels_query.items() <= resource.get_labels().items())):
                 result.append(resource.get_id())
+
         return result
 
     @staticmethod

--- a/dae/dae/annotation/annotation_factory.py
+++ b/dae/dae/annotation/annotation_factory.py
@@ -253,7 +253,9 @@ class AnnotationConfigParser:
         return AnnotationConfigParser.parse_raw(pipeline_raw_config, grr=grr)
 
     @staticmethod
-    def parse_config_file(filename: str, grr: Optional[GenomicResourceRepo]) -> List[AnnotatorInfo]:
+    def parse_config_file(
+        filename: str, grr: Optional[GenomicResourceRepo]
+    ) -> List[AnnotatorInfo]:
         """Parse annotation pipeline configuration file."""
         logger.info("loading annotation pipeline configuration: %s", filename)
         try:
@@ -350,10 +352,12 @@ def build_annotation_pipeline(
     elif pipeline_config_str is not None:
         assert pipeline_config_raw is None
         assert pipeline_config is None
-        pipeline_config = AnnotationConfigParser.parse_str(pipeline_config_str, grr=grr_repository)
+        pipeline_config = AnnotationConfigParser.parse_str(
+            pipeline_config_str, grr=grr_repository)
     elif pipeline_config_raw is not None:
         assert pipeline_config is None
-        pipeline_config = AnnotationConfigParser.parse_raw(pipeline_config_raw, grr=grr_repository)
+        pipeline_config = AnnotationConfigParser.parse_raw(
+            pipeline_config_raw, grr=grr_repository)
     assert pipeline_config is not None
 
     pipeline = AnnotationPipeline(grr_repository)

--- a/dae/dae/annotation/annotation_pipeline.py
+++ b/dae/dae/annotation/annotation_pipeline.py
@@ -59,8 +59,10 @@ class AnnotatorInfo:
     def __init__(self, _type: str, attributes: list[AttributeInfo],
                  parameters: ParamsUsageMonitor | dict[str, Any],
                  documentation: str = "",
-                 resources: Optional[list[GenomicResource]] = None):
+                 resources: Optional[list[GenomicResource]] = None,
+                 uid: str = "N/A"):
         self.type = _type
+        self.uid = f"{uid} ({self.type})"
         self.attributes = attributes
         self.documentation = documentation
         if isinstance(parameters, ParamsUsageMonitor):
@@ -72,6 +74,7 @@ class AnnotatorInfo:
         else:
             self.resources = resources
 
+    uid: str
     type: str
     attributes: list[AttributeInfo]
     parameters: ParamsUsageMonitor

--- a/dae/dae/annotation/annotation_pipeline.py
+++ b/dae/dae/annotation/annotation_pipeline.py
@@ -60,9 +60,9 @@ class AnnotatorInfo:
                  parameters: ParamsUsageMonitor | dict[str, Any],
                  documentation: str = "",
                  resources: Optional[list[GenomicResource]] = None,
-                 uid: str = "N/A"):
+                 annotator_id: str = "N/A"):
         self.type = _type
-        self.uid = f"{uid} ({self.type})"
+        self.annotator_id = f"{annotator_id} ({self.type})"
         self.attributes = attributes
         self.documentation = documentation
         if isinstance(parameters, ParamsUsageMonitor):
@@ -74,7 +74,7 @@ class AnnotatorInfo:
         else:
             self.resources = resources
 
-    uid: str
+    annotator_id: str
     type: str
     attributes: list[AttributeInfo]
     parameters: ParamsUsageMonitor

--- a/dae/dae/annotation/tests/test_annotation_pipeline_config.py
+++ b/dae/dae/annotation/tests/test_annotation_pipeline_config.py
@@ -30,6 +30,10 @@ def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
                         - id: score
                           type: float
                           name: s1
+                        meta:
+                            labels:
+                                foo: ALPHA
+                                bar: GAMMA
                     """),
                     "data.txt": convert_to_tab_separated("""
                         chrom  pos_begin  s1
@@ -45,6 +49,10 @@ def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
                         - id: score
                           type: float
                           name: s2
+                        meta:
+                            labels:
+                                foo: BETA
+                                bar: GAMMA
                     """),
                     "data.txt": convert_to_tab_separated("""
                         chrom  pos_begin  s2
@@ -82,6 +90,10 @@ def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
                                 - id: score
                                   type: float
                                   name: s1
+                                meta:
+                                    labels:
+                                        foo: ALPHA
+                                        bar: DELTA
                             """),
                             "data.txt": convert_to_tab_separated("""
                                 chrom  pos_begin  s1
@@ -99,6 +111,10 @@ def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
                                 - id: score
                                   type: float
                                   name: s2
+                                meta:
+                                    labels:
+                                        foo: BETA
+                                        bar: DELTA
                             """),
                             "data.txt": convert_to_tab_separated("""
                                 chrom  pos_begin  s2
@@ -281,4 +297,35 @@ def test_wildcard_directory(test_grr: GenomicResourceRepo) -> None:
             "position_score", [],
             {"resource_id": "scores/scoredir_two/subscore"}
         ),
+    ]
+
+
+def test_wildcard_label_single(test_grr: GenomicResourceRepo) -> None:
+    pipeline_config = AnnotationConfigParser.parse_str("""
+        - position_score: score_*[foo=ALPHA]
+    """, grr=test_grr)
+    assert pipeline_config == [
+        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
+    ]
+
+
+def test_wildcard_label_and_dir(test_grr: GenomicResourceRepo) -> None:
+    pipeline_config = AnnotationConfigParser.parse_str("""
+        - position_score: "*[foo=ALPHA]"
+    """, grr=test_grr)
+    assert pipeline_config == [
+        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
+        AnnotatorInfo(
+            "position_score", [],
+            {"resource_id": "scores/scoredir_one/subscore"}
+        ),
+    ]
+
+
+def test_wildcard_label_multiple(test_grr: GenomicResourceRepo) -> None:
+    pipeline_config = AnnotationConfigParser.parse_str("""
+        - position_score: "*[foo=ALPHA and bar=GAMMA]"
+    """, grr=test_grr)
+    assert pipeline_config == [
+        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
     ]

--- a/dae/dae/annotation/tests/test_annotation_pipeline_config.py
+++ b/dae/dae/annotation/tests/test_annotation_pipeline_config.py
@@ -159,8 +159,9 @@ def test_simple_annotator_simple() -> None:
             resource_id: resource
     """)
 
-    assert pipeline_config == \
-        [AnnotatorInfo("annotator", [], {"resource_id": "resource"})]
+    assert pipeline_config == [
+        AnnotatorInfo("annotator", [], {"resource_id": "resource"}, uid="#0")
+    ]
 
 
 def test_short_annotator_config() -> None:
@@ -168,15 +169,16 @@ def test_short_annotator_config() -> None:
         - annotator: resource
     """)
 
-    assert pipeline_config == \
-        [AnnotatorInfo("annotator", [], {"resource_id": "resource"})]
+    assert pipeline_config == [
+        AnnotatorInfo("annotator", [], {"resource_id": "resource"}, uid="#0")
+    ]
 
 
 def test_minimal_annotator_config() -> None:
     pipeline_config = AnnotationConfigParser.parse_str("""
         - annotator
     """)
-    assert pipeline_config == [AnnotatorInfo("annotator", [], {})]
+    assert pipeline_config == [AnnotatorInfo("annotator", [], {}, uid="#0")]
 
 
 def test_annotator_config_with_more_parameters() -> None:
@@ -186,9 +188,12 @@ def test_annotator_config_with_more_parameters() -> None:
                 key: value
     """)
 
-    assert pipeline_config == \
-        [AnnotatorInfo("annotator", [], {"resource_id": "resource",
-                                         "key": "value"})]
+    assert pipeline_config == [
+        AnnotatorInfo(
+            "annotator", [], {"resource_id": "resource", "key": "value"},
+            uid="#0"
+        )
+    ]
 
 
 def test_annotator_config_with_attributes() -> None:
@@ -216,7 +221,7 @@ def test_annotator_config_with_attributes() -> None:
             AttributeInfo("att4", "some_score", False, {"att_param": "foo"}),
             AttributeInfo("att5", "att5", True, {"att_param": "raz"}),
             AttributeInfo("att6", "att6", False, {})],
-            {})]
+            {}, uid="#0")]
 
 
 def test_annotator_config_with_params_and_attributes() -> None:
@@ -234,7 +239,7 @@ def test_annotator_config_with_params_and_attributes() -> None:
             AttributeInfo("att2", "att2", False, {}),
         ], {
             "resource_id": "resource"
-        })]
+        }, uid="#0")]
 
 
 def test_empty_config() -> None:
@@ -269,7 +274,7 @@ def test_effect_annotator_extra_attributes() -> None:
             AttributeInfo("genes_missense", "genes_missense", False, {})], {
             "gene_models": "hg38/gene_models/refSeq_20200330",
             "genome": "hg38/genomes/GRCh38-hg38",
-            "promoter_len": 100}
+            "promoter_len": 100}, uid="#0"
         )
     ]
 
@@ -279,8 +284,14 @@ def test_wildcard_basic(test_grr: GenomicResourceRepo) -> None:
         - position_score: score_*
     """, grr=test_grr)
     assert pipeline_config == [
-        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
-        AnnotatorInfo("position_score", [], {"resource_id": "score_two"}),
+        AnnotatorInfo(
+            "position_score", [], {"resource_id": "score_one"},
+            uid="#0-score_one"
+        ),
+        AnnotatorInfo(
+            "position_score", [], {"resource_id": "score_two"},
+            uid="#0-score_two"
+        ),
     ]
 
 
@@ -291,11 +302,13 @@ def test_wildcard_directory(test_grr: GenomicResourceRepo) -> None:
     assert pipeline_config == [
         AnnotatorInfo(
             "position_score", [],
-            {"resource_id": "scores/scoredir_one/subscore"}
+            {"resource_id": "scores/scoredir_one/subscore"},
+            uid="#0-scores/scoredir_one/subscore"
         ),
         AnnotatorInfo(
             "position_score", [],
-            {"resource_id": "scores/scoredir_two/subscore"}
+            {"resource_id": "scores/scoredir_two/subscore"},
+            uid="#0-scores/scoredir_two/subscore"
         ),
     ]
 
@@ -305,7 +318,10 @@ def test_wildcard_label_single(test_grr: GenomicResourceRepo) -> None:
         - position_score: score_*[foo=ALPHA]
     """, grr=test_grr)
     assert pipeline_config == [
-        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
+        AnnotatorInfo(
+            "position_score", [], {"resource_id": "score_one"},
+            uid="#0-score_one"
+        )
     ]
 
 
@@ -314,10 +330,14 @@ def test_wildcard_label_and_dir(test_grr: GenomicResourceRepo) -> None:
         - position_score: "*[foo=ALPHA]"
     """, grr=test_grr)
     assert pipeline_config == [
-        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
+        AnnotatorInfo(
+            "position_score", [], {"resource_id": "score_one"},
+            uid="#0-score_one"
+        ),
         AnnotatorInfo(
             "position_score", [],
-            {"resource_id": "scores/scoredir_one/subscore"}
+            {"resource_id": "scores/scoredir_one/subscore"},
+            uid="#0-scores/scoredir_one/subscore"
         ),
     ]
 
@@ -327,5 +347,8 @@ def test_wildcard_label_multiple(test_grr: GenomicResourceRepo) -> None:
         - position_score: "*[foo=ALPHA and bar=GAMMA]"
     """, grr=test_grr)
     assert pipeline_config == [
-        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
+        AnnotatorInfo(
+            "position_score", [], {"resource_id": "score_one"},
+            uid="#0-score_one"
+        ),
     ]

--- a/dae/dae/annotation/tests/test_annotation_pipeline_config.py
+++ b/dae/dae/annotation/tests/test_annotation_pipeline_config.py
@@ -160,7 +160,8 @@ def test_simple_annotator_simple() -> None:
     """)
 
     assert pipeline_config == [
-        AnnotatorInfo("annotator", [], {"resource_id": "resource"}, uid="#0")
+        AnnotatorInfo("annotator", [], {"resource_id": "resource"},
+                      annotator_id="#0")
     ]
 
 
@@ -170,7 +171,9 @@ def test_short_annotator_config() -> None:
     """)
 
     assert pipeline_config == [
-        AnnotatorInfo("annotator", [], {"resource_id": "resource"}, uid="#0")
+        AnnotatorInfo(
+            "annotator", [], {"resource_id": "resource"}, annotator_id="#0"
+        )
     ]
 
 
@@ -178,7 +181,9 @@ def test_minimal_annotator_config() -> None:
     pipeline_config = AnnotationConfigParser.parse_str("""
         - annotator
     """)
-    assert pipeline_config == [AnnotatorInfo("annotator", [], {}, uid="#0")]
+    assert pipeline_config == [
+        AnnotatorInfo("annotator", [], {}, annotator_id="#0")
+    ]
 
 
 def test_annotator_config_with_more_parameters() -> None:
@@ -191,7 +196,7 @@ def test_annotator_config_with_more_parameters() -> None:
     assert pipeline_config == [
         AnnotatorInfo(
             "annotator", [], {"resource_id": "resource", "key": "value"},
-            uid="#0"
+            annotator_id="#0"
         )
     ]
 
@@ -221,7 +226,7 @@ def test_annotator_config_with_attributes() -> None:
             AttributeInfo("att4", "some_score", False, {"att_param": "foo"}),
             AttributeInfo("att5", "att5", True, {"att_param": "raz"}),
             AttributeInfo("att6", "att6", False, {})],
-            {}, uid="#0")]
+            {}, annotator_id="#0")]
 
 
 def test_annotator_config_with_params_and_attributes() -> None:
@@ -239,7 +244,7 @@ def test_annotator_config_with_params_and_attributes() -> None:
             AttributeInfo("att2", "att2", False, {}),
         ], {
             "resource_id": "resource"
-        }, uid="#0")]
+        }, annotator_id="#0")]
 
 
 def test_empty_config() -> None:
@@ -274,7 +279,7 @@ def test_effect_annotator_extra_attributes() -> None:
             AttributeInfo("genes_missense", "genes_missense", False, {})], {
             "gene_models": "hg38/gene_models/refSeq_20200330",
             "genome": "hg38/genomes/GRCh38-hg38",
-            "promoter_len": 100}, uid="#0"
+            "promoter_len": 100}, annotator_id="#0"
         )
     ]
 
@@ -286,11 +291,11 @@ def test_wildcard_basic(test_grr: GenomicResourceRepo) -> None:
     assert pipeline_config == [
         AnnotatorInfo(
             "position_score", [], {"resource_id": "score_one"},
-            uid="#0-score_one"
+            annotator_id="#0-score_one"
         ),
         AnnotatorInfo(
             "position_score", [], {"resource_id": "score_two"},
-            uid="#0-score_two"
+            annotator_id="#0-score_two"
         ),
     ]
 
@@ -303,12 +308,12 @@ def test_wildcard_directory(test_grr: GenomicResourceRepo) -> None:
         AnnotatorInfo(
             "position_score", [],
             {"resource_id": "scores/scoredir_one/subscore"},
-            uid="#0-scores/scoredir_one/subscore"
+            annotator_id="#0-scores/scoredir_one/subscore"
         ),
         AnnotatorInfo(
             "position_score", [],
             {"resource_id": "scores/scoredir_two/subscore"},
-            uid="#0-scores/scoredir_two/subscore"
+            annotator_id="#0-scores/scoredir_two/subscore"
         ),
     ]
 
@@ -320,7 +325,7 @@ def test_wildcard_label_single(test_grr: GenomicResourceRepo) -> None:
     assert pipeline_config == [
         AnnotatorInfo(
             "position_score", [], {"resource_id": "score_one"},
-            uid="#0-score_one"
+            annotator_id="#0-score_one"
         )
     ]
 
@@ -332,12 +337,12 @@ def test_wildcard_label_and_dir(test_grr: GenomicResourceRepo) -> None:
     assert pipeline_config == [
         AnnotatorInfo(
             "position_score", [], {"resource_id": "score_one"},
-            uid="#0-score_one"
+            annotator_id="#0-score_one"
         ),
         AnnotatorInfo(
             "position_score", [],
             {"resource_id": "scores/scoredir_one/subscore"},
-            uid="#0-scores/scoredir_one/subscore"
+            annotator_id="#0-scores/scoredir_one/subscore"
         ),
     ]
 
@@ -349,6 +354,6 @@ def test_wildcard_label_multiple(test_grr: GenomicResourceRepo) -> None:
     assert pipeline_config == [
         AnnotatorInfo(
             "position_score", [], {"resource_id": "score_one"},
-            uid="#0-score_one"
+            annotator_id="#0-score_one"
         ),
     ]

--- a/dae/dae/annotation/tests/test_annotation_pipeline_config.py
+++ b/dae/dae/annotation/tests/test_annotation_pipeline_config.py
@@ -206,6 +206,6 @@ def test_basic_config_wildcard(test_grr: GenomicResourceRepo) -> None:
         - position_score: score_*
     """, grr=test_grr)
     assert pipeline_config == [
-        AnnotatorInfo("position_score", [], {'resource_id': 'score_one'}),
-        AnnotatorInfo("position_score", [], {'resource_id': 'score_two'}),
+        AnnotatorInfo("position_score", [], {"resource_id": "score_one"}),
+        AnnotatorInfo("position_score", [], {"resource_id": "score_two"}),
     ]

--- a/dae/dae/annotation/tests/test_annotation_pipeline_config.py
+++ b/dae/dae/annotation/tests/test_annotation_pipeline_config.py
@@ -1,7 +1,62 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 
+import pathlib
+import textwrap
+import pytest
 from dae.annotation.annotation_pipeline import AnnotatorInfo, AttributeInfo
 from dae.annotation.annotation_factory import AnnotationConfigParser
+from dae.genomic_resources import build_genomic_resource_repository
+from dae.genomic_resources.repository import GenomicResourceRepo
+from dae.testing import setup_directories, convert_to_tab_separated
+
+
+@pytest.fixture
+def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
+    root_path = tmp_path
+    setup_directories(
+        root_path, {
+            "grr.yaml": textwrap.dedent(f"""
+                id: reannotation_repo
+                type: dir
+                directory: "{root_path}/grr"
+            """),
+            "grr": {
+                "score_one": {
+                    "genomic_resource.yaml": textwrap.dedent("""
+                        type: position_score
+                        table:
+                            filename: data.txt
+                        scores:
+                        - id: score
+                          type: float
+                          name: s1
+                    """),
+                    "data.txt": convert_to_tab_separated("""
+                        chrom  pos_begin  s1
+                        foo    1          0.1
+                    """)
+                },
+                "score_two": {
+                    "genomic_resource.yaml": textwrap.dedent("""
+                        type: position_score
+                        table:
+                            filename: data.txt
+                        scores:
+                        - id: score
+                          type: float
+                          name: s2
+                    """),
+                    "data.txt": convert_to_tab_separated("""
+                        chrom  pos_begin  s2
+                        foo    1          0.2
+                    """)
+                },
+            },
+        }
+    )
+    return build_genomic_resource_repository(file_name=str(
+        root_path / "grr.yaml"
+    ))
 
 
 def test_simple_annotator_simple() -> None:
@@ -122,4 +177,15 @@ def test_effect_annotator_extra_attributes() -> None:
             "genome": "hg38/genomes/GRCh38-hg38",
             "promoter_len": 100}
         )
+    ]
+
+
+def test_basic_config_wildcard(test_grr: GenomicResourceRepo) -> None:
+    # TODO Add grr to arguments
+    pipeline_config = AnnotationConfigParser.parse_str("""
+        - position_score: score_*
+    """, grr=test_grr)
+    assert pipeline_config == [
+        AnnotatorInfo("position_score", [], {'resource_id': 'score_one'}),
+        AnnotatorInfo("position_score", [], {'resource_id': 'score_two'}),
     ]

--- a/dae/dae/annotation/tests/test_annotation_pipeline_config.py
+++ b/dae/dae/annotation/tests/test_annotation_pipeline_config.py
@@ -51,6 +51,26 @@ def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
                         foo    1          0.2
                     """)
                 },
+                "score_three": {
+                    "genomic_resource.yaml": textwrap.dedent("""
+                        type: np_score
+                        table:
+                            filename: data.txt
+                            reference:
+                              name: ref
+                            alternative:
+                              name: alt
+                        scores:
+                            - id: s3
+                              name: s3
+                              type: float
+                              desc: ""
+                    """),
+                    "data.txt": convert_to_tab_separated("""
+                        chrom  pos_begin  ref  alt  s3
+                        foo    1          A    G    0.2
+                    """)
+                },
             },
         }
     )

--- a/dae/dae/annotation/tests/test_pipeline.py
+++ b/dae/dae/annotation/tests/test_pipeline.py
@@ -1,10 +1,66 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import pathlib
+import textwrap
+import pytest
+from dae.annotation.annotatable import Position
 from dae.annotation.annotation_factory import build_annotation_pipeline
+from dae.genomic_resources import build_genomic_resource_repository
+from dae.genomic_resources.repository import GenomicResourceRepo
+from dae.testing import setup_directories, convert_to_tab_separated
+
+
+@pytest.fixture
+def test_grr(tmp_path: pathlib.Path) -> GenomicResourceRepo:
+    root_path = tmp_path
+    setup_directories(
+        root_path, {
+            "grr.yaml": textwrap.dedent(f"""
+                id: reannotation_repo
+                type: dir
+                directory: "{root_path}/grr"
+            """),
+            "grr": {
+                "score_one": {
+                    "genomic_resource.yaml": textwrap.dedent("""
+                        type: position_score
+                        table:
+                            filename: data.txt
+                        scores:
+                        - id: s1
+                          type: float
+                          name: s1
+                    """),
+                    "data.txt": convert_to_tab_separated("""
+                        chrom  pos_begin  s1
+                        foo    1          0.1
+                    """)
+                },
+                "score_two": {
+                    "genomic_resource.yaml": textwrap.dedent("""
+                        type: position_score
+                        table:
+                            filename: data.txt
+                        scores:
+                        - id: s2
+                          type: float
+                          name: s2
+                    """),
+                    "data.txt": convert_to_tab_separated("""
+                        chrom  pos_begin  s2
+                        foo    1          0.2
+                    """)
+                },
+            },
+        }
+    )
+    return build_genomic_resource_repository(file_name=str(
+        root_path / "grr.yaml"
+    ))
 
 
 def test_build_pipeline(
-        annotation_config, grr_fixture):
-
+    annotation_config: str, grr_fixture: GenomicResourceRepo
+) -> None:
     pipeline = build_annotation_pipeline(
         pipeline_config_file=annotation_config,
         grr_repository=grr_fixture)
@@ -13,8 +69,8 @@ def test_build_pipeline(
 
 
 def test_build_pipeline_schema(
-        annotation_config, grr_fixture):
-
+    annotation_config: str, grr_fixture: GenomicResourceRepo
+) -> None:
     pipeline = build_annotation_pipeline(
         pipeline_config_file=annotation_config,
         grr_repository=grr_fixture)
@@ -26,3 +82,15 @@ def test_build_pipeline_schema(
     attribute = pipeline.get_attribute_info("cadd_raw")
     assert attribute is not None
     assert attribute.type == "float", attribute
+
+
+def test_pipeline_with_wildcards(test_grr: GenomicResourceRepo) -> None:
+    pipeline_config = """
+        - position_score: score_*
+    """
+    pipeline = build_annotation_pipeline(
+        pipeline_config_str=pipeline_config,
+        grr_repository=test_grr)
+    result = pipeline.annotate(Position("foo", 1))
+    assert len(pipeline.annotators) == 2
+    assert result == {"s1": 0.1, "s2": 0.2}


### PR DESCRIPTION
## Aim

Implement wildcards for annotator configurations so that multiple annotators can be written using a single UNIX-style wildcard string that matches multiple resource.

The wildcards look like so:
```
position_score: scores/*[foo=one and bar=two]
```
Where the `*` symbols work as expected (such as in programs like `ls`), while the bracketed part selects resource labels.

## Implementation

The annotator config parser class will perform an additional step if it detects wildcards symbols, where it will parse the string and expand it into as many annotators according to the matching resources that have been found.
