### PR TITLE
Disable unsupported federation features

### DIFF
--- a/dae/dae/configuration/schemas/study_config.py
+++ b/dae/dae/configuration/schemas/study_config.py
@@ -301,6 +301,7 @@ study_config_schema = {
         "coerce": "abspath",
         "default": "description.md"
     },
+    "description_editable": {"type": "boolean", "default": True},
     "study_type": {"type": "list", "schema": {"type": "string"}},
     "year": {"type": "list", "schema": {"type": "integer"}},
     "pub_med": {"type": "list", "schema": {"type": "string"}},

--- a/dae/dae/configuration/tests/test_study_config.py
+++ b/dae/dae/configuration/tests/test_study_config.py
@@ -60,6 +60,7 @@ def full_study_config():
         "phenotype_data": "test",
         "phenotype_browser": True,
         "phenotype_tool": True,
+        "description_editable": True, 
         "description_file": "test",
         "study_type": ["test"],
         "year": [1],

--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -33,6 +33,15 @@ def test_datasets_api_get_one(admin_client):
     assert response.data["data"]["name"] == "QUADS_IN_PARENT"
 
 
+def test_datasets_default_description_editable(admin_client):
+    response = admin_client.get("/api/v3/datasets/quads_in_parent")
+    print(response.data)
+    assert response
+    assert response.status_code == 200
+    assert response.data["data"]["description_editable"] is True
+    assert response.data["data"]["name"] == "QUADS_IN_PARENT"
+
+
 def test_datasets_api_get_404(admin_client):
     response = admin_client.get("/api/v3/datasets/alabala")
 
@@ -76,18 +85,6 @@ def test_user_client_get_nonexistant_dataset_details(
 
     assert response
     assert response.status_code == 404
-
-
-def test_user_client_get_dataset_details_remote(
-        user_client, wdae_gpf_instance):
-
-    response = user_client.get(
-        "/api/v3/datasets/details/TEST_REMOTE_iossifov_2014")
-
-    assert response
-    assert response.status_code == 200
-    print(response.data)
-    assert response.data["hasDenovo"]
 
 
 def test_datasets_api_get_all_with_selected_restriction(

--- a/wdae/wdae/datasets_api/tests/test_datasets_remote_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_remote_api.py
@@ -15,3 +15,25 @@ def test_datasets_api_get_remote_studies(admin_client):
     data = response.json()["data"]
 
     assert any(map(lambda x: x["id"] == "TEST_REMOTE_iossifov_2014", data))
+
+
+def test_datasets_api_unsupported_features_unaccessible(admin_client):
+    response = admin_client.get("/api/v3/datasets/TEST_REMOTE_iossifov_2014")
+    assert response
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["phenotype_tool"] is False
+    assert data["description_editable"] is False
+    assert data["gene_browser"]["enabled"] is False
+
+
+def test_user_client_get_dataset_details_remote(
+        user_client, wdae_gpf_instance):
+
+    response = user_client.get(
+        "/api/v3/datasets/details/TEST_REMOTE_iossifov_2014")
+
+    assert response
+    assert response.status_code == 200
+    print(response.data)
+    assert response.data["hasDenovo"]

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -85,31 +85,29 @@ class DatasetView(QueryBaseView):
             return Response({"error": f"Dataset {dataset_id} not found"},
                             status=status.HTTP_404_NOT_FOUND)
 
-        if dataset:
-            # pylint: disable=no-member
-            dataset_object = Dataset.objects.get(dataset_id=dataset_id)
+        dataset_object = Dataset.objects.get(dataset_id=dataset_id)
 
-            if user_has_permission(user, dataset_object):
-                person_set_collection_configs = {
-                    psc.id: psc.domain_json()
-                    for psc in dataset.person_set_collections.values()
-                }
-                res = StudyWrapperBase.build_genotype_data_description(
-                    self.gpf_instance,
-                    dataset.config,
-                    dataset.description,
-                    person_set_collection_configs
-                )
-            else:
-                res = StudyWrapperBase.build_genotype_data_all_datasets(
-                    dataset.config
-                )
+        if user_has_permission(user, dataset_object.dataset_id):
+            person_set_collection_configs = {
+                psc.id: psc.domain_json()
+                for psc in dataset.person_set_collections.values()
+            }
+            res = StudyWrapperBase.build_genotype_data_description(
+                self.gpf_instance,
+                dataset.config,
+                dataset.description,
+                person_set_collection_configs
+            )
+        else:
+            res = StudyWrapperBase.build_genotype_data_all_datasets(
+                dataset.config
+            )
 
-            res = augment_accessibility(res, user)
-            res = augment_with_groups(res)
-            res = augment_with_parents(res)
+        res = augment_accessibility(res, user)
+        res = augment_with_groups(res)
+        res = augment_with_parents(res)
 
-            return Response({"data": res})
+        return Response({"data": res})
 
 
 class StudiesView(QueryBaseView):

--- a/wdae/wdae/studies/remote_study.py
+++ b/wdae/wdae/studies/remote_study.py
@@ -27,6 +27,10 @@ class RemoteGenotypeData(GenotypeData):
         config["name"] = self.rest_client.prefix_remote_name(
             config.get("name", self._remote_study_id)
         )
+        config["phenotype_tool"] = False
+        config["description_editable"] = False
+        if config["gene_browser"]:
+            config["gene_browser"]["enabled"] = False
 
         if config["parents"]:
             config["parents"] = list(

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -114,6 +114,7 @@ class StudyWrapperBase:
             "genome",
             "chr_prefix",
             "gene_browser",
+            "description_editable"
         ]
         result = {
             key: config.get(key, None) for key in keys


### PR DESCRIPTION
## Background

The federation while functional, still does not support every WDAE feature.

## Aim

Any unsupported federation WDAE feature should be disabled.

## Implementation

The phenotype tool and gene browser have been made permanently disabled in remote studies, regardless of configuration.
Added a new flag to the study config `description_editable` which for now is used only for remote studies and defaults to `True`.
