### PR TITLE
Gene sets remote description fix

### DIFF
--- a/wdae/wdae/remote/gene_sets_db.py
+++ b/wdae/wdae/remote/gene_sets_db.py
@@ -66,7 +66,7 @@ class RemoteGeneSetCollection(BaseGeneSetCollection):
             raw_gene_set = [gs.strip() for gs in raw_gene_set]
             raw_gene_set = [gs for gs in raw_gene_set if gs]
 
-            description = raw_gene_set.pop(0)
+            description = raw_gene_set.pop(0).strip(f"{gene_set_id}: ")
             gene_set = GeneSet(gene_set_id, description, raw_gene_set)
             self.gene_sets[gene_set_id] = gene_set
 

--- a/wdae/wdae/remote/gene_sets_db.py
+++ b/wdae/wdae/remote/gene_sets_db.py
@@ -65,8 +65,10 @@ class RemoteGeneSetCollection(BaseGeneSetCollection):
             ).split("\n")
             raw_gene_set = [gs.strip() for gs in raw_gene_set]
             raw_gene_set = [gs for gs in raw_gene_set if gs]
-
-            description = raw_gene_set.pop(0).strip(f"{gene_set_id}: ")
+            whole_gene_set = raw_gene_set.pop(0).strip('\"').split(":")
+            assert whole_gene_set is not None
+            assert whole_gene_set[0] == gene_set_id
+            description = whole_gene_set[1]
             gene_set = GeneSet(gene_set_id, description, raw_gene_set)
             self.gene_sets[gene_set_id] = gene_set
 

--- a/wdae/wdae/remote/gene_sets_db.py
+++ b/wdae/wdae/remote/gene_sets_db.py
@@ -65,10 +65,9 @@ class RemoteGeneSetCollection(BaseGeneSetCollection):
             ).split("\n")
             raw_gene_set = [gs.strip() for gs in raw_gene_set]
             raw_gene_set = [gs for gs in raw_gene_set if gs]
-            whole_gene_set = raw_gene_set.pop(0).strip('\"').split(":")
-            assert whole_gene_set is not None
-            assert whole_gene_set[0] == gene_set_id
-            description = whole_gene_set[1]
+            name, description = raw_gene_set.pop(0).strip('\"').split(":", 1)
+            assert name is not None and description is not None
+            assert name == gene_set_id
             gene_set = GeneSet(gene_set_id, description, raw_gene_set)
             self.gene_sets[gene_set_id] = gene_set
 


### PR DESCRIPTION
## Background

Remote gene sets currently have the id duplicated at the beginning of the description string.

## Aim

Fix the remote gene sets formatting.