### PR TITLE
Fix email guessing

### DIFF
--- a/wdae/wdae/users_api/tests/test_users_researcher_registration.py
+++ b/wdae/wdae/users_api/tests/test_users_researcher_registration.py
@@ -82,7 +82,7 @@ def test_reset_pass_without_registration_wrong_email(db, client):
     response = client.post(
         url, json.dumps(data), content_type="application/json", format="json"
     )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_200_OK
 
 
 def test_successful_register(client, researcher_without_password):

--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -155,15 +155,14 @@ class ForgotPassword(views.APIView):
             )
         email = form.data["email"]
         user_model = get_user_model()
+        message = (
+            f"An e-mail has been sent to {email}"
+            " containing the reset link"
+        )
         try:
             user = user_model.objects.get(email=email)
             user.reset_password()
             user.deauthenticate()
-
-            message = (
-                f"An e-mail has been sent to {email}"
-                " containing the reset link"
-            )
 
             return render(
                 request,
@@ -176,18 +175,15 @@ class ForgotPassword(views.APIView):
                 }
             )
         except user_model.DoesNotExist:
-            form = WdaePasswordForgottenForm()
-            message = f"There is no user registered for {email}"
             return render(
                 request,
                 "users_api/registration/forgotten-password.html",
                 {
                     "form": form,
                     "message": message,
-                    "message_type": "warn",
-                    "show_form": True
-                },
-                status=status.HTTP_404_NOT_FOUND
+                    "message_type": "success",
+                    "show_form": False
+                }
             )
 
 


### PR DESCRIPTION
## Background
Our reset password API could be used to check what emails are registered on the system, which could enable other vulnerabilities.

## Aim
Make the reset password response uniform, regardless of whether the email is registered or not.