### PR TITLE
Update SQLAlchemy version

### DIFF
--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -302,7 +302,7 @@ class DbManager(object):
             query_params.append(
                 self.variable_browser.c.description.like(keyword, escape="\\")
             )
-            query = self.variable_browser.select(or_(*query_params))
+            query = self.variable_browser.select().where((or_(*query_params)))
         else:
             query = self.variable_browser.select()
 

--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -414,10 +414,10 @@ class DbManager(object):
         )
         with self.browser_engine.connect() as connection:
             for row in connection.execute(selector):
-                res[row.values()[0]] = {
-                    "display_name": row.values()[1],
-                    "instrument_name": row.values()[2],
-                    "measure_name": row.values()[3],
+                res[row[0]] = {
+                    "display_name": row[1],
+                    "instrument_name": row[2],
+                    "measure_name": row[3],
                 }
         return res
 

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -989,12 +989,12 @@ class PhenotypeStudy(PhenotypeData):
                 measure["measure_id"]) or []
 
             for reg in regressions:
-                reg = dict(reg)
+                reg = reg._mapping
                 if isnan(reg["pvalue_regression_male"]):
                     reg["pvalue_regression_male"] = "NaN"
                 if isnan(reg["pvalue_regression_female"]):
                     reg["pvalue_regression_female"] = "NaN"
-                measure["regressions"].append(reg)
+                measure["regressions"].append(dict(reg))
 
             yield {
                 "measure": measure,

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -638,7 +638,7 @@ class PhenotypeStudy(PhenotypeData):
             measure.c.min_value,
             measure.c.max_value,
         ]
-        query = select(columns)
+        query = select(*columns)
         query = query.where(not_(measure.c.measure_type.is_(None)))
         if instrument is not None:
             query = query.where(measure.c.instrument_name == instrument)
@@ -716,7 +716,7 @@ class PhenotypeStudy(PhenotypeData):
             self.db.person.c.status,
             self.db.person.c.sex,
         ]
-        query = select(columns)
+        query = select(*columns)
         query = query.select_from(self.db.family.join(self.db.person))
         if roles is not None:
             query = query.where(self.db.person.c.role.in_(roles))
@@ -763,7 +763,7 @@ class PhenotypeStudy(PhenotypeData):
             value_table.c.value,
         ]
 
-        query = select(columns)
+        query = select(*columns)
         query = query.select_from(
             value_table.join(self.db.measure)
             .join(self.db.person)
@@ -920,7 +920,7 @@ class PhenotypeStudy(PhenotypeData):
         output = {}
 
         for table in value_tables:
-            query = select(columns + [table.c.value])
+            query = select(*columns, table.c.value)
 
             join = (
                 self.db.family.join(self.db.person)
@@ -943,6 +943,7 @@ class PhenotypeStudy(PhenotypeData):
             with self.db.pheno_engine.connect() as connection:
                 results = connection.execute(query)
                 for row in results:
+                    row = row._mapping
                     person_id = row["person_id"]
                     if person_id not in output:
                         output[person_id] = ["-"] * len(header)

--- a/dae/dae/pheno/prepare/pheno_prepare.py
+++ b/dae/dae/pheno/prepare/pheno_prepare.py
@@ -59,6 +59,7 @@ class PreparePersons(PrepareBase):
         ins = self.db.family.insert()
         with self.db.pheno_engine.connect() as connection:
             connection.execute(ins, families)
+            connection.commit()
 
     @staticmethod
     def _build_sample_id(sample_id):
@@ -84,6 +85,7 @@ class PreparePersons(PrepareBase):
         ins = self.db.person.insert()
         with self.db.pheno_engine.connect() as connection:
             connection.execute(ins, persons)
+            connection.commit()
 
     def save_pedigree(self, ped_df):
         self._save_families(ped_df)
@@ -356,6 +358,7 @@ class PrepareVariables(PreparePersons):
         with self.db.pheno_engine.begin() as connection:
             result = connection.execute(ins)
             measure_id = result.inserted_primary_key[0]
+            connection.commit()
 
         return measure_id
 
@@ -373,6 +376,7 @@ class PrepareVariables(PreparePersons):
 
         with self.db.pheno_engine.begin() as connection:
             connection.execute(ins, list(values.values()))
+            connection.commit()
 
     def _collect_instruments(self, dirname):
         regexp = re.compile("(?P<instrument>.*)(?P<ext>\\.csv.*)")

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - dask=2023.8
   - python-box=7.1
   - setuptools=67
-  - sqlalchemy=1.4.49
+  - sqlalchemy=2.0.21
   - sqlite=3.43
   - django=4.2.3
   - django-cors-headers=4.0


### PR DESCRIPTION
## Background
SQLAlchemy updated to a new major version, removing a few deprecated features, which were still used in GPF.

## Aim
Bump the version to 2.x and update the deprecated code.

## Implementation
The main things that have changed are the `select()` arguments, listing columns is now done via varargs instead of a single list argument, connections now do not autocommit and we have to perform manual commits and rows are named tuples and not mappings (old mappings are still accessible via `row._mapping`)

## Related issues
Closes #552.
