### PR TITLE
Fix pheno browser download search

### DIFF
--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -146,7 +146,7 @@ def test_download_specific_measures(admin_client):
     data = {
         "dataset_id": "quads_f1",
         "instrument": "instrument1",
-        "measures": ["instrument1.continuous", "instrument1.categorical"]
+        "measure_ids": ["instrument1.continuous", "instrument1.categorical"]
     }
     response = admin_client.post(
         DOWNLOAD_URL, json.dumps(data), "application/json"
@@ -189,7 +189,7 @@ def test_download_all_instruments(admin_client):
 def test_download_all_instruments_specific_measures(admin_client):
     data = {
         "dataset_id": "quads_f1",
-        "measures": ["instrument1.continuous", "instrument1.categorical"]
+        "measure_ids": ["instrument1.continuous", "instrument1.categorical"]
     }
     response = admin_client.post(
         DOWNLOAD_URL, json.dumps(data), "application/json"

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -136,7 +136,7 @@ class PhenoMeasuresDownload(QueryDatasetView):
         if not dataset or dataset.phenotype_data is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        measure_ids = data.get("measures", None)
+        measure_ids = data.get("measure_ids", None)
         instrument = data.get("instrument", None)
         if instrument is None:
             if measure_ids is None:

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -359,7 +359,7 @@ class RESTClient:
             "pheno_browser/download",
             data={
                 "dataset_id": dataset_id,
-                "measures": measure_ids,
+                "measure_ids": measure_ids,
                 "instrument": instrument,
             },
             stream=True


### PR DESCRIPTION
## Background
Pheno browser download is not working correctly when searching. It always downloads all measures.

## Aim
Fix the download.

## Implementation
The issue was that for some reason, the frontend was sending the measures from the search as `measure_ids`, but the backend was expecting `measures`. I decided to fix this to `measure_ids`.

## Related issues
Closes #558 
