### PR TITLE
Denovo optimization

### DIFF
--- a/dae/conftest.py
+++ b/dae/conftest.py
@@ -1,9 +1,15 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import pathlib
 from typing import Optional, Any
+import textwrap
+
 import pytest
+from dae.gpf_instance.gpf_instance import GPFInstance
 from dae.genotype_storage.genotype_storage_registry import \
     GenotypeStorageRegistry, GenotypeStorage
+from dae.testing.t4c8_import import t4c8_gpf
+from dae.testing import setup_pedigree, setup_vcf, setup_dataset, vcf_study
+from dae.studies.study import GenotypeData, GenotypeDataGroup
 
 pytest_plugins = ["dae_conftests.dae_conftests"]
 
@@ -44,6 +50,254 @@ def default_genotype_storage_configs(root_path: pathlib.Path) -> list[dict]:
 GENOTYPE_STORAGE_REGISTRY = GenotypeStorageRegistry()
 GENOTYPE_STORAGES: Optional[dict[str, Any]] = None
 
+@pytest.fixture(scope="module", params=["duckdb", "inmemory"])
+def t4c8_instance(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory
+) -> GPFInstance:
+    root_path = tmp_path_factory.mktemp(
+        "study_group_person_set_queries_genotype_storages")
+
+    storage_configs = {
+        # DuckDb Storage
+        "duckdb": {
+            "id": "duckdb",
+            "storage_type": "duckdb",
+            "db": "duckdb_storage/dev_storage.db",
+            "base_dir": str(root_path)
+        },
+
+        # Filesystem InMemory
+        "inmemory": {
+            "id": "inmemory",
+            "storage_type": "inmemory",
+            "dir": f"{root_path}/genotype_filesystem_data"
+        },
+    }
+
+    if not GENOTYPE_STORAGE_REGISTRY.get_all_genotype_storage_ids():
+        for storage_config in storage_configs.values():
+            GENOTYPE_STORAGE_REGISTRY\
+                .register_storage_config(storage_config)
+
+    genotype_storage = GENOTYPE_STORAGE_REGISTRY.get_genotype_storage(
+        request.param)
+    assert genotype_storage is not None
+
+    root_path = tmp_path_factory.mktemp(
+        "study_group_person_set_queries")
+    gpf_instance = t4c8_gpf(root_path, storage=genotype_storage)
+    return gpf_instance
+
+
+@pytest.fixture(scope="module")
+def t4c8_study_1(t4c8_instance: GPFInstance) -> GenotypeData:
+    root_path = pathlib.Path(t4c8_instance.dae_dir)
+    ped_path = setup_pedigree(
+        root_path / "study_1" / "pedigree" / "in.ped",
+        """
+familyId personId dadId momId sex status role
+f1.1     mom1     0     0     2   1      mom
+f1.1     dad1     0     0     1   1      dad
+f1.1     ch1      dad1  mom1  2   2      prb
+f1.3     mom3     0     0     2   1      mom
+f1.3     dad3     0     0     1   1      dad
+f1.3     ch3      dad3  mom3  2   2      prb
+        """)
+    vcf_path1 = setup_vcf(
+        root_path / "study_1" / "vcf" / "in.vcf.gz",
+        """
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+##contig=<ID=chr2>
+##contig=<ID=chr3>
+#CHROM POS ID REF ALT QUAL FILTER INFO FORMAT mom1 dad1 ch1 mom3 dad3 ch3
+chr1   1   .  A   C   .    .      .    GT     0/0  0/0  0/1 0/0  0/0  0/0
+chr1   2   .  C   G   .    .      .    GT     0/0  0/0  0/0 0/0  0/0  0/1
+chr1   3   .  G   T   .    .      .    GT     0/0  1/0  0/1 0/0  0/0  0/0
+        """)  # noqa
+
+    project_config_update = {
+        "input": {
+            "vcf": {
+                "denovo_mode": "denovo",
+                "omission_mode": "omission",
+            }
+        },
+    }
+    study = vcf_study(
+        root_path,
+        "study_1", ped_path, [vcf_path1],
+        t4c8_instance,
+        project_config_update=project_config_update,
+        study_config_update={
+            "conf_dir": str(root_path / "study_1"),
+            "person_set_collections": {
+                "phenotype": {
+                    "id": "phenotype",
+                    "name": "Phenotype",
+                    "sources": [
+                        {
+                            "from": "pedigree",
+                            "source": "status"
+                        }
+                    ],
+                    "default": {
+                        "color": "#aaaaaa",
+                        "id": "unspecified",
+                        "name": "unspecified",
+                    },
+                    "domain": [
+                        {
+                            "color": "#bbbbbb",
+                            "id": "autism",
+                            "name": "autism",
+                            "values": [
+                                "affected"
+                            ]
+                        },
+                        {
+                            "color": "#00ff00",
+                            "id": "unaffected",
+                            "name": "unaffected",
+                            "values": [
+                                "unaffected"
+                            ]
+                        },
+                    ]
+                },
+                "selected_person_set_collections": [
+                    "phenotype"
+                ]
+            }
+        })
+    return study
+
+
+@pytest.fixture(scope="module")
+def t4c8_study_2(t4c8_instance: GPFInstance) -> GenotypeData:
+    root_path = pathlib.Path(t4c8_instance.dae_dir)
+    ped_path = setup_pedigree(
+        root_path / "study_2" / "pedigree" / "in.ped",
+        """
+familyId personId dadId momId sex status role
+f2.1     mom1     0     0     2   1      mom
+f2.1     dad1     0     0     1   1      dad
+f2.1     ch1      dad1  mom1  2   2      prb
+f2.3     mom3     0     0     2   1      mom
+f2.3     dad3     0     0     1   1      dad
+f2.3     ch3      dad3  mom3  2   2      prb
+f2.3     ch4      dad3  mom3  2   0      prb
+        """)
+    vcf_path1 = setup_vcf(
+        root_path / "study_2" / "vcf" / "in.vcf.gz",
+        """
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+##contig=<ID=chr2>
+##contig=<ID=chr3>
+#CHROM POS ID REF ALT QUAL FILTER INFO FORMAT mom1 dad1 ch1 mom3 dad3 ch3 ch4
+chr1   5   .  A   C   .    .      .    GT     0/0  0/0  0/1 0/0  0/0  0/0 0/1
+chr1   6   .  C   G   .    .      .    GT     0/0  0/0  0/0 0/0  0/0  0/1 0/0
+chr1   7   .  G   T   .    .      .    GT     0/0  1/0  0/1 0/0  0/0  0/0 0/1
+        """)  # noqa
+
+    project_config_update = {
+        "input": {
+            "vcf": {
+                "denovo_mode": "denovo",
+                "omission_mode": "omission",
+            }
+        },
+    }
+    study = vcf_study(
+        root_path,
+        "study_2", ped_path, [vcf_path1],
+        t4c8_instance,
+        project_config_update=project_config_update,
+        study_config_update={
+            "conf_dir": str(root_path / "study_2"),
+            "person_set_collections": {
+                "phenotype": {
+                    "id": "phenotype",
+                    "name": "Phenotype",
+                    "sources": [
+                        {
+                            "from": "pedigree",
+                            "source": "status"
+                        }
+                    ],
+                    "default": {
+                        "color": "#aaaaaa",
+                        "id": "unspecified",
+                        "name": "unspecified",
+                    },
+                    "domain": [
+                        {
+                            "color": "#bbbbbb",
+                            "id": "epilepsy",
+                            "name": "epilepsy",
+                            "values": [
+                                "affected"
+                            ]
+                        },
+                        {
+                            "color": "#00ff00",
+                            "id": "unaffected",
+                            "name": "unaffected",
+                            "values": [
+                                "unaffected"
+                            ]
+                        },
+                    ]
+                },
+                "selected_person_set_collections": [
+                    "phenotype"
+                ]
+            }
+        })
+    return study
+
+
+@pytest.fixture
+def t4c8_dataset(
+    t4c8_instance: GPFInstance,
+    t4c8_study_1: GenotypeData,
+    t4c8_study_2: GenotypeData
+) -> GenotypeDataGroup:
+    root_path = pathlib.Path(t4c8_instance.dae_dir)
+    (root_path / "dataset").mkdir(exist_ok=True)
+
+    return setup_dataset(
+        "dataset", t4c8_instance, t4c8_study_1, t4c8_study_2,
+        dataset_config_update=textwrap.dedent(f"""
+            conf_dir: { root_path / "dataset "}
+            person_set_collections:
+                phenotype:
+                  id: phenotype
+                  name: Phenotype
+                  sources:
+                  - from: pedigree
+                    source: status
+                  domain:
+                  - color: '#4b2626'
+                    id: developmental_disorder
+                    name: developmental disorder
+                    values:
+                    - affected
+                  - color: '#ffffff'
+                    id: unaffected
+                    name: unaffected
+                    values:
+                    - unaffected
+                  default:
+                    color: '#aaaaaa'
+                    id: unspecified
+                    name: unspecified
+                selected_person_set_collections:
+                - phenotype"""))
 
 def _select_storages_by_type(
         storage_types: list[str]) -> dict[str, GenotypeStorage]:

--- a/dae/dae/common_reports/denovo_report.py
+++ b/dae/dae/common_reports/denovo_report.py
@@ -262,9 +262,6 @@ class DenovoReportTable:
             "effect_types": self.effect_types,
         }
 
-    def count_variant(self, fv):
-        self.rows
-
     def is_empty(self):
         """Return whether the table does not have a single counted variant."""
         def _is_row_empty(row):

--- a/dae/dae/common_reports/tests/test_denovo_report.py
+++ b/dae/dae/common_reports/tests/test_denovo_report.py
@@ -47,7 +47,7 @@ def test_denovo_report(
 
 def test_denovo_report_empty(study2, phenotype_role_collection):
     denovo_report = DenovoReport.from_genotype_study(
-        study2, phenotype_role_collection
+        study2, [phenotype_role_collection]
     )
 
     assert len(denovo_report.tables) == 0
@@ -59,8 +59,10 @@ def test_denovo_report_empty(study2, phenotype_role_collection):
 
 def test_effect_row(denovo_variants_ds1, phenotype_role_sets):
     effect_row = EffectRow(
-        denovo_variants_ds1, "Missense", phenotype_role_sets
+        "Missense", phenotype_role_sets
     )
+    for fv in denovo_variants_ds1:
+        effect_row.count_variant(fv)
     out_dict = effect_row.to_dict()
     assert out_dict["effect_type"] == "Missense"
 
@@ -96,8 +98,11 @@ def test_effect_row(denovo_variants_ds1, phenotype_role_sets):
 
 def test_effect_cell(denovo_variants_ds1, phenotype_role_sets):
     effect_cell1 = EffectCell(
-        denovo_variants_ds1, phenotype_role_sets[0], "Missense"
+        phenotype_role_sets[0], "Missense"
     )
+    for fv in denovo_variants_ds1:
+        for fa in fv.alt_alleles:
+            effect_cell1.count_variant(fv, fa)
     assert effect_cell1.to_dict() == {
         "number_of_observed_events": 3,
         "number_of_children_with_event": 3,
@@ -107,8 +112,11 @@ def test_effect_cell(denovo_variants_ds1, phenotype_role_sets):
     }
 
     effect_cell2 = EffectCell(
-        denovo_variants_ds1, phenotype_role_sets[1], "Missense"
+        phenotype_role_sets[1], "Missense"
     )
+    for fv in denovo_variants_ds1:
+        for fa in fv.alt_alleles:
+            effect_cell2.count_variant(fv, fa)
     assert effect_cell2.to_dict() == {
         "number_of_observed_events": 2,
         "number_of_children_with_event": 1,
@@ -118,8 +126,11 @@ def test_effect_cell(denovo_variants_ds1, phenotype_role_sets):
     }
 
     effect_cell3 = EffectCell(
-        denovo_variants_ds1, phenotype_role_sets[2], "Missense"
+        phenotype_role_sets[2], "Missense"
     )
+    for fv in denovo_variants_ds1:
+        for fa in fv.alt_alleles:
+            effect_cell3.count_variant(fv, fa)
     assert effect_cell3.to_dict() == {
         "number_of_observed_events": 0,
         "number_of_children_with_event": 0,
@@ -129,8 +140,11 @@ def test_effect_cell(denovo_variants_ds1, phenotype_role_sets):
     }
 
     effect_cell4 = EffectCell(
-        denovo_variants_ds1, phenotype_role_sets[3], "Missense"
+        phenotype_role_sets[3], "Missense"
     )
+    for fv in denovo_variants_ds1:
+        for fa in fv.alt_alleles:
+            effect_cell4.count_variant(fv, fa)
     assert effect_cell4.to_dict() == {
         "number_of_observed_events": 0,
         "number_of_children_with_event": 0,

--- a/dae/dae/enrichment_tool/genotype_helper.py
+++ b/dae/dae/enrichment_tool/genotype_helper.py
@@ -1,4 +1,4 @@
-from typing import Optional, Generator
+from typing import Optional
 from collections import Counter, defaultdict
 
 from dae.variants.attributes import Inheritance
@@ -20,7 +20,11 @@ class GenotypeHelper:
         # self.person_set = person_set_collection.person_sets[person_set_id]
         self._children_stats: dict[str, dict[str, int]] = {}
         self._children_by_sex: dict[str, dict[str, set[tuple[str, str]]]] = {}
-        self._effect_types = effect_types
+
+        self._denovo_variants = list(
+            self.genotype_data.query_variants(
+                effect_types=effect_types,
+                inheritance=str(Inheritance.denovo.name)))
 
         self._build_children_stats()
 
@@ -46,11 +50,8 @@ class GenotypeHelper:
                 counter[sex] = len(persons)
             self._children_stats[person_set_id] = counter
 
-    def get_denovo_variants(self) -> Generator[FamilyVariant, None, None]:
-        return self.genotype_data.query_variants(
-            effect_types=self._effect_types,
-            inheritance=str(Inheritance.denovo.name)
-        )
+    def get_denovo_variants(self) -> list[FamilyVariant]:
+        return self._denovo_variants
 
     def children_by_sex(
         self, person_set_id: str

--- a/dae/dae/enrichment_tool/genotype_helper.py
+++ b/dae/dae/enrichment_tool/genotype_helper.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Generator
 from collections import Counter, defaultdict
 
 from dae.variants.attributes import Inheritance
@@ -20,11 +20,7 @@ class GenotypeHelper:
         # self.person_set = person_set_collection.person_sets[person_set_id]
         self._children_stats: dict[str, dict[str, int]] = {}
         self._children_by_sex: dict[str, dict[str, set[tuple[str, str]]]] = {}
-
-        self._denovo_variants = list(
-            self.genotype_data.query_variants(
-                effect_types=effect_types,
-                inheritance=str(Inheritance.denovo.name)))
+        self._effect_types = effect_types
 
         self._build_children_stats()
 
@@ -50,8 +46,11 @@ class GenotypeHelper:
                 counter[sex] = len(persons)
             self._children_stats[person_set_id] = counter
 
-    def get_denovo_variants(self) -> list[FamilyVariant]:
-        return self._denovo_variants
+    def get_denovo_variants(self) -> Generator[FamilyVariant, None, None]:
+        return self.genotype_data.query_variants(
+            effect_types=self._effect_types,
+            inheritance=str(Inheritance.denovo.name)
+        )
 
     def children_by_sex(
         self, person_set_id: str

--- a/dae/dae/tools/tests/test_generate_denovo_gene_sets.py
+++ b/dae/dae/tools/tests/test_generate_denovo_gene_sets.py
@@ -1,10 +1,86 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
+from dae.common_reports.common_report import CommonReport
+from dae.gpf_instance.gpf_instance import GPFInstance
+from dae.studies.study import GenotypeData
 from dae.tools.generate_denovo_gene_sets import main
 
 
 # pytestmark = pytest.mark.usefixtures("gene_info_cache_dir")
 
 
-def test_generate_denovo_gene_sets_script_passes(gpf_instance_2013):
+def test_generate_denovo_gene_sets_script_passes(
+    gpf_instance_2013: GPFInstance
+) -> None:
     gpf_instance_2013.reload()
     main(gpf_instance=gpf_instance_2013, argv=[])
     main(gpf_instance=gpf_instance_2013, argv=["--show-studies"])
+
+
+def test_generate_denovo_gene_sets_study_1(
+    t4c8_instance: GPFInstance,
+    t4c8_study_1: GenotypeData
+) -> None:
+    main(gpf_instance=t4c8_instance, argv=[])
+    report_path = os.path.join(
+        t4c8_instance.dae_dir,
+        "studies",
+        "study_1",
+        "common_report.json"
+    )
+    print(t4c8_instance.dae_dir)
+    assert os.path.exists(report_path)
+
+    report = CommonReport.load(report_path)
+    assert report is not None
+    assert report.denovo_report is not None
+
+    denovo_report = report.denovo_report.to_dict()
+
+    assert denovo_report["tables"][0]["rows"][0]["effect_type"] == "Intergenic"
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "number_of_observed_events"
+    ] == 2
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "number_of_children_with_event"
+    ] == 2
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "observed_rate_per_child"
+    ] == 1.0
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "column"
+    ] == "autism (2)"
+
+def test_generate_denovo_gene_sets_study_2(
+    t4c8_instance: GPFInstance,
+    t4c8_study_2: GenotypeData
+) -> None:
+    main(gpf_instance=t4c8_instance, argv=[])
+    report_path = os.path.join(
+        t4c8_instance.dae_dir,
+        "studies",
+        "study_2",
+        "common_report.json"
+    )
+    print(t4c8_instance.dae_dir)
+    assert os.path.exists(report_path)
+
+    report = CommonReport.load(report_path)
+    assert report is not None
+    assert report.denovo_report is not None
+
+    denovo_report = report.denovo_report.to_dict()
+
+    assert denovo_report["tables"][0]["rows"][0]["effect_type"] == "UTRs"
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "number_of_observed_events"
+    ] == 1
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "number_of_children_with_event"
+    ] == 1
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "observed_rate_per_child"
+    ] == 0.5
+    assert denovo_report["tables"][0]["rows"][0]["row"][0][
+        "column"
+    ] == "epilepsy (2)"

--- a/dae/dae/tools/tests/test_generate_denovo_gene_sets.py
+++ b/dae/dae/tools/tests/test_generate_denovo_gene_sets.py
@@ -51,6 +51,7 @@ def test_generate_denovo_gene_sets_study_1(
         "column"
     ] == "autism (2)"
 
+
 def test_generate_denovo_gene_sets_study_2(
     t4c8_instance: GPFInstance,
     t4c8_study_2: GenotypeData


### PR DESCRIPTION
## Background
Denovo reports and enrichment tool converted the generator of denovo variants to a list. This caused problems with very large studies, due to memory shortage.

## Aim
Optimize denovo reports and enrichment tool to use the generators instead.

## Implementation
The denovo report used to pass around a single list of variants to each and every element of itself (every single table, row, cell). All denovo report elements now do not require a list of variants to create and instead have a count_variant method which is used for generating a table from a generator of variants. As a side effect of this, if we have a denovo report with multiple tables, the query will be executed multiple times.
Enrichment has also been changed to use a generator instead.
