### PR TITLE
Fix family combining

### DIFF
--- a/dae/dae/pedigrees/family.py
+++ b/dae/dae/pedigrees/family.py
@@ -810,22 +810,23 @@ class FamiliesData(Mapping[str, Family]):
             first: FamiliesData, second: FamiliesData,
             forced: bool = True) -> FamiliesData:
         """Combine families from two families data objects."""
-        same_families = set(first.keys()) & \
-            set(second.keys())
+        all_families = set(first.keys()) | set(second.keys())
         combined_dict: dict[str, Family] = {}
-        combined_dict.update(first)
-        combined_dict.update(second)
         mismatched_families = []
-        for fid in same_families:
-            try:
-                combined_dict[fid] = Family.merge(
-                    first[fid], second[fid], forced=forced)
-            except AssertionError:
-                logger.error(
-                    "mismatched families: %s, %s",
-                    first[fid], second[fid], exc_info=True)
-
-                mismatched_families.append(fid)
+        for fid in all_families:
+            if fid in first and fid in second:
+                try:
+                    combined_dict[fid] = Family.merge(
+                        first[fid], second[fid], forced=forced)
+                except AssertionError:
+                    logger.error(
+                        "mismatched families: %s, %s",
+                        first[fid], second[fid], exc_info=True)
+                    mismatched_families.append(fid)
+            elif fid in first:
+                combined_dict[fid] = copy.deepcopy(first[fid])
+            elif fid in second:
+                combined_dict[fid] = copy.deepcopy(second[fid])
 
         if len(mismatched_families) > 0:
             logger.warning("mismatched families: %s", mismatched_families)

--- a/dae/dae/pedigrees/family.py
+++ b/dae/dae/pedigrees/family.py
@@ -667,10 +667,6 @@ class FamiliesData(Mapping[str, Family]):
         families_data = FamiliesData.from_family_persons(
             {fam.family_id: fam.full_members for fam in families.values()}
         )
-        # FIXME: Avoid this workaround
-        for family_id, family in families.items():
-            families_data[family_id]\
-                ._tags = family.tags  # pylint: disable=protected-access
 
         return families_data
 

--- a/dae/dae/pedigrees/tests/test_combine_families.py
+++ b/dae/dae/pedigrees/tests/test_combine_families.py
@@ -9,6 +9,7 @@ from dae.pedigrees.family_tag_builder import FamilyTagsBuilder
 
 from dae.testing import setup_pedigree
 
+
 @pytest.fixture
 def ped_a(tmp_path: pathlib.Path) -> FamiliesData:
     ped_path = setup_pedigree(
@@ -21,6 +22,7 @@ def ped_a(tmp_path: pathlib.Path) -> FamiliesData:
         """)
     )
     return FamiliesLoader(str(ped_path)).load()
+
 
 @pytest.fixture
 def ped_b(tmp_path: pathlib.Path) -> FamiliesData:

--- a/dae/dae/pedigrees/tests/test_combine_families.py
+++ b/dae/dae/pedigrees/tests/test_combine_families.py
@@ -247,14 +247,6 @@ def test_combine_families_creates_copy(
     assert len(ped_a["f1"].tags.intersection(["tag_family_type"])) == 0
     assert len(ped_f["f2"].tags.intersection(["tag_family_type"])) == 0
     assert len(ped_g["f1"].tags.intersection(["tag_family_type"])) == 0
-    print(ped_a["f1"].persons["f1.dad"]._attributes)
-    print(ped_f["f2"].persons["f2.dad"]._attributes)
-    print(ped_g["f1"].persons["f1.dad"]._attributes)
-    print(ped_g["f3"].persons["f3.dad"]._attributes)
-    print(ped_a["f1"].tags)
-    print(ped_f["f2"].tags)
-    print(ped_g["f1"].tags)
-    print(ped_g["f3"].tags)
     assert ped_a["f1"].persons["f1.dad"].get_attr("tag_family_type") is None
     assert ped_f["f2"].persons["f2.dad"].get_attr("tag_family_type") is None
     assert ped_g["f1"].persons["f1.dad"].get_attr("tag_family_type") is None

--- a/dae/dae/pedigrees/tests/test_combine_families.py
+++ b/dae/dae/pedigrees/tests/test_combine_families.py
@@ -5,9 +5,9 @@ import pathlib
 import pytest
 from dae.pedigrees.loader import FamiliesLoader
 from dae.pedigrees.family import FamiliesData
+from dae.pedigrees.family_tag_builder import FamilyTagsBuilder
 
 from dae.testing import setup_pedigree
-
 
 @pytest.fixture
 def ped_a(tmp_path: pathlib.Path) -> FamiliesData:
@@ -21,7 +21,6 @@ def ped_a(tmp_path: pathlib.Path) -> FamiliesData:
         """)
     )
     return FamiliesLoader(str(ped_path)).load()
-
 
 @pytest.fixture
 def ped_b(tmp_path: pathlib.Path) -> FamiliesData:
@@ -73,6 +72,37 @@ f1        f1.dad    0      0      1    1       dad
 f1        f1.mom    0      0      2    1       mom
 f1        f1.s1     f1.dad f1.mom 0    1       sib
 f1        f1.s2     f1.dad f1.mom 2    2       sib
+        """)
+    )
+    return FamiliesLoader(str(ped_path)).load()
+
+
+@pytest.fixture
+def ped_f(tmp_path: pathlib.Path) -> FamiliesData:
+    ped_path = setup_pedigree(
+        tmp_path / "ped_a" / "ped.ped", textwrap.dedent("""
+        familyId  personId  dadId   momId   sex  status  role
+        f2        f2.dad    0       0       1    1       dad
+        f2        f2.mom    0       0       2    1       mom
+        f2        f2.p1     f2.dad  f2.mom  1    2       prb
+        """)
+    )
+    return FamiliesLoader(str(ped_path)).load()
+
+
+@pytest.fixture
+def ped_g(tmp_path: pathlib.Path) -> FamiliesData:
+    ped_path = setup_pedigree(
+        tmp_path / "ped_a" / "ped.ped", textwrap.dedent("""
+        familyId  personId  dadId   momId   sex  status  role
+        f1        f1.dad    0       0       1    1       dad
+        f1        f1.mom    0       0       2    1       mom
+        f1        f1.s1     f1.dad  f1.mom  2    1       sib
+        f1        f1.p1     f1.dad  f1.mom  1    2       prb
+        f3        f3.dad    0       0       1    1       dad
+        f3        f3.mom    0       0       2    1       mom
+        f3        f3.s1     f3.dad  f3.mom  2    1       sib
+        f3        f3.p1     f3.dad  f3.mom  1    2       prb
         """)
     )
     return FamiliesLoader(str(ped_path)).load()
@@ -184,3 +214,46 @@ def test_combine_families_generated_and_missing(
     p_s4 = new_families.persons["f1.s4"]
     assert p_s4.missing
     assert p_s4.generated
+
+
+def test_combine_families_creates_copy(
+    ped_a: FamiliesData, ped_f: FamiliesData, ped_g: FamiliesData
+) -> None:
+    new_families = FamiliesData.combine(
+        ped_a,
+        ped_f,
+        forced=True
+    )
+    new_families = FamiliesData.combine(
+        new_families,
+        ped_g,
+        forced=True
+    )
+
+    new_families["f2"].persons["f2.dad"].set_attr("test", "asdf")
+    print(ped_f["f2"].persons["f2.dad"]._attributes)
+    new_families["f1"].persons["f1.dad"].set_attr("test", "asdf")
+    print(ped_a["f1"].persons["f1.dad"]._attributes)
+
+    builder = FamilyTagsBuilder()
+
+    builder.tag_families_data(new_families)
+
+    assert new_families["f1"].persons["f1.dad"].get_attr(
+        "tag_family_type"
+    ) is not None
+    assert len(ped_a["f1"].tags.intersection(["tag_family_type"])) == 0
+    assert len(ped_f["f2"].tags.intersection(["tag_family_type"])) == 0
+    assert len(ped_g["f1"].tags.intersection(["tag_family_type"])) == 0
+    print(ped_a["f1"].persons["f1.dad"]._attributes)
+    print(ped_f["f2"].persons["f2.dad"]._attributes)
+    print(ped_g["f1"].persons["f1.dad"]._attributes)
+    print(ped_g["f3"].persons["f3.dad"]._attributes)
+    print(ped_a["f1"].tags)
+    print(ped_f["f2"].tags)
+    print(ped_g["f1"].tags)
+    print(ped_g["f3"].tags)
+    assert ped_a["f1"].persons["f1.dad"].get_attr("tag_family_type") is None
+    assert ped_f["f2"].persons["f2.dad"].get_attr("tag_family_type") is None
+    assert ped_g["f1"].persons["f1.dad"].get_attr("tag_family_type") is None
+    assert ped_g["f3"].persons["f3.dad"].get_attr("tag_family_type") is None


### PR DESCRIPTION
## Background

There was an issue with family type tags in studies that are in groups.

## Aim

Find and fix the problem with the tags.

## Implementation

The problem was that when we initialize a genotype data group, we create its `FamiliesData` on the spot, by using `.combine` with all of its child genotype datas' `FamiliesData`.  `.combine` collects all of the shared family IDs between two instances of `FamiliesData` and merges each. Before doing that, all of the families from the first get pasted into a dictionary, and then all of the families from the second get pasted over. This exact step is erroneous, because any family that isn't shared between the two instances is just pasted over as a reference, whereas the shared families are merged into new instances. 
When we tag a family that has not been merged, its tags will persist and the tagging will be broken and leak.