### PR TITLE
Remote genomic scores

### DIFF
--- a/dae/dae/gene/denovo_gene_sets_db.py
+++ b/dae/dae/gene/denovo_gene_sets_db.py
@@ -114,6 +114,7 @@ class DenovoGeneSetsDb:
         permitted_datasets=None,
         collection_id="denovo"  # pylint: disable=unused-argument
     ):
+        """Return all de Novo gene sets matching the spec for permitted DS."""
         denovo_gene_set_spec = self._filter_spec(
             denovo_gene_set_spec, permitted_datasets
         )

--- a/dae/dae/gene/denovo_gene_sets_db.py
+++ b/dae/dae/gene/denovo_gene_sets_db.py
@@ -93,7 +93,12 @@ class DenovoGeneSetsDb:
         return self._denovo_gene_set_configs[genotype_data_id].gene_sets_names
 
     def get_gene_set(
-            self, gene_set_id, gene_set_spec, permitted_datasets=None):
+        self,
+        gene_set_id,
+        gene_set_spec,
+        permitted_datasets=None,
+        collection_id="denovo"  # pylint: disable=unused-argument
+    ):
         """Return de Novo gene set matching the spec for permitted datasets."""
         gene_set_spec = self._filter_spec(gene_set_spec, permitted_datasets)
 
@@ -103,7 +108,12 @@ class DenovoGeneSetsDb:
             gene_set_spec,
         )
 
-    def get_all_gene_sets(self, denovo_gene_set_spec, permitted_datasets=None):
+    def get_all_gene_sets(
+        self,
+        denovo_gene_set_spec,
+        permitted_datasets=None,
+        collection_id="denovo"  # pylint: disable=unused-argument
+    ):
         denovo_gene_set_spec = self._filter_spec(
             denovo_gene_set_spec, permitted_datasets
         )

--- a/dae/dae/gene/scores.py
+++ b/dae/dae/gene/scores.py
@@ -20,7 +20,7 @@ class ScoreDesc:
     resource_id: str
     score_id: str
     source: str
-    destination: str
+    name: str
     hist: Optional[Union[NumberHistogram, CategoricalHistogram, NullHistogram]]
     description: str
     help: str
@@ -33,7 +33,7 @@ class ScoreDesc:
             "resource_id": self.resource_id,
             "score_id": self.score_id,
             "source": self.source,
-            "destination": self.destination,
+            "name": self.name,
             "hist": hist_data,
             "description": self.description,
             "help": self.help
@@ -56,7 +56,7 @@ class ScoreDesc:
             data["resource_id"],
             data["score_id"],
             data["source"],
-            data["destination"],
+            data["name"],
             hist_data,
             data["description"],
             data["help"]

--- a/dae/dae/gene/scores.py
+++ b/dae/dae/gene/scores.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 from dataclasses import dataclass
-from typing import Union, Any, Optional
+from typing import Any
 
 from dae.genomic_resources.repository import GenomicResourceRepo
 from dae.genomic_resources.genomic_scores import build_score_from_resource
@@ -21,14 +21,12 @@ class ScoreDesc:
     score_id: str
     source: str
     name: str
-    hist: Optional[Union[NumberHistogram, CategoricalHistogram, NullHistogram]]
+    hist: Histogram
     description: str
     help: str
 
     def to_json(self) -> dict[str, Any]:
-        hist_data = None
-        if self.hist is not None:
-            hist_data = self.hist.to_dict()
+        hist_data = self.hist.to_dict()
         return {
             "resource_id": self.resource_id,
             "score_id": self.score_id,
@@ -42,17 +40,16 @@ class ScoreDesc:
     @staticmethod
     def from_json(data: dict[str, Any]) -> ScoreDesc:
         """Build a ScoreDesc from a JSON."""
-        hist_data: Optional[Histogram] = None
-        if "hist" in data:
-            hist_type = data["hist"]["config"]["type"]
-            if hist_type == "categorical":
-                hist_data = CategoricalHistogram.from_dict(data["hist"])
-            elif hist_type == "null":
-                hist_data = NullHistogram.from_dict(data["hist"])
-            elif hist_type == "number":
-                hist_data = NumberHistogram.from_dict(data["hist"])
-            else:
-                raise ValueError(f"Unknown histogram type {hist_type}")
+        assert "hist" in data
+        hist_type = data["hist"]["config"]["type"]
+        if hist_type == "categorical":
+            hist_data: Histogram = CategoricalHistogram.from_dict(data["hist"])
+        elif hist_type == "null":
+            hist_data = NullHistogram.from_dict(data["hist"])
+        elif hist_type == "number":
+            hist_data = NumberHistogram.from_dict(data["hist"])
+        else:
+            raise ValueError(f"Unknown histogram type {hist_type}")
         return ScoreDesc(
             data["resource_id"],
             data["score_id"],

--- a/dae/dae/gene/scores.py
+++ b/dae/dae/gene/scores.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
 import logging
 from dataclasses import dataclass
-from typing import Union
+from typing import Union, Any, Optional
 
 from dae.genomic_resources.repository import GenomicResourceRepo
 from dae.genomic_resources.genomic_scores import build_score_from_resource
 from dae.genomic_resources.histogram import NumberHistogram, \
-    CategoricalHistogram, NullHistogram
+    CategoricalHistogram, NullHistogram, Histogram
 from dae.annotation.annotation_pipeline import AnnotatorInfo
 
 
@@ -20,9 +21,47 @@ class ScoreDesc:
     score_id: str
     source: str
     destination: str
-    hist: Union[NumberHistogram, CategoricalHistogram, NullHistogram]
+    hist: Optional[Union[NumberHistogram, CategoricalHistogram, NullHistogram]]
     description: str
     help: str
+
+    def to_json(self) -> dict[str, Any]:
+        hist_data = None
+        if self.hist is not None:
+            hist_data = self.hist.to_dict()
+        return {
+            "resource_id": self.resource_id,
+            "score_id": self.score_id,
+            "source": self.source,
+            "destination": self.destination,
+            "hist": hist_data,
+            "description": self.description,
+            "help": self.help
+        }
+
+    @staticmethod
+    def from_json(data: dict[str, Any]) -> ScoreDesc:
+        hist_data: Optional[Histogram] = None
+        if "hist" in data:
+            hist_type = data["hist"]["config"]["type"]
+            if hist_type == "categorical":
+                hist_data = CategoricalHistogram.from_dict(data["hist"])
+            elif hist_type == "null":
+                hist_data = NullHistogram.from_dict(data["hist"])
+            elif hist_type == "number":
+                hist_data = NumberHistogram.from_dict(data["hist"])
+            else:
+                raise ValueError(f"Unknown histogram type {hist_type}")
+        return ScoreDesc(
+            data["resource_id"],
+            data["score_id"],
+            data["source"],
+            data["destination"],
+            hist_data,
+            data["description"],
+            data["help"]
+
+        )
 
 
 class GenomicScoresDb:

--- a/dae/dae/gene/scores.py
+++ b/dae/dae/gene/scores.py
@@ -41,6 +41,7 @@ class ScoreDesc:
 
     @staticmethod
     def from_json(data: dict[str, Any]) -> ScoreDesc:
+        """Build a ScoreDesc from a JSON."""
         hist_data: Optional[Histogram] = None
         if "hist" in data:
             hist_type = data["hist"]["config"]["type"]

--- a/dae/dae/genomic_resources/histogram.py
+++ b/dae/dae/genomic_resources/histogram.py
@@ -369,7 +369,8 @@ class NumberHistogram(Statistic):
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> NumberHistogram:
-        config = NumberHistogramConfig.from_dict(data.get("config"))
+        """Build a number histogram from a dict."""
+        config = NumberHistogramConfig.from_dict(data["config"])
 
         hist = NumberHistogram(
             config,
@@ -381,7 +382,6 @@ class NumberHistogram(Statistic):
         hist.out_of_range_bins = data.get("out_of_range_bins", [0, 0])
 
         return hist
-
 
     @staticmethod
     def deserialize(content: str) -> NumberHistogram:
@@ -442,6 +442,7 @@ class NullHistogram(Statistic):
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> NullHistogram:
+        """Build a null histogram from a dict."""
         config = data["config"]
         hist_type = config.get("type")
         if hist_type != "null":

--- a/dae/dae/genomic_resources/histogram.py
+++ b/dae/dae/genomic_resources/histogram.py
@@ -368,8 +368,7 @@ class NumberHistogram(Statistic):
         plt.clf()
 
     @staticmethod
-    def deserialize(content: str) -> NumberHistogram:
-        data = yaml.load(content, yaml.Loader)
+    def from_dict(data: dict[str, Any]) -> NumberHistogram:
         config = NumberHistogramConfig.from_dict(data.get("config"))
 
         hist = NumberHistogram(
@@ -382,6 +381,12 @@ class NumberHistogram(Statistic):
         hist.out_of_range_bins = data.get("out_of_range_bins", [0, 0])
 
         return hist
+
+
+    @staticmethod
+    def deserialize(content: str) -> NumberHistogram:
+        data = yaml.load(content, yaml.Loader)
+        return NumberHistogram.from_dict(data)
 
 
 class HistogramStatisticMixin:
@@ -436,8 +441,7 @@ class NullHistogram(Statistic):
         ))
 
     @staticmethod
-    def deserialize(content: str) -> NullHistogram:
-        data = yaml.load(content, yaml.Loader)
+    def from_dict(data: dict[str, Any]) -> NullHistogram:
         config = data["config"]
         hist_type = config.get("type")
         if hist_type != "null":
@@ -446,6 +450,11 @@ class NullHistogram(Statistic):
             )
         reason = config.get("reason", "")
         return NullHistogram(NullHistogramConfig(reason=reason))
+
+    @staticmethod
+    def deserialize(content: str) -> NullHistogram:
+        data = yaml.load(content, yaml.Loader)
+        return NullHistogram.from_dict(data)
 
 
 class CategoricalHistogram(Statistic):
@@ -532,10 +541,14 @@ class CategoricalHistogram(Statistic):
         return cast(str, yaml.dump(self.to_dict()))
 
     @staticmethod
-    def deserialize(content: str) -> CategoricalHistogram:
-        data = yaml.load(content, yaml.Loader)
+    def from_dict(data: dict[str, Any]) -> CategoricalHistogram:
         config = CategoricalHistogramConfig.from_dict(data.get("config"))
         return CategoricalHistogram(config, data.get("values"))
+
+    @staticmethod
+    def deserialize(content: str) -> CategoricalHistogram:
+        data = yaml.load(content, yaml.Loader)
+        return CategoricalHistogram.from_dict(data)
 
     def plot(self, outfile: IO, score_id: str) -> None:
         """Plot histogram and save it into outfile."""

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from dae.utils.fs_utils import find_directory_with_a_file
 from dae.enrichment_tool.background_facade import BackgroundFacade
 from dae.studies.study import GenotypeData
-from dae.gene.scores import GenomicScoresDb
+from dae.gene.scores import GenomicScoresDb, ScoreDesc
 from dae.gene.gene_sets_db import GeneSetsDb, \
     build_gene_set_collection_from_resource
 from dae.gene.denovo_gene_sets_db import DenovoGeneSetsDb
@@ -337,8 +337,14 @@ class GPFInstance:
         return self._pheno_db.get_phenotype_data_config(phenotype_data_id)
 
     # Genomic scores
-    def get_genomic_scores(self):
+    def get_genomic_scores(self) -> list[tuple[str, ScoreDesc]]:
         return self.genomic_scores_db.get_scores()
+
+    def has_genomic_score(self, score_id: str) -> bool:
+        return score_id in self.genomic_scores_db
+
+    def get_genomic_score(self, score_id: str) -> ScoreDesc:
+        return self.genomic_scores_db.get(score_id)
 
     # Gene scores
 

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -11,7 +11,6 @@ from box import Box
 from dae.annotation.annotation_pipeline import AnnotationPipeline
 from dae.autism_gene_profile.statistic import AGPStatistic
 from dae.enrichment_tool.background import BackgroundBase
-from dae.gene.denovo_gene_set_collection import DenovoGeneSetCollection
 from dae.gene.gene_scores import GeneScore
 from dae.genomic_resources.gene_models import GeneModels
 from dae.genomic_resources.reference_genome import ReferenceGenome
@@ -315,7 +314,7 @@ class GPFInstance:
         genotype_data_study = self._variants_db.get_genotype_study(
             genotype_data_id)
         if genotype_data_study:
-            return cast(GenotypeData, genotype_data_study)
+            return genotype_data_study
         return cast(
             GenotypeData,
             self._variants_db.get_genotype_group(genotype_data_id)
@@ -331,7 +330,7 @@ class GPFInstance:
     def get_genotype_data_config(self, genotype_data_id: str) -> Optional[Box]:
         config = self._variants_db.get_genotype_study_config(genotype_data_id)
         if config is not None:
-            return cast(Box, config)
+            return config
         return cast(Box, self._variants_db.get_genotype_group_config(
             genotype_data_id
         ))
@@ -461,9 +460,9 @@ class GPFInstance:
         types: dict[str, Any],
         datasets: list[GenotypeData],
         collection_id: str  # pylint: disable=unused-argument
-    ) -> DenovoGeneSetCollection:
+    ) -> dict[str, Any]:
         return cast(
-            DenovoGeneSetCollection,
+            dict[str, Any],
             self.denovo_gene_sets_db.get_gene_set(
                 gene_set_id, types, datasets
             )

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -420,7 +420,7 @@ class GPFInstance:
     # Gene sets
     def get_gene_sets_collections(self) -> list[dict[str, Any]]:
         return cast(
-            list[GeneSetCollection], self.gene_sets_db.collections_descriptions
+            list[dict[str, Any]], self.gene_sets_db.collections_descriptions
         )
 
     def has_gene_set_collection(self, gsc_id: str) -> bool:

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -22,7 +22,7 @@ from dae.enrichment_tool.background_facade import BackgroundFacade
 from dae.studies.study import GenotypeData
 from dae.gene.scores import GenomicScoresDb, ScoreDesc
 from dae.gene.gene_scores import ScoreDesc as GeneScoreDesc
-from dae.gene.gene_sets_db import GeneSet, GeneSetCollection, GeneSetsDb, \
+from dae.gene.gene_sets_db import GeneSet, GeneSetsDb, \
     build_gene_set_collection_from_resource
 from dae.gene.denovo_gene_sets_db import DenovoGeneSetsDb
 from dae.common_reports.common_report import CommonReport

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -21,6 +21,7 @@ from dae.utils.fs_utils import find_directory_with_a_file
 from dae.enrichment_tool.background_facade import BackgroundFacade
 from dae.studies.study import GenotypeData
 from dae.gene.scores import GenomicScoresDb, ScoreDesc
+from dae.gene.gene_scores import ScoreDesc as GeneScoreDesc
 from dae.gene.gene_sets_db import GeneSet, GeneSetCollection, GeneSetsDb, \
     build_gene_set_collection_from_resource
 from dae.gene.denovo_gene_sets_db import DenovoGeneSetsDb
@@ -381,14 +382,16 @@ class GPFInstance:
             GeneScore, self.gene_scores_db.get_gene_score(gene_score_id)
         )
 
-    def get_gene_score_desc(self, score_id: str) -> ScoreDesc:
-        return cast(ScoreDesc, self.gene_scores_db.get_score_desc(score_id))
+    def get_gene_score_desc(self, score_id: str) -> GeneScoreDesc:
+        return cast(
+            GeneScoreDesc, self.gene_scores_db.get_score_desc(score_id)
+        )
 
     def get_all_gene_scores(self) -> list[GeneScore]:
         return cast(list[GeneScore], self.gene_scores_db.get_gene_scores())
 
-    def get_all_gene_score_descs(self) -> list[ScoreDesc]:
-        return cast(list[ScoreDesc], self.gene_scores_db.get_scores())
+    def get_all_gene_score_descs(self) -> list[GeneScoreDesc]:
+        return cast(list[GeneScoreDesc], self.gene_scores_db.get_scores())
 
     # Common reports
     def get_common_report(self, study_id: str) -> Optional[CommonReport]:
@@ -415,7 +418,7 @@ class GPFInstance:
         return configs
 
     # Gene sets
-    def get_gene_sets_collections(self) -> list[GeneSetCollection]:
+    def get_gene_sets_collections(self) -> list[dict[str, Any]]:
         return cast(
             list[GeneSetCollection], self.gene_sets_db.collections_descriptions
         )
@@ -444,17 +447,20 @@ class GPFInstance:
         return len(self.denovo_gene_sets_db) > 0
 
     def get_all_denovo_gene_sets(
-        self, types: dict[str, Any], datasets: list[GenotypeData]
-    ) -> list[DenovoGeneSetCollection]:
+        self, types: dict[str, Any],
+        datasets: list[Any],
+        collection_id: str  # pylint: disable=unused-argument
+    ) -> list[dict[str, Any]]:
         return cast(
-            list[DenovoGeneSetCollection],
+            list[dict[str, Any]],
             self.denovo_gene_sets_db.get_all_gene_sets(types, datasets)
         )
 
     def get_denovo_gene_set(
         self, gene_set_id: str,
         types: dict[str, Any],
-        datasets: list[GenotypeData]
+        datasets: list[GenotypeData],
+        collection_id: str  # pylint: disable=unused-argument
     ) -> DenovoGeneSetCollection:
         return cast(
             DenovoGeneSetCollection,

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -5,21 +5,30 @@ from __future__ import annotations
 import os
 import logging
 from functools import cached_property
-from typing import Optional, Union
+from typing import Optional, Union, Any, cast
 from pathlib import Path
+from box import Box
+from dae.annotation.annotation_pipeline import AnnotationPipeline
+from dae.autism_gene_profile.statistic import AGPStatistic
+from dae.enrichment_tool.background import BackgroundBase
+from dae.gene.denovo_gene_set_collection import DenovoGeneSetCollection
+from dae.gene.gene_scores import GeneScore
+from dae.genomic_resources.gene_models import GeneModels
+from dae.genomic_resources.reference_genome import ReferenceGenome
 
+from dae.genomic_resources.repository import GenomicResourceRepo
 from dae.utils.fs_utils import find_directory_with_a_file
 from dae.enrichment_tool.background_facade import BackgroundFacade
 from dae.studies.study import GenotypeData
 from dae.gene.scores import GenomicScoresDb, ScoreDesc
-from dae.gene.gene_sets_db import GeneSetsDb, \
+from dae.gene.gene_sets_db import GeneSet, GeneSetCollection, GeneSetsDb, \
     build_gene_set_collection_from_resource
 from dae.gene.denovo_gene_sets_db import DenovoGeneSetsDb
 from dae.common_reports.common_report import CommonReport
 
 from dae.studies.variants_db import VariantsDb
 
-from dae.pheno.pheno_db import PhenoDb
+from dae.pheno.pheno_db import PhenoDb, PhenotypeData
 
 from dae.configuration.gpf_config_parser import GPFConfigParser
 from dae.configuration.schemas.dae_conf import dae_conf_schema
@@ -38,7 +47,9 @@ class GPFInstance:
 
     # pylint: disable=too-many-public-methods
     @staticmethod
-    def _build_gpf_config(config_filename: Optional[Union[str, Path]] = None):
+    def _build_gpf_config(
+        config_filename: Optional[Union[str, Path]] = None
+    ) -> tuple[Box, Path]:
         dae_dir: Optional[Path]
         if config_filename is not None:
             config_filename = Path(config_filename)
@@ -63,7 +74,7 @@ class GPFInstance:
     @staticmethod
     def build(
             config_filename: Optional[Union[str, Path]] = None,
-            **kwargs) -> GPFInstance:
+            **kwargs: dict[str, Any]) -> GPFInstance:
         """Construct and return a GPF instance.
 
         If the config_filename is None, tries to discover the GPF instance.
@@ -78,20 +89,25 @@ class GPFInstance:
 
     def __init__(
             self,
-            dae_config,
-            dae_dir,
-            **kwargs):
+            dae_config: Box,
+            dae_dir: Union[str, Path],
+            **kwargs: dict[str, Any]):
         assert dae_dir is not None
 
         self.dae_config = dae_config
         self.dae_dir = str(dae_dir)
 
-        self._grr = kwargs.get("grr")
-        self._reference_genome = kwargs.get("reference_genome")
-        self._gene_models = kwargs.get("gene_models")
-        self._annotation_pipeline = None
+        self._grr = cast(GenomicResourceRepo, kwargs.get("grr"))
+        self._reference_genome = cast(
+            ReferenceGenome, kwargs.get("reference_genome")
+        )
+        self._gene_models = cast(
+            GeneModels,
+            kwargs.get("gene_models")
+        )
+        self._annotation_pipeline: Optional[AnnotationPipeline] = None
 
-    def load(self):
+    def load(self) -> GPFInstance:
         """Load all GPF instance attributes."""
         # pylint: disable=pointless-statement
         self.reference_genome
@@ -106,7 +122,7 @@ class GPFInstance:
         return self
 
     @cached_property
-    def grr(self):
+    def grr(self) -> GenomicResourceRepo:
         """Return genomic resource repository configured for GPF instance."""
         if self._grr is not None:
             return self._grr
@@ -121,7 +137,7 @@ class GPFInstance:
         return self._grr
 
     @cached_property
-    def reference_genome(self):
+    def reference_genome(self) -> ReferenceGenome:
         """Return reference genome defined in the GPFInstance config."""
         if self._reference_genome is not None:
             return self._reference_genome
@@ -137,7 +153,7 @@ class GPFInstance:
         return result
 
     @cached_property
-    def gene_models(self):
+    def gene_models(self) -> GeneModels:
         """Return gene models used in the GPF instance."""
         if self._gene_models is not None:
             return self._gene_models
@@ -155,7 +171,7 @@ class GPFInstance:
         return result
 
     @cached_property
-    def _pheno_db(self):
+    def _pheno_db(self) -> PhenoDb:
         return PhenoDb(dae_config=self.dae_config)
 
     @cached_property
@@ -178,7 +194,7 @@ class GPFInstance:
         return GeneScoresDb(collections)
 
     @cached_property
-    def genomic_scores_db(self):
+    def genomic_scores_db(self) -> GenomicScoresDb:
         """Load and return genomic scores db."""
         score_annotators = []
 
@@ -213,7 +229,7 @@ class GPFInstance:
         return registry
 
     @cached_property
-    def _variants_db(self):
+    def _variants_db(self) -> VariantsDb:
         return VariantsDb(
             self.dae_config,
             self.reference_genome,
@@ -222,7 +238,7 @@ class GPFInstance:
         )
 
     @cached_property
-    def _autism_gene_profile_db(self):
+    def _autism_gene_profile_db(self) -> AutismGeneProfileDB:
         config = None if self._autism_gene_profile_config is None else\
             self._autism_gene_profile_config.to_dict()
 
@@ -232,13 +248,13 @@ class GPFInstance:
         )
         return agpdb
 
-    def reload(self):
+    def reload(self) -> None:
         """Reload GPF instance studies, de Novo gene sets, etc."""
         self._variants_db.reload()
         self.denovo_gene_sets_db.reload()
 
     @cached_property
-    def _autism_gene_profile_config(self):
+    def _autism_gene_profile_config(self) -> Optional[Box]:
         agp_config = self.dae_config.autism_gene_tool_config
         config_filename = None
 
@@ -259,7 +275,7 @@ class GPFInstance:
         )
 
     @cached_property
-    def gene_sets_db(self):
+    def gene_sets_db(self) -> GeneSetsDb:
         """Return GeneSetsDb populated with gene sets from the GPFInstance."""
         logger.debug("creating new instance of GeneSetsDb")
         if "gene_sets_db" in self.dae_config:
@@ -280,61 +296,70 @@ class GPFInstance:
         return GeneSetsDb([])
 
     @cached_property
-    def denovo_gene_sets_db(self):
+    def denovo_gene_sets_db(self) -> DenovoGeneSetsDb:
         return DenovoGeneSetsDb(self)
 
     @cached_property
-    def _background_facade(self):
+    def _background_facade(self) -> BackgroundFacade:
         return BackgroundFacade(self._variants_db)
 
-    def get_genotype_data_ids(self, local_only=False):
+    def get_genotype_data_ids(self, local_only: bool = False) -> list[str]:
         # pylint: disable=unused-argument
-        return (
+        return cast(list[str], (
             self._variants_db.get_all_genotype_study_ids()
             + self._variants_db.get_all_genotype_group_ids()
-        )
+        ))
 
-    def get_genotype_data(self, genotype_data_id) -> GenotypeData:
+    def get_genotype_data(self, genotype_data_id: str) -> GenotypeData:
         genotype_data_study = self._variants_db.get_genotype_study(
             genotype_data_id)
         if genotype_data_study:
-            return genotype_data_study
-        return self._variants_db.get_genotype_group(genotype_data_id)
-
-    def get_all_genotype_data(self):
-        genotype_studies = self._variants_db.get_all_genotype_studies()
-        genotype_data_groups = self._variants_db.get_all_genotype_groups()
-        return genotype_studies + genotype_data_groups
-
-    def get_genotype_data_config(self, genotype_data_id):
-        config = self._variants_db.get_genotype_study_config(genotype_data_id)
-        if config is not None:
-            return config
-        return self._variants_db.get_genotype_group_config(
-            genotype_data_id
+            return cast(GenotypeData, genotype_data_study)
+        return cast(
+            GenotypeData,
+            self._variants_db.get_genotype_group(genotype_data_id)
         )
 
-    def register_genotype_data(self, genotype_data):
+    def get_all_genotype_data(self) -> list[GenotypeData]:
+        genotype_studies = self._variants_db.get_all_genotype_studies()
+        genotype_data_groups = self._variants_db.get_all_genotype_groups()
+        return cast(
+            list[GenotypeData], genotype_studies + genotype_data_groups
+        )
+
+    def get_genotype_data_config(self, genotype_data_id: str) -> Optional[Box]:
+        config = self._variants_db.get_genotype_study_config(genotype_data_id)
+        if config is not None:
+            return cast(Box, config)
+        return cast(Box, self._variants_db.get_genotype_group_config(
+            genotype_data_id
+        ))
+
+    def register_genotype_data(self, genotype_data: GenotypeData) -> None:
         self._variants_db.register_genotype_data(genotype_data)
 
-    def unregister_genotype_data(self, genotype_data):
+    def unregister_genotype_data(self, genotype_data: GenotypeData) -> None:
         self._variants_db.unregister_genotype_data(genotype_data)
 
     # Phenotype data
-    def get_phenotype_db_config(self):
-        return self._pheno_db.config
+    def get_phenotype_db_config(self) -> Box:
+        return cast(Box, self._pheno_db.config)
 
-    def get_phenotype_data_ids(self):
-        return self._pheno_db.get_phenotype_data_ids()
+    def get_phenotype_data_ids(self) -> list[str]:
+        return cast(list[str], self._pheno_db.get_phenotype_data_ids())
 
-    def get_phenotype_data(self, phenotype_data_id):
+    def get_phenotype_data(self, phenotype_data_id: str) -> PhenotypeData:
         return self._pheno_db.get_phenotype_data(phenotype_data_id)
 
-    def get_all_phenotype_data(self):
-        return self._pheno_db.get_all_phenotype_data()
+    def get_all_phenotype_data(self) -> list[PhenotypeData]:
+        return cast(
+            list[PhenotypeData], self._pheno_db.get_all_phenotype_data()
+        )
 
-    def get_phenotype_data_config(self, phenotype_data_id):
-        return self._pheno_db.get_phenotype_data_config(phenotype_data_id)
+    def get_phenotype_data_config(self, phenotype_data_id: str) -> Box:
+        return cast(
+            Box, self._pheno_db.get_phenotype_data_config(phenotype_data_id)
+        )
 
     # Genomic scores
     def get_genomic_scores(self) -> list[tuple[str, ScoreDesc]]:
@@ -344,27 +369,29 @@ class GPFInstance:
         return score_id in self.genomic_scores_db
 
     def get_genomic_score(self, score_id: str) -> ScoreDesc:
-        return self.genomic_scores_db.get(score_id)
+        return self.genomic_scores_db[score_id]
 
     # Gene scores
 
-    def has_gene_score(self, gene_score_id):
+    def has_gene_score(self, gene_score_id: str) -> bool:
         return gene_score_id in self.gene_scores_db
 
-    def get_gene_score(self, gene_score_id):
-        return self.gene_scores_db.get_gene_score(gene_score_id)
+    def get_gene_score(self, gene_score_id: str) -> GeneScore:
+        return cast(
+            GeneScore, self.gene_scores_db.get_gene_score(gene_score_id)
+        )
 
-    def get_gene_score_desc(self, score_id):
-        return self.gene_scores_db.get_score_desc(score_id)
+    def get_gene_score_desc(self, score_id: str) -> ScoreDesc:
+        return cast(ScoreDesc, self.gene_scores_db.get_score_desc(score_id))
 
-    def get_all_gene_scores(self):
-        return self.gene_scores_db.get_gene_scores()
+    def get_all_gene_scores(self) -> list[GeneScore]:
+        return cast(list[GeneScore], self.gene_scores_db.get_gene_scores())
 
-    def get_all_gene_score_descs(self):
-        return self.gene_scores_db.get_scores()
+    def get_all_gene_score_descs(self) -> list[ScoreDesc]:
+        return cast(list[ScoreDesc], self.gene_scores_db.get_scores())
 
     # Common reports
-    def get_common_report(self, study_id):
+    def get_common_report(self, study_id: str) -> Optional[CommonReport]:
         """Load and return common report (dataset statistics) for a study."""
         study = self.get_genotype_data(study_id)
         if study is None or study.is_remote:
@@ -377,67 +404,103 @@ class GPFInstance:
             report = CommonReport.build_and_save(study)
         return report
 
-    def get_all_common_report_configs(self):
+    def get_all_common_report_configs(self) -> list[Box]:
         """Return all common report configuration."""
         configs = []
         local_ids = self.get_genotype_data_ids(True)
         for gd_id in local_ids:
             config = self.get_genotype_data_config(gd_id)
-            if config.common_report is not None:
+            if config is not None and config.common_report is not None:
                 configs.append(config.common_report)
         return configs
 
     # Gene sets
-    def get_gene_sets_collections(self):
-        return self.gene_sets_db.collections_descriptions
+    def get_gene_sets_collections(self) -> list[GeneSetCollection]:
+        return cast(
+            list[GeneSetCollection], self.gene_sets_db.collections_descriptions
+        )
 
-    def has_gene_set_collection(self, gsc_id):
-        return self.gene_sets_db.has_gene_set_collection(gsc_id)
+    def has_gene_set_collection(self, gsc_id: str) -> bool:
+        return cast(bool, self.gene_sets_db.has_gene_set_collection(gsc_id))
 
-    def get_all_gene_sets(self, collection_id):
+    def get_all_gene_sets(self, collection_id: str) -> list[GeneSet]:
         return self.gene_sets_db.get_all_gene_sets(collection_id)
 
-    def get_gene_set(self, collection_id, gene_set_id):
-        return self.gene_sets_db.get_gene_set(collection_id, gene_set_id)
+    def get_gene_set(self, collection_id: str, gene_set_id: str) -> GeneSet:
+        return cast(
+            GeneSet,
+            self.gene_sets_db.get_gene_set(collection_id, gene_set_id)
+        )
 
-    def get_denovo_gene_sets(self, datasets):
-        return self.denovo_gene_sets_db.get_gene_set_descriptions(datasets)
+    def get_denovo_gene_sets(
+        self, datasets: list[GenotypeData]
+    ) -> list[dict[str, Any]]:
+        return cast(
+            list[dict[str, Any]],
+            self.denovo_gene_sets_db.get_gene_set_descriptions(datasets)
+        )
 
-    def has_denovo_gene_sets(self):
+    def has_denovo_gene_sets(self) -> bool:
         return len(self.denovo_gene_sets_db) > 0
 
-    def get_all_denovo_gene_sets(self, types, datasets):
-        return self.denovo_gene_sets_db.get_all_gene_sets(types, datasets)
+    def get_all_denovo_gene_sets(
+        self, types: dict[str, Any], datasets: list[GenotypeData]
+    ) -> list[DenovoGeneSetCollection]:
+        return cast(
+            list[DenovoGeneSetCollection],
+            self.denovo_gene_sets_db.get_all_gene_sets(types, datasets)
+        )
 
-    def get_denovo_gene_set(self, gene_set_id, types, datasets):
-        return self.denovo_gene_sets_db.get_gene_set(
-            gene_set_id, types, datasets)
+    def get_denovo_gene_set(
+        self, gene_set_id: str,
+        types: dict[str, Any],
+        datasets: list[GenotypeData]
+    ) -> DenovoGeneSetCollection:
+        return cast(
+            DenovoGeneSetCollection,
+            self.denovo_gene_sets_db.get_gene_set(
+                gene_set_id, types, datasets
+            )
+        )
 
     # Variants DB
-    def get_dataset(self, dataset_id):
-        return self._variants_db.get(dataset_id)
+    def get_dataset(self, dataset_id: str) -> GenotypeData:
+        return cast(GenotypeData, self._variants_db.get(dataset_id))
 
     # Enrichment
-    def get_study_enrichment_config(self, dataset_id):
+    def get_study_enrichment_config(self, dataset_id: str) -> Optional[Box]:
         return self._background_facade.get_study_enrichment_config(dataset_id)
 
-    def has_background(self, dataset_id, background_name):
+    def has_background(self, dataset_id: str, background_name: str) -> bool:
         return self._background_facade.has_background(
             dataset_id, background_name)
 
-    def get_study_background(self, dataset_id, background_name):
-        return self._background_facade.get_study_background(
-            dataset_id, background_name)
+    def get_study_background(
+        self, dataset_id: str, background_name: str
+    ) -> BackgroundBase:
+        return cast(
+            BackgroundBase,
+            self._background_facade.get_study_background(
+                dataset_id, background_name
+            )
+        )
 
     # AGP
-    def get_agp_configuration(self):
-        return self._autism_gene_profile_db.configuration
+    def get_agp_configuration(self) -> Box:
+        return cast(Box, self._autism_gene_profile_db.configuration)
 
-    def get_agp_statistic(self, gene_symbol):
-        return self._autism_gene_profile_db.get_agp(gene_symbol)
+    def get_agp_statistic(self, gene_symbol: str) -> AGPStatistic:
+        return cast(
+            AGPStatistic, self._autism_gene_profile_db.get_agp(gene_symbol)
+        )
 
     def query_agp_statistics(
-            self, page, symbol_like=None, sort_by=None, order=None):
+        self,
+        page: int,
+        symbol_like: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        order: Optional[str] = None
+    ) -> list[AGPStatistic]:
         """Query AGR statistics and return results."""
         rows = self._autism_gene_profile_db.query_agps(
             page, symbol_like, sort_by, order
@@ -446,9 +509,9 @@ class GPFInstance:
             self._autism_gene_profile_db.agp_from_table_row,
             rows
         ))
-        return statistics
+        return cast(list[AGPStatistic], statistics)
 
-    def get_annotation_pipeline(self):
+    def get_annotation_pipeline(self) -> AnnotationPipeline:
         """Return the annotation pipeline configured in the GPF instance."""
         if self._annotation_pipeline is None:
             if self.dae_config.annotation is None:

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -543,6 +543,33 @@ class PhenotypeData(ABC):
             measure_ids = self._get_instrument_measures(instrument_name)
         return self.get_values(measure_ids, person_ids, family_ids, role)
 
+    @abstractmethod
+    def get_values_streaming_csv(
+        self,
+        measure_ids: list[str],
+        person_ids=None,
+        family_ids=None,
+        roles=None,
+    ):
+        """
+        Collect and format the values of the given measures in CSV format.
+
+        Yields lines.
+
+        `measure_ids` -- list of measure ids which values should be returned.
+
+        `person_ids` -- list of person IDs to filter result. Only data for
+        individuals with person_id in the list `person_ids` are returned.
+
+        `family_ids` -- list of family IDs to filter result. Only data for
+        individuals that are members of any of the specified `family_ids`
+        are returned.
+
+        `roles` -- list of roles of individuals to select measure value for.
+        If not specified value for individuals in all roles are returned.
+        """
+        raise NotImplementedError()
+
 
 class PhenotypeStudy(PhenotypeData):
     """
@@ -857,23 +884,6 @@ class PhenotypeStudy(PhenotypeData):
         family_ids=None,
         roles=None,
     ):
-        """
-        Collect and format the values of the given measures in CSV format.
-
-        Yields lines.
-
-        `measure_ids` -- list of measure ids which values should be returned.
-
-        `person_ids` -- list of person IDs to filter result. Only data for
-        individuals with person_id in the list `person_ids` are returned.
-
-        `family_ids` -- list of family IDs to filter result. Only data for
-        individuals that are members of any of the specified `family_ids`
-        are returned.
-
-        `roles` -- list of roles of individuals to select measure value for.
-        If not specified value for individuals in all roles are returned.
-        """
         assert isinstance(measure_ids, list)
         assert len(measure_ids) >= 1
         assert all(self.has_measure(m) for m in measure_ids)
@@ -1204,6 +1214,15 @@ class PhenotypeGroup(PhenotypeData):
         ]
         measures = chain(*generators)
         yield from measures
+
+    def get_values_streaming_csv(
+        self,
+        measure_ids: list[str],
+        person_ids=None,
+        family_ids=None,
+        roles=None,
+    ):
+        raise NotImplementedError()
 
 
 class PhenoDb(object):

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -3,7 +3,7 @@ import os
 import math
 import logging
 from typing import Dict, Iterable, Any, List, cast
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Union, Generator
 from abc import ABC, abstractmethod
 
 from collections import defaultdict
@@ -547,10 +547,10 @@ class PhenotypeData(ABC):
     def get_values_streaming_csv(
         self,
         measure_ids: list[str],
-        person_ids=None,
-        family_ids=None,
-        roles=None,
-    ):
+        person_ids: Optional[list[str]] = None,
+        family_ids: Optional[list[str]] = None,
+        roles: Optional[list[str]] = None,
+    ) -> Generator[str, None, None]:
         """
         Collect and format the values of the given measures in CSV format.
 
@@ -880,10 +880,10 @@ class PhenotypeStudy(PhenotypeData):
     def get_values_streaming_csv(
         self,
         measure_ids: list[str],
-        person_ids=None,
-        family_ids=None,
-        roles=None,
-    ):
+        person_ids: Optional[list[str]] = None,
+        family_ids: Optional[list[str]] = None,
+        roles: Optional[list[str]] = None,
+    ) -> Generator[str, None, None]:
         assert isinstance(measure_ids, list)
         assert len(measure_ids) >= 1
         assert all(self.has_measure(m) for m in measure_ids)
@@ -959,21 +959,23 @@ class PhenotypeStudy(PhenotypeData):
         buffer.close()
         del output
 
-    def get_regressions(self):
-        return self.db.regression_display_names_with_ids
+    def get_regressions(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self.db.regression_display_names_with_ids)
 
-    def _get_pheno_images_base_url(self):
+    def _get_pheno_images_base_url(self) -> Optional[str]:
         return None if self.config is None \
             else self.config.get("browser_images_url")
 
-    def get_measures_info(self):
+    def get_measures_info(self) -> dict[str, Any]:
         return {
             "base_image_url": self._get_pheno_images_base_url(),
             "has_descriptions": self.db.has_descriptions,
             "regression_names": self.db.regression_display_names,
         }
 
-    def search_measures(self, instrument, search_term):
+    def search_measures(
+        self, instrument: Optional[str], search_term: Optional[str]
+    ) -> Generator[dict[str, Any], None, None]:
         measures = self.db.search_measures(instrument, search_term)
 
         for measure in measures:
@@ -1218,14 +1220,14 @@ class PhenotypeGroup(PhenotypeData):
     def get_values_streaming_csv(
         self,
         measure_ids: list[str],
-        person_ids=None,
-        family_ids=None,
-        roles=None,
-    ):
+        person_ids: Optional[list[str]] = None,
+        family_ids: Optional[list[str]] = None,
+        roles: Optional[list[str]] = None,
+    ) -> Generator[str, None, None]:
         raise NotImplementedError()
 
 
-class PhenoDb(object):
+class PhenoDb:
     """Represents a phenotype databases stored in an sqlite database."""
 
     def __init__(self, dae_config):

--- a/dae/dae/studies/study.py
+++ b/dae/dae/studies/study.py
@@ -43,6 +43,7 @@ class GenotypeData(ABC):  # pylint: disable=too-many-public-methods
         self._person_set_collections: dict[str, PersonSetCollection] = {}
         self._parents: set[str] = set()
         self._executor = None
+        self.is_remote = False
 
     def close(self) -> None:
         logger.error("base genotype data close() called for %s", self.study_id)

--- a/dae/dae/studies/variants_db.py
+++ b/dae/dae/studies/variants_db.py
@@ -570,7 +570,9 @@ class VariantsDb:
             logger.exception(ex)
             return None
 
-    def register_genotype_data(self, genotype_data: GenotypeDataGroup) -> None:
+    def register_genotype_data(
+        self, genotype_data: Union[GenotypeData, GenotypeDataGroup]
+    ) -> None:
         """Add GenotypeData to DB."""
         if genotype_data.study_id in self.get_all_genotype_study_ids():
             logger.warning(

--- a/wdae/wdae/enrichment_api/enrichment_builder.py
+++ b/wdae/wdae/enrichment_api/enrichment_builder.py
@@ -10,7 +10,7 @@ from dae.enrichment_tool.genotype_helper import GenotypeHelper
 from dae.enrichment_tool.tool import EnrichmentTool
 
 from dae.utils.effect_utils import expand_effect_types
-from dae.person_sets import PersonSet
+from dae.person_sets import PersonSet, PersonSetCollection
 
 from .enrichment_serializer import EnrichmentSerializer
 
@@ -37,8 +37,11 @@ class EnrichmentBuilder(BaseEnrichmentBuilder):
         assert enrichment_config is not None
         effect_types = expand_effect_types(enrichment_config.effect_types)
 
-        self.person_set_collection = self.dataset.get_person_set_collection(
-            enrichment_config.selected_person_set_collections[0]
+        self.person_set_collection = cast(
+            PersonSetCollection,
+            self.dataset.get_person_set_collection(
+                enrichment_config.selected_person_set_collections[0]
+            )
         )
 
         self.helper = GenotypeHelper(

--- a/wdae/wdae/enrichment_api/enrichment_builder.py
+++ b/wdae/wdae/enrichment_api/enrichment_builder.py
@@ -1,8 +1,9 @@
 import abc
-from typing import Any, Optional, Iterable, cast
+from typing import Any, Optional, Iterable, cast, Union
 
 from remote.rest_api_client import RESTClient
 from studies.remote_study import RemoteGenotypeData
+from studies.study_wrapper import RemoteStudyWrapper
 
 from dae.studies.study import GenotypeData
 from dae.enrichment_tool.genotype_helper import GenotypeHelper
@@ -104,15 +105,15 @@ class RemoteEnrichmentBuilder(BaseEnrichmentBuilder):
     """Builder for enrichment tool test for remote dataset."""
 
     def __init__(
-        self, dataset: RemoteGenotypeData,
+        self, dataset: Union[RemoteGenotypeData, RemoteStudyWrapper],
         client: RESTClient,
-        background_name: str,
-        counting_name: str,
+        background_name: Optional[str],
+        counting_name: Optional[str],
         gene_syms: Iterable[str]
     ):
         self.dataset = dataset
         self.client = client
-        query = {}
+        query: dict[str, Any] = {}
         query["datasetId"] = dataset._remote_study_id
         query["geneSymbols"] = list(gene_syms)
         query["enrichmentBackgroundModel"] = background_name

--- a/wdae/wdae/gene_scores/views.py
+++ b/wdae/wdae/gene_scores/views.py
@@ -35,7 +35,7 @@ class GeneScoresListView(QueryBaseView):
                         "linear",
                     "range": score.number_hist.config.view_range,
                 }
-                for score in gene_scores
+                for score in gene_scores if score.number_hist is not None
             ]
         )
 

--- a/wdae/wdae/gene_sets/views.py
+++ b/wdae/wdae/gene_sets/views.py
@@ -4,11 +4,9 @@ import ast
 import json
 import itertools
 import logging
-from typing import Union, Optional, Sequence, Any
+from typing import Union, Sequence, Any
 
 from copy import deepcopy
-from dae.gene.denovo_gene_set_collection import DenovoGeneSetCollection
-from dae.gene.gene_sets_db import GeneSet
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -18,6 +16,8 @@ from django.http.response import StreamingHttpResponse
 from django.utils.http import urlencode
 
 from query_base.query_base import QueryBaseView
+
+from dae.gene.gene_sets_db import GeneSet
 
 
 logger = logging.getLogger(__name__)

--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -1,8 +1,10 @@
+from typing import cast
 import logging
 from rest_framework import status
 from rest_framework.response import Response
 from django.http.response import FileResponse
 from query_base.query_base import QueryDatasetView
+from studies.study_wrapper import StudyWrapper
 from utils.logger import request_logging
 from utils.query_params import parse_query_params
 from utils.expand_gene_set import expand_gene_set
@@ -46,6 +48,11 @@ class QueryVariantsView(QueryDatasetView):
         if dataset is None:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+        if dataset.is_remote:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        dataset = cast(StudyWrapper, dataset)
+
         user = request.user
         handle_partial_permissions(user, dataset_id, data)
 
@@ -71,6 +78,11 @@ class DownloadSummaryVariantsView(QueryDatasetView):
 
         if dataset is None:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        if dataset.is_remote:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        dataset = cast(StudyWrapper, dataset)
 
         user = request.user
         user = request.user

--- a/wdae/wdae/genomic_scores_api/urls.py
+++ b/wdae/wdae/genomic_scores_api/urls.py
@@ -3,4 +3,14 @@ from . import views
 
 urlpatterns = [
     re_path(r"^/?$", views.GenomicScoresView.as_view(), name="genomic_scores"),
+    re_path(
+        r"^/score_descs/(?P<score_id>.+)?$",
+        views.GenomicScoreDescsView.as_view(),
+        name="score_desc"
+    ),
+    re_path(
+        r"^/score_descs?$",
+        views.GenomicScoreDescsView.as_view(),
+        name="score_descs_all"
+    ),
 ]

--- a/wdae/wdae/genomic_scores_api/views.py
+++ b/wdae/wdae/genomic_scores_api/views.py
@@ -1,3 +1,5 @@
+from typing import Optional
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.request import Request
 
@@ -36,4 +38,24 @@ class GenomicScoresView(QueryBaseView):
                     "range": None,
                     "help": score.help
                 })
+        return Response(res)
+
+
+class GenomicScoreDescsView(QueryBaseView):
+    def get(
+        self, _request: Request, score_id: Optional[str] = None
+    ) -> Response:
+        res = []
+        if score_id is not None:
+            if not self.gpf_instance.has_genomic_score(score_id):
+                return Response(status=status.HTTP_404_NOT_FOUND)
+            scores = [
+                (score_id, self.gpf_instance.get_genomic_score(score_id))
+            ]
+        else:
+            scores = self.gpf_instance.get_genomic_scores()
+
+        for _, score in scores:
+            res.append(score.to_json())
+
         return Response(res)

--- a/wdae/wdae/genomic_scores_api/views.py
+++ b/wdae/wdae/genomic_scores_api/views.py
@@ -42,9 +42,12 @@ class GenomicScoresView(QueryBaseView):
 
 
 class GenomicScoreDescsView(QueryBaseView):
+    """View for accessing inner genomic scores data from federations."""
+
     def get(
         self, _request: Request, score_id: Optional[str] = None
     ) -> Response:
+        """Convert all genomic score descs into a JSON list."""
         res = []
         if score_id is not None:
             if not self.gpf_instance.has_genomic_score(score_id):

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -43,7 +43,8 @@ class WGPFInstance(GPFInstance):
     """GPF instance class for use in wdae."""
 
     def __init__(
-        self, dae_config: dict[str, Any], dae_dir: str,
+        self, dae_config: dict[str, Any],
+        dae_dir: Union[str, pathlib.Path],
         **kwargs: dict[str, Any]
     ) -> None:
         self._remote_study_db: Optional[RemoteStudyDB] = None
@@ -51,7 +52,7 @@ class WGPFInstance(GPFInstance):
         self._study_wrappers: Dict[
             str, Union[StudyWrapper, RemoteStudyWrapper]
         ] = {}
-        super().__init__(dae_config, dae_dir, **kwargs)
+        super().__init__(cast(Box, dae_config), dae_dir, **kwargs)
 
     @staticmethod
     def build(
@@ -191,7 +192,7 @@ class WGPFInstance(GPFInstance):
         genotype_data_config = \
             super().get_genotype_data_config(genotype_data_id)
         if genotype_data_config is not None:
-            return cast(Box, genotype_data_config)
+            return genotype_data_config
         assert self._remote_study_db is not None
         return cast(
             Box,
@@ -242,7 +243,7 @@ class WGPFInstance(GPFInstance):
             counting_name = enrichment_config.default_counting_model
 
         background = self.get_study_background(
-            dataset_id, background_name
+            dataset_id, cast(str, background_name)
         )
 
         if background is None:
@@ -315,12 +316,12 @@ class WGPFInstance(GPFInstance):
         return list(self._remote_study_db.get_genotype_data_ids())
 
     def get_all_denovo_gene_sets(
-            self, types: dict[str, Any],
-            datasets: list[Any], collection_id: str
-    ) -> list[DenovoGeneSetCollection]:
+        self, types: dict[str, Any],
+        datasets: list[Any], collection_id: str
+    ) -> list[dict[str, Any]]:
         # pylint: disable=arguments-differ
         return cast(
-            list[DenovoGeneSetCollection],
+            list[dict[str, Any]],
             self.denovo_gene_sets_db.get_all_gene_sets(
                 types, datasets, collection_id
             )
@@ -331,10 +332,10 @@ class WGPFInstance(GPFInstance):
         types: dict[str, Any],
         datasets: list[Any],
         collection_id: str
-    ) -> DenovoGeneSetCollection:
+    ) -> dict[str, Any]:
         # pylint: disable=arguments-differ
         return cast(
-            DenovoGeneSetCollection,
+            dict[str, Any],
             self.denovo_gene_sets_db.get_gene_set(
                 gene_set_id, types, datasets, collection_id
             )

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -18,6 +18,7 @@ from enrichment_api.enrichment_builder import \
 from remote.gene_sets_db import RemoteGeneSetsDb
 from remote.denovo_gene_sets_db import RemoteDenovoGeneSetsDb
 from remote.rest_api_client import RESTClient
+from remote.genomic_scores_db import RemoteGenomicScoresDb
 
 from dae.utils.fs_utils import find_directory_with_a_file
 from dae.gpf_instance.gpf_instance import GPFInstance
@@ -109,6 +110,13 @@ class WGPFInstance(GPFInstance):
         self.load_remotes()
         denovo_gene_sets_db = super().denovo_gene_sets_db
         return RemoteDenovoGeneSetsDb(self._clients, denovo_gene_sets_db)
+
+    @cached_property
+    def genomic_scores_db(self):
+        self.load_remotes()
+        genomic_scores_db = super().genomic_scores_db
+        db = RemoteGenomicScoresDb(self._clients, genomic_scores_db)
+        return db
 
     def register_genotype_data(self, genotype_data):
         super().register_genotype_data(genotype_data)

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -27,7 +27,6 @@ from dae.gpf_instance.gpf_instance import GPFInstance
 from dae.enrichment_tool.tool import EnrichmentTool
 from dae.enrichment_tool.event_counters import CounterBase
 from dae.common_reports.common_report import CommonReport
-from dae.gene.denovo_gene_set_collection import DenovoGeneSetCollection
 
 
 logger = logging.getLogger(__name__)

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -42,7 +42,7 @@ class PhenoInstrumentsView(QueryDatasetView):
         dataset_id = request.query_params["dataset_id"]
 
         dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
-        if dataset is None or not dataset.has_pheno_data():
+        if not dataset or dataset.phenotype_data is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         instruments = sorted(dataset.phenotype_data.get_instruments())
@@ -60,7 +60,7 @@ class PhenoMeasuresInfoView(PhenoBrowserBaseView):
         dataset_id = request.query_params["dataset_id"]
 
         dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
-        if dataset is None or not dataset.has_pheno_data():
+        if not dataset or dataset.phenotype_data is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         res = dataset.phenotype_data.get_measures_info()
@@ -75,7 +75,7 @@ class PhenoMeasureDescriptionView(PhenoBrowserBaseView):
         dataset_id = request.query_params["dataset_id"]
 
         dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
-        if dataset is None or not dataset.has_pheno_data():
+        if not dataset or dataset.phenotype_data is None:
             return Response(
                 {"error": "Dataset not found"},
                 status=status.HTTP_404_NOT_FOUND
@@ -101,7 +101,7 @@ class PhenoMeasuresView(PhenoBrowserBaseView):
         dataset_id = request.query_params["dataset_id"]
 
         dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
-        if dataset is None or not dataset.has_pheno_data():
+        if not dataset or dataset.phenotype_data is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         instrument = request.query_params.get("instrument", None)
@@ -133,7 +133,7 @@ class PhenoMeasuresDownload(QueryDatasetView):
         dataset_id = data["dataset_id"]
 
         dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
-        if dataset is None or not dataset.has_pheno_data():
+        if not dataset or dataset.phenotype_data is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         measure_ids = data.get("measures", None)

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -92,9 +92,11 @@ class PhenoToolView(QueryDatasetView):
     def _build_report_description(measure_id, normalize_by):
         if not normalize_by:
             return measure_id
-        return "{} ~ {}".format(measure_id, " + ".join(normalize_by))
+        normalize_desc = " + ".join(normalize_by)
+        return f"{measure_id} ~ {normalize_desc}"
 
     def post(self, request):
+        """Return pheno tool results based on POST request."""
         data = expand_gene_set(request.data, request.user)
         adapter = self.prepare_pheno_tool_adapter(data)
 
@@ -195,6 +197,7 @@ class PhenoToolPersons(QueryDatasetView):
 
 
 class PhenoToolPersonsValues(QueryDatasetView):
+    """View for returning person phenotype data."""
 
     def post(self, request):
         data = request.data

--- a/wdae/wdae/remote/genomic_scores_db.py
+++ b/wdae/wdae/remote/genomic_scores_db.py
@@ -3,10 +3,13 @@ from dae.gene.scores import GenomicScoresDb, ScoreDesc
 
 
 class RemoteGenomicScoresDb(GenomicScoresDb):
+    """Class for automatic fetching and usage of remote genomic scores."""
+
     def __init__(
         self, rest_clients: list[RESTClient],
         local_scores_db: GenomicScoresDb
     ):
+        # pylint: disable=super-init-not-called
         self.remote_scores: dict[str, ScoreDesc] = {}
         self.local_db = local_scores_db
         for client in rest_clients:

--- a/wdae/wdae/remote/genomic_scores_db.py
+++ b/wdae/wdae/remote/genomic_scores_db.py
@@ -1,0 +1,50 @@
+from remote.rest_api_client import RESTClient
+from dae.gene.scores import GenomicScoresDb, ScoreDesc
+
+
+class RemoteGenomicScoresDb(GenomicScoresDb):
+    def __init__(
+        self, rest_clients: list[RESTClient],
+        local_scores_db: GenomicScoresDb
+    ):
+        self.remote_scores: dict[str, ScoreDesc] = {}
+        self.local_db = local_scores_db
+        for client in rest_clients:
+            scores = client.get_genomic_scores()
+            if scores is not None:
+                for score in scores:
+                    desc = score.get("description")
+                    if desc is None:
+                        desc = score["score_id"]
+                    score["description"] = client.prefix_remote_name(
+                        desc
+                    )
+
+                    self.remote_scores[score["score_id"]] = \
+                        ScoreDesc.from_json(score)
+
+    def get_scores(self) -> list[tuple[str, ScoreDesc]]:
+        result = []
+
+        result.extend(self.local_db.get_scores())
+
+        for score_id, score in self.remote_scores.items():
+            result.append((score_id, score))
+
+        return result
+
+    def get_local_scores(self) -> list[tuple[str, ScoreDesc]]:
+        return self.local_db.get_scores()
+
+    def __getitem__(self, score_id: str) -> ScoreDesc:
+        if score_id not in self.local_db:
+            if score_id not in self.remote_scores:
+                raise KeyError()
+            return self.remote_scores[score_id]
+        return self.local_db[score_id]
+
+    def __contains__(self, score_id: str) -> bool:
+        return score_id in self.local_db or score_id in self.remote_scores
+
+    def __len__(self) -> int:
+        return len(self.scores) + len(self.local_db)

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -668,4 +668,4 @@ class RESTClient:
         response = self._get(f"genomic_scores/score_descs/{score_id}")
         if response.status_code != 200:
             return None
-        return response.json()[0]
+        return cast(dict[str, Any], response.json()[0])

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -657,3 +657,15 @@ class RESTClient:
             return None
 
         return response.content.decode()
+
+    def get_genomic_scores(self) -> Optional[list[dict[str, Any]]]:
+        response = self._get("genomic_scores/score_descs")
+        if response.status_code != 200:
+            return None
+        return cast(list[dict[str, Any]], response.json())
+
+    def get_genomic_score(self, score_id: str) -> Optional[dict[str, Any]]:
+        response = self._get(f"genomic_scores/score_descs/{score_id}")
+        if response.status_code != 200:
+            return None
+        return response.json()[0]

--- a/wdae/wdae/remote/tests/test_remote_genomic_scores.py
+++ b/wdae/wdae/remote/tests/test_remote_genomic_scores.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
 from pytest_mock import MockerFixture
 from remote.genomic_scores_db import RemoteGenomicScoresDb
 from remote.rest_api_client import RESTClient

--- a/wdae/wdae/remote/tests/test_remote_genomic_scores.py
+++ b/wdae/wdae/remote/tests/test_remote_genomic_scores.py
@@ -1,0 +1,64 @@
+from pytest_mock import MockerFixture
+from remote.genomic_scores_db import RemoteGenomicScoresDb
+from remote.rest_api_client import RESTClient
+from gpf_instance.gpf_instance import WGPFInstance
+
+
+def test_remote_genomic_scores(
+    mocker: MockerFixture, rest_client: RESTClient,
+    wdae_gpf_instance: WGPFInstance
+) -> None:
+    patch = mocker.patch.object(rest_client, "get_genomic_scores")
+    patch.return_value = [{
+        "resource_id": "test_resource",
+        "score_id": "test_score",
+        "source": "attr_source",
+        "destination": "attr_dest",
+        "hist": {
+            "config": {
+                "type": "number",
+                "view_range": {
+                    "min": 0,
+                    "max": 10
+                },
+                "number_of_bins": 10,
+                "x_log_scale": False,
+                "y_log_scale": False,
+                "x_min_log": None
+            },
+            "bins": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "bars": [
+                10,
+                23,
+                50,
+                10,
+                0,
+                6,
+                9,
+                18,
+                31,
+                1
+            ],
+            "min_value": 1,
+            "max_value": 10
+        },
+        "description": "ala bala",
+        "help": "bala ala"
+    }]
+    local_db = wdae_gpf_instance.genomic_scores_db
+    db = RemoteGenomicScoresDb([rest_client], local_db)
+    assert len(db.remote_scores) == 1
+    assert "test_score" in db.remote_scores
+    score = db.remote_scores["test_score"]
+    assert score.description == "(TEST_REMOTE) ala bala"

--- a/wdae/wdae/remote/tests/test_remote_genomic_scores.py
+++ b/wdae/wdae/remote/tests/test_remote_genomic_scores.py
@@ -14,7 +14,7 @@ def test_remote_genomic_scores(
         "resource_id": "test_resource",
         "score_id": "test_score",
         "source": "attr_source",
-        "destination": "attr_dest",
+        "name": "attr_dest",
         "hist": {
             "config": {
                 "type": "number",

--- a/wdae/wdae/studies/remote_study_db.py
+++ b/wdae/wdae/studies/remote_study_db.py
@@ -4,7 +4,6 @@ import logging
 from typing import List, Dict, Optional
 from remote.rest_api_client import RESTClient, RESTClientRequestError
 from studies.remote_study import RemoteGenotypeData
-from dae.studies.study import GenotypeData
 
 logger = logging.getLogger(__name__)
 

--- a/wdae/wdae/studies/remote_study_db.py
+++ b/wdae/wdae/studies/remote_study_db.py
@@ -1,7 +1,7 @@
 """Provides class for handling of remote studies."""
 
 import logging
-from typing import List, Dict
+from typing import List, Dict, Optional
 from remote.rest_api_client import RESTClient, RESTClientRequestError
 from studies.remote_study import RemoteGenotypeData
 from dae.studies.study import GenotypeData
@@ -15,7 +15,7 @@ class RemoteStudyDB:
     def __init__(self, clients: List[RESTClient]):
         self.remote_study_clients: Dict[str, RESTClient] = {}
         self.remote_study_ids: Dict[str, str] = {}
-        self.remote_genotype_data: Dict[str, GenotypeData] = {}
+        self.remote_genotype_data: Dict[str, RemoteGenotypeData] = {}
 
         for client in clients:
             try:
@@ -26,7 +26,7 @@ class RemoteStudyDB:
     def add_client(self, rest_client: RESTClient) -> None:
         self._fetch_remote_studies(rest_client)
 
-    def _fetch_remote_studies(self, rest_client: RESTClient):
+    def _fetch_remote_studies(self, rest_client: RESTClient) -> None:
         studies = rest_client.get_studies()
         if studies is None:
             raise RESTClientRequestError(
@@ -40,7 +40,7 @@ class RemoteStudyDB:
             self.remote_study_clients[study_id] = rest_client
             self.remote_genotype_data[study_id] = rgd
 
-    def get_genotype_data(self, study_id: str) -> RemoteGenotypeData:
+    def get_genotype_data(self, study_id: str) -> Optional[RemoteGenotypeData]:
         return self.remote_genotype_data.get(study_id)
 
     def get_genotype_data_config(self, study_id):

--- a/wdae/wdae/studies/remote_study_db.py
+++ b/wdae/wdae/studies/remote_study_db.py
@@ -40,7 +40,7 @@ class RemoteStudyDB:
             self.remote_study_clients[study_id] = rest_client
             self.remote_genotype_data[study_id] = rgd
 
-    def get_genotype_data(self, study_id):
+    def get_genotype_data(self, study_id: str) -> RemoteGenotypeData:
         return self.remote_genotype_data.get(study_id)
 
     def get_genotype_data_config(self, study_id):

--- a/wdae/wdae/studies/tests/test_study_wrapper.py
+++ b/wdae/wdae/studies/tests/test_study_wrapper.py
@@ -4,9 +4,11 @@ from gpf_instance.gpf_instance import WGPFInstance
 
 def test_is_group_study(wdae_gpf_instance: WGPFInstance) -> None:
     wrapper = wdae_gpf_instance.get_wdae_wrapper("f1_study")
+    assert wrapper is not None
     assert wrapper.is_group is False
 
 
 def test_is_group_dataset(wdae_gpf_instance: WGPFInstance) -> None:
     wrapper = wdae_gpf_instance.get_wdae_wrapper("Dataset1")
+    assert wrapper is not None
     assert wrapper.is_group is True


### PR DESCRIPTION
## Background
Since we switched to genomic scores being tied to annotation, setting up local genomic scores to substitute this as a feature has become difficult.

## Aim
Implement remote genomic scores.

## Implementation
Genomic scores are represented by a `ScoreDesc` class, so these are now exposed on a new view on the API. The remote genomic scores DB fetches all of the `ScoreDesc` classes on the remote and recreates them locally, prefixing an ID to the description. Because this included changes in the WDAE GPF instance, this made a lot of lint errors resurface, so this is also addressed in this PR.
