### PR TITLE
Add AGP configuration views caching

### DIFF
--- a/dae/dae/configuration/schemas/autism_gene_profile.py
+++ b/dae/dae/configuration/schemas/autism_gene_profile.py
@@ -134,6 +134,7 @@ autism_gene_tool_config = {
     "default_dataset": {"type": "string", "required": True},
     "order": {
         "type": "list",
+        "required": True,
         "schema": {
             "type": "string",
         }

--- a/wdae/wdae/autism_gene_profiles_api/table_views.py
+++ b/wdae/wdae/autism_gene_profiles_api/table_views.py
@@ -8,136 +8,13 @@ from query_base.query_base import QueryBaseView
 LOGGER = logging.getLogger(__name__)
 
 
-def column(
-    id, display_name, visible=True, clickable=None,
-    display_vertical=False, sortable=False, columns=None, meta=None
-):
-    if columns is None:
-        columns = list()
-    return {
-        "id": id,
-        "displayName": display_name,
-        "visible": visible,
-        "displayVertical": display_vertical,
-        "sortable": sortable,
-        "clickable": clickable,
-        "columns": columns,
-        "meta": meta
-    }
-
-
 class TableConfigurationView(QueryBaseView):
-    def find_category_section(self, configuration, category):
-        for gene_set in configuration["geneSets"]:
-            if gene_set["category"] == category:
-                return "geneSets"
-        for genomic_score in configuration["genomicScores"]:
-            if genomic_score["category"] == category:
-                return "genomicScores"
-        for dataset in configuration["datasets"]:
-            if dataset["id"] == category:
-                return "datasets"
-
-    def get(self, request):
-        configuration = self.gpf_instance.get_agp_configuration()
+    def get(self, _request):
+        configuration = self.gpf_instance.get_wdae_agp_table_configuration()
         if configuration is None:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        if len(configuration) == 0:
-            return Response(dict())
-
-        response = {
-            "defaultDataset": configuration.get("default_dataset"),
-            "columns": [],
-            "pageSize": self.gpf_instance._autism_gene_profile_db.PAGE_SIZE,
-        }
-
-        response["columns"].append(
-            column("geneSymbol", "Gene", clickable="createTab")
-        )
-
-        for category in configuration["gene_sets"]:
-            response["columns"].append(column(
-                f"{category['category']}_rank",
-                category["display_name"],
-                visible=category.get("default_visible", True),
-                meta=category.get("meta"),
-                sortable=True,
-                columns=[column(
-                    f"{category['category']}_rank.{gene_set['set_id']}",
-                    gene_set["set_id"],
-                    visible=gene_set.get("default_visible", True),
-                    meta=gene_set.get("meta"),
-                    display_vertical=True,
-                    sortable=True) for gene_set in category["sets"]
-                ]
-            ))
-
-        for category in configuration["genomic_scores"]:
-            response["columns"].append(column(
-                category["category"],
-                category["display_name"],
-                visible=category.get("default_visible", True),
-                meta=category.get("meta"),
-                columns=[column(
-                    f"{category['category']}.{genomic_score['score_name']}",
-                    genomic_score["score_name"],
-                    visible=genomic_score.get("default_visible", True),
-                    meta=genomic_score.get("meta"),
-                    display_vertical=True,
-                    sortable=True) for genomic_score in category["scores"]
-                ]
-            ))
-
-        if "datasets" in configuration:
-            for dataset_id, dataset in configuration["datasets"].items():
-                study_wrapper = self.gpf_instance.get_wdae_wrapper(dataset_id)
-                if study_wrapper is None:
-                    LOGGER.error("missing dataset %s", dataset_id)
-                    continue
-                display_name = dataset.get("display_name") \
-                    or study_wrapper.config.get("name") \
-                    or dataset_id
-                dataset_col = column(
-                    f"{dataset_id}", display_name,
-                    visible=dataset.get("default_visible", True),
-                    meta=dataset.get("meta"),
-                )
-                for person_set in dataset.get("person_sets", []):
-                    set_id = person_set["set_name"]
-                    collection_id = person_set["collection_name"]
-                    person_set_collection = \
-                        study_wrapper.genotype_data.person_set_collections[
-                            collection_id
-                        ]
-                    set_name = \
-                        person_set_collection.person_sets[set_id].name
-                    stats = person_set_collection.get_stats()[set_id]
-                    dataset_col["columns"].append(column(
-                        f"{dataset_id}.{set_id}",
-                        f"{set_name} ({stats['children']})",
-                        visible=person_set.get("default_visible", True),
-                        meta=person_set.get("meta"),
-                        columns=[column(
-                            f"{dataset_id}.{set_id}.{statistic['id']}",
-                            statistic["display_name"],
-                            visible=statistic.get("default_visible", True),
-                            meta=statistic.get("meta"),
-                            clickable="goToQuery",
-                            sortable=True)
-
-                            for statistic in dataset["statistics"]
-                        ]
-                    ))
-                response["columns"].append(dataset_col)
-
-        if configuration.get("order"):
-            category_order = ["geneSymbol", *configuration["order"]]
-            response["columns"].sort(
-                key=lambda col: category_order.index(col["id"])
-            )
-
-        return Response(response)
+        return Response(configuration)
 
 
 class TableRowsView(QueryBaseView):

--- a/wdae/wdae/autism_gene_profiles_api/views.py
+++ b/wdae/wdae/autism_gene_profiles_api/views.py
@@ -1,8 +1,8 @@
 import logging
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.request import Request
 
-from dae.utils.helpers import to_response_json
 from query_base.query_base import QueryBaseView
 
 
@@ -10,93 +10,15 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigurationView(QueryBaseView):
-    def find_category_section(self, configuration, category):
-        for gene_set in configuration["geneSets"]:
-            if gene_set["category"] == category:
-                return "geneSets"
-        for genomic_score in configuration["genomicScores"]:
-            if genomic_score["category"] == category:
-                return "genomicScores"
-        for dataset in configuration["datasets"]:
-            if dataset["id"] == category:
-                return "datasets"
-
-    def get(self, request):
-        configuration = self.gpf_instance.get_agp_configuration()
+    def get(self, _request: Request) -> Response:
+        configuration = self.gpf_instance.get_wdae_agp_configuration()
         if configuration is None:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        # Camelize snake_cased keys, excluding "datasets"
-        # since its keys are dataset IDs
-        response = to_response_json(configuration)
-        if len(configuration) == 0:
-            return Response(response)
-
-        if "datasets" in configuration:
-            response["datasets"] = []
-
-            for dataset_id, dataset in configuration["datasets"].items():
-                study_wrapper = self.gpf_instance.get_wdae_wrapper(dataset_id)
-                if study_wrapper is None:
-                    logger.error(
-                        "could not create a study wrapper for %s",
-                        dataset_id)
-                    continue
-
-                if "person_sets" in dataset:
-                    # Attach person set counts
-                    person_sets_config = []
-                    for person_set in dataset["person_sets"]:
-                        set_id = person_set["set_name"]
-                        collection_id = person_set["collection_name"]
-                        description = ""
-                        if "description" in person_set:
-                            description = person_set["description"]
-                        person_set_collection = \
-                            study_wrapper.genotype_data.person_set_collections[
-                                collection_id
-                            ]
-                        stats = person_set_collection.get_stats()[set_id]
-                        set_name = \
-                            person_set_collection.person_sets[set_id].name
-                        person_sets_config.append({
-                            "id": set_id,
-                            "displayName": set_name,
-                            "collectionId": collection_id,
-                            "description": description,
-                            "parentsCount": stats["parents"],
-                            "childrenCount": stats["children"],
-                            "statistics":
-                                to_response_json(dataset)["statistics"],
-                        })
-
-                display_name = dataset.get("display_name")
-                if display_name is None:
-                    display_name = study_wrapper.config.get("name")
-                if display_name is None:
-                    display_name = dataset_id
-
-                response["datasets"].append({
-                    "id": dataset_id,
-                    "displayName": display_name,
-                    "defaultVisible": True,
-                    **to_response_json(dataset),
-                    "personSets": person_sets_config,  # overwrite person_sets
-                })
-
-        assert "order" in response
-
-        order = response["order"]
-        response["order"] = [
-            {"section": self.find_category_section(response, o), "id": o}
-            for o in order
-        ]
-
-        return Response(response)
+        return Response(configuration)
 
 
 class ProfileView(QueryBaseView):
-    def get(self, request, gene_symbol):
+    def get(self, _request: Request, gene_symbol: str) -> Response:
         agp = self.gpf_instance.get_agp_statistic(gene_symbol)
         if not agp:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/wdae/wdae/conftest.py
+++ b/wdae/wdae/conftest.py
@@ -232,7 +232,8 @@ def wdae_gpf_instance(
         "datasets_api.permissions.get_wgpf_instance",
         return_value=fixtures_wgpf_instance,
     )
-    wdae_gpf_instance._autism_gene_profile_config = None
+    fixtures_wgpf_instance._autism_gene_profile_config = None
+    fixtures_wgpf_instance.prepare_agp_configuration()
 
     return fixtures_wgpf_instance
 
@@ -296,8 +297,12 @@ def agp_wgpf_instance(  # pylint: disable=too-many-arguments
             clear=True
         )
     wdae_gpf_instance._autism_gene_profile_db.insert_agp(sample_agp)
+    wdae_gpf_instance.prepare_agp_configuration()
 
     yield wdae_gpf_instance
+
+    wdae_gpf_instance._agp_configuration = {}
+    wdae_gpf_instance._agp_table_configuration = {}
 
     wdae_gpf_instance.__autism_gene_profile_config = None
     wdae_gpf_instance.__autism_gene_profile_db = None

--- a/wdae/wdae/gpf_instance/apps.py
+++ b/wdae/wdae/gpf_instance/apps.py
@@ -27,6 +27,8 @@ class WDAEConfig(AppConfig):
 
         gpf_instance = get_wgpf_instance(config_filename)
 
+        gpf_instance.prepare_agp_configuration()
+
         if not settings.STUDIES_EAGER_LOADING:
             logger.info("skip preloading gpf instance...")
             return

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -379,6 +379,8 @@ class WGPFInstance(GPFInstance):
         """Prepare AGP configuration for response ahead of time."""
         configuration = self.get_agp_configuration()
         if configuration is None:
+            self._agp_configuration = {}
+            self._agp_table_configuration = {}
             return
 
         # Camelize snake_cased keys, excluding "datasets"

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -23,6 +23,7 @@ from remote.genomic_scores_db import RemoteGenomicScoresDb
 
 from dae.studies.study import GenotypeData
 from dae.utils.fs_utils import find_directory_with_a_file
+from dae.utils.helpers import to_response_json
 from dae.gpf_instance.gpf_instance import GPFInstance
 from dae.enrichment_tool.tool import EnrichmentTool
 from dae.enrichment_tool.event_counters import CounterBase
@@ -51,6 +52,8 @@ class WGPFInstance(GPFInstance):
         self._study_wrappers: Dict[
             str, Union[StudyWrapper, RemoteStudyWrapper]
         ] = {}
+        self._agp_configuration: Optional[dict[str, Any]] = None
+        self._agp_table_configuration: Optional[dict[str, Any]] = None
         super().__init__(cast(Box, dae_config), dae_dir, **kwargs)
 
     @staticmethod
@@ -351,6 +354,223 @@ class WGPFInstance(GPFInstance):
             in self.dae_config.gpfjs.visible_datasets
             if dataset_id in all_datasets
         ]
+
+    def _agp_find_category_section(
+        self, configuration: dict[str, Any], category: str
+    ) -> Optional[str]:
+        for gene_set in configuration["geneSets"]:
+            if gene_set["category"] == category:
+                return "geneSets"
+        for genomic_score in configuration["genomicScores"]:
+            if genomic_score["category"] == category:
+                return "genomicScores"
+        for dataset in configuration["datasets"]:
+            if dataset["id"] == category:
+                return "datasets"
+        return None
+
+    def get_wdae_agp_configuration(self) -> Optional[dict[str, Any]]:
+        return self._agp_configuration
+
+    def get_wdae_agp_table_configuration(self) -> Optional[dict[str, Any]]:
+        return self._agp_table_configuration
+
+    def prepare_agp_configuration(self) -> None:
+        """Prepare AGP configuration for response ahead of time."""
+        configuration = self.get_agp_configuration()
+        if configuration is None:
+            return
+
+        # Camelize snake_cased keys, excluding "datasets"
+        # since its keys are dataset IDs
+        json_config = to_response_json(configuration)
+        if len(configuration) == 0:
+            self._agp_configuration = json_config
+
+        if "datasets" in configuration:
+            json_config["datasets"] = []
+
+            for dataset_id, dataset in configuration["datasets"].items():
+                study_wrapper = self.get_wdae_wrapper(dataset_id)
+                if study_wrapper is None:
+                    logger.error(
+                        "could not create a study wrapper for %s",
+                        dataset_id)
+                    continue
+
+                if "person_sets" in dataset:
+                    # Attach person set counts
+                    person_sets_config = []
+                    for person_set in dataset["person_sets"]:
+                        set_id = person_set["set_name"]
+                        collection_id = person_set["collection_name"]
+                        description = ""
+                        if "description" in person_set:
+                            description = person_set["description"]
+                        person_set_collection = \
+                            study_wrapper.genotype_data.person_set_collections[
+                                collection_id
+                            ]
+                        stats = person_set_collection.get_stats()[set_id]
+                        set_name = \
+                            person_set_collection.person_sets[set_id].name
+                        person_sets_config.append({
+                            "id": set_id,
+                            "displayName": set_name,
+                            "collectionId": collection_id,
+                            "description": description,
+                            "parentsCount": stats["parents"],
+                            "childrenCount": stats["children"],
+                            "statistics":
+                                to_response_json(dataset)["statistics"],
+                        })
+
+                display_name = dataset.get("display_name")
+                if display_name is None:
+                    display_name = study_wrapper.config.get("name")
+                if display_name is None:
+                    display_name = dataset_id
+
+                json_config["datasets"].append({
+                    "id": dataset_id,
+                    "displayName": display_name,
+                    "defaultVisible": True,
+                    **to_response_json(dataset),
+                    "personSets": person_sets_config,  # overwrite person_sets
+                })
+
+        assert "order" in json_config
+
+        order = json_config["order"]
+        json_config["order"] = [
+            {
+                "section": self._agp_find_category_section(json_config, o),
+                "id": o
+            }
+            for o in order
+        ]
+
+        self._agp_configuration = json_config
+
+        if len(configuration) == 0:
+            self._agp_table_configuration = dict()
+
+        table_config = {
+            "defaultDataset": configuration.get("default_dataset"),
+            "columns": [],
+            "pageSize": self._autism_gene_profile_db.PAGE_SIZE,
+        }
+
+        table_config["columns"].append(
+            column("geneSymbol", "Gene", clickable="createTab")
+        )
+
+        for category in configuration["gene_sets"]:
+            table_config["columns"].append(column(
+                f"{category['category']}_rank",
+                category["display_name"],
+                visible=category.get("default_visible", True),
+                meta=category.get("meta"),
+                sortable=True,
+                columns=[column(
+                    f"{category['category']}_rank.{gene_set['set_id']}",
+                    gene_set["set_id"],
+                    visible=gene_set.get("default_visible", True),
+                    meta=gene_set.get("meta"),
+                    display_vertical=True,
+                    sortable=True) for gene_set in category["sets"]
+                ]
+            ))
+
+        for category in configuration["genomic_scores"]:
+            table_config["columns"].append(column(
+                category["category"],
+                category["display_name"],
+                visible=category.get("default_visible", True),
+                meta=category.get("meta"),
+                columns=[column(
+                    f"{category['category']}.{genomic_score['score_name']}",
+                    genomic_score["score_name"],
+                    visible=genomic_score.get("default_visible", True),
+                    meta=genomic_score.get("meta"),
+                    display_vertical=True,
+                    sortable=True) for genomic_score in category["scores"]
+                ]
+            ))
+
+        if "datasets" in configuration:
+            for dataset_id, dataset in configuration["datasets"].items():
+                study_wrapper = self.get_wdae_wrapper(dataset_id)
+                if study_wrapper is None:
+                    LOGGER.error("missing dataset %s", dataset_id)
+                    continue
+                display_name = dataset.get("display_name") \
+                    or study_wrapper.config.get("name") \
+                    or dataset_id
+                dataset_col = column(
+                    f"{dataset_id}", display_name,
+                    visible=dataset.get("default_visible", True),
+                    meta=dataset.get("meta"),
+                )
+                for person_set in dataset.get("person_sets", []):
+                    set_id = person_set["set_name"]
+                    collection_id = person_set["collection_name"]
+                    person_set_collection = \
+                        study_wrapper.genotype_data.person_set_collections[
+                            collection_id
+                        ]
+                    set_name = \
+                        person_set_collection.person_sets[set_id].name
+                    stats = person_set_collection.get_stats()[set_id]
+                    dataset_col["columns"].append(column(
+                        f"{dataset_id}.{set_id}",
+                        f"{set_name} ({stats['children']})",
+                        visible=person_set.get("default_visible", True),
+                        meta=person_set.get("meta"),
+                        columns=[column(
+                            f"{dataset_id}.{set_id}.{statistic['id']}",
+                            statistic["display_name"],
+                            visible=statistic.get("default_visible", True),
+                            meta=statistic.get("meta"),
+                            clickable="goToQuery",
+                            sortable=True)
+
+                            for statistic in dataset["statistics"]
+                        ]
+                    ))
+                table_config["columns"].append(dataset_col)
+
+        if configuration.get("order"):
+            category_order = ["geneSymbol", *configuration["order"]]
+            table_config["columns"].sort(
+                key=lambda col: category_order.index(col["id"])
+            )
+
+        self._agp_table_configuration = table_config
+
+
+def column(
+    col_id: str,
+    display_name: str,
+    visible: bool = True,
+    clickable: Optional[bool] = None,
+    display_vertical: bool = False,
+    sortable: bool = False,
+    columns: Optional[list[dict[str, Any]]] = None,
+    meta: Optional[str] = None
+):
+    if columns is None:
+        columns = list()
+    return {
+        "id": col_id,
+        "displayName": display_name,
+        "visible": visible,
+        "displayVertical": display_vertical,
+        "sortable": sortable,
+        "clickable": clickable,
+        "columns": columns,
+        "meta": meta
+    }
 
 
 def get_wgpf_instance_path(

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -384,169 +384,170 @@ class WGPFInstance(GPFInstance):
         # Camelize snake_cased keys, excluding "datasets"
         # since its keys are dataset IDs
         json_config = to_response_json(configuration)
-        if len(configuration) == 0:
+        self._agp_configuration = json_config
+        if len(configuration) > 0:
+            if "datasets" in configuration:
+                json_config["datasets"] = []
+
+                for dataset_id, dataset in configuration["datasets"].items():
+                    study_wrapper = self.get_wdae_wrapper(dataset_id)
+                    if study_wrapper is None:
+                        logger.error(
+                            "could not create a study wrapper for %s",
+                            dataset_id)
+                        continue
+
+                    if "person_sets" in dataset:
+                        # Attach person set counts
+                        person_sets_config = []
+                        collections = study_wrapper.genotype_data
+
+                        for person_set in dataset["person_sets"]:
+                            set_id = person_set["set_name"]
+                            collection_id = person_set["collection_name"]
+                            description = ""
+                            if "description" in person_set:
+                                description = person_set["description"]
+                            person_set_collection = \
+                                collections.person_set_collections[
+                                    collection_id
+                                ]
+                            stats = person_set_collection.get_stats()[set_id]
+                            set_name = \
+                                person_set_collection.person_sets[set_id].name
+                            person_sets_config.append({
+                                "id": set_id,
+                                "displayName": set_name,
+                                "collectionId": collection_id,
+                                "description": description,
+                                "parentsCount": stats["parents"],
+                                "childrenCount": stats["children"],
+                                "statistics":
+                                    to_response_json(dataset)["statistics"],
+                            })
+
+                    display_name = dataset.get("display_name")
+                    if display_name is None:
+                        display_name = study_wrapper.config.get("name")
+                    if display_name is None:
+                        display_name = dataset_id
+
+                    json_config["datasets"].append({
+                        "id": dataset_id,
+                        "displayName": display_name,
+                        "defaultVisible": True,
+                        **to_response_json(dataset),
+                        "personSets": person_sets_config,  # overwrite ps
+                    })
+
+            assert "order" in json_config
+
+            order = json_config["order"]
+            json_config["order"] = [
+                {
+                    "section": self._agp_find_category_section(json_config, o),
+                    "id": o
+                }
+                for o in order
+            ]
+
             self._agp_configuration = json_config
 
-        if "datasets" in configuration:
-            json_config["datasets"] = []
+        self._agp_table_configuration = dict()
+        if len(configuration) > 0:
+            table_config = {
+                "defaultDataset": configuration.get("default_dataset"),
+                "columns": [],
+                "pageSize": self._autism_gene_profile_db.PAGE_SIZE,
+            }
 
-            for dataset_id, dataset in configuration["datasets"].items():
-                study_wrapper = self.get_wdae_wrapper(dataset_id)
-                if study_wrapper is None:
-                    logger.error(
-                        "could not create a study wrapper for %s",
-                        dataset_id)
-                    continue
+            table_config["columns"].append(
+                column("geneSymbol", "Gene", clickable="createTab")
+            )
 
-                if "person_sets" in dataset:
-                    # Attach person set counts
-                    person_sets_config = []
-                    for person_set in dataset["person_sets"]:
+            for category in configuration["gene_sets"]:
+                table_config["columns"].append(column(
+                    f"{category['category']}_rank",
+                    category["display_name"],
+                    visible=category.get("default_visible", True),
+                    meta=category.get("meta"),
+                    sortable=True,
+                    columns=[column(
+                        f"{category['category']}_rank.{gene_set['set_id']}",
+                        gene_set["set_id"],
+                        visible=gene_set.get("default_visible", True),
+                        meta=gene_set.get("meta"),
+                        display_vertical=True,
+                        sortable=True) for gene_set in category["sets"]
+                    ]
+                ))
+
+            for category in configuration["genomic_scores"]:
+                table_config["columns"].append(column(
+                    category["category"],
+                    category["display_name"],
+                    visible=category.get("default_visible", True),
+                    meta=category.get("meta"),
+                    columns=[column(
+                        f"{category['category']}."
+                        f"{genomic_score['score_name']}",
+                        genomic_score["score_name"],
+                        visible=genomic_score.get("default_visible", True),
+                        meta=genomic_score.get("meta"),
+                        display_vertical=True,
+                        sortable=True) for genomic_score in category["scores"]
+                    ]
+                ))
+
+            if "datasets" in configuration:
+                for dataset_id, dataset in configuration["datasets"].items():
+                    study_wrapper = self.get_wdae_wrapper(dataset_id)
+                    if study_wrapper is None:
+                        LOGGER.error("missing dataset %s", dataset_id)
+                        continue
+                    display_name = dataset.get("display_name") \
+                        or study_wrapper.config.get("name") \
+                        or dataset_id
+                    dataset_col = column(
+                        f"{dataset_id}", display_name,
+                        visible=dataset.get("default_visible", True),
+                        meta=dataset.get("meta"),
+                    )
+                    for person_set in dataset.get("person_sets", []):
                         set_id = person_set["set_name"]
                         collection_id = person_set["collection_name"]
-                        description = ""
-                        if "description" in person_set:
-                            description = person_set["description"]
                         person_set_collection = \
                             study_wrapper.genotype_data.person_set_collections[
                                 collection_id
                             ]
-                        stats = person_set_collection.get_stats()[set_id]
                         set_name = \
                             person_set_collection.person_sets[set_id].name
-                        person_sets_config.append({
-                            "id": set_id,
-                            "displayName": set_name,
-                            "collectionId": collection_id,
-                            "description": description,
-                            "parentsCount": stats["parents"],
-                            "childrenCount": stats["children"],
-                            "statistics":
-                                to_response_json(dataset)["statistics"],
-                        })
+                        stats = person_set_collection.get_stats()[set_id]
+                        dataset_col["columns"].append(column(
+                            f"{dataset_id}.{set_id}",
+                            f"{set_name} ({stats['children']})",
+                            visible=person_set.get("default_visible", True),
+                            meta=person_set.get("meta"),
+                            columns=[column(
+                                f"{dataset_id}.{set_id}.{statistic['id']}",
+                                statistic["display_name"],
+                                visible=statistic.get("default_visible", True),
+                                meta=statistic.get("meta"),
+                                clickable="goToQuery",
+                                sortable=True)
 
-                display_name = dataset.get("display_name")
-                if display_name is None:
-                    display_name = study_wrapper.config.get("name")
-                if display_name is None:
-                    display_name = dataset_id
+                                for statistic in dataset["statistics"]
+                            ]
+                        ))
+                    table_config["columns"].append(dataset_col)
 
-                json_config["datasets"].append({
-                    "id": dataset_id,
-                    "displayName": display_name,
-                    "defaultVisible": True,
-                    **to_response_json(dataset),
-                    "personSets": person_sets_config,  # overwrite person_sets
-                })
-
-        assert "order" in json_config
-
-        order = json_config["order"]
-        json_config["order"] = [
-            {
-                "section": self._agp_find_category_section(json_config, o),
-                "id": o
-            }
-            for o in order
-        ]
-
-        self._agp_configuration = json_config
-
-        if len(configuration) == 0:
-            self._agp_table_configuration = dict()
-
-        table_config = {
-            "defaultDataset": configuration.get("default_dataset"),
-            "columns": [],
-            "pageSize": self._autism_gene_profile_db.PAGE_SIZE,
-        }
-
-        table_config["columns"].append(
-            column("geneSymbol", "Gene", clickable="createTab")
-        )
-
-        for category in configuration["gene_sets"]:
-            table_config["columns"].append(column(
-                f"{category['category']}_rank",
-                category["display_name"],
-                visible=category.get("default_visible", True),
-                meta=category.get("meta"),
-                sortable=True,
-                columns=[column(
-                    f"{category['category']}_rank.{gene_set['set_id']}",
-                    gene_set["set_id"],
-                    visible=gene_set.get("default_visible", True),
-                    meta=gene_set.get("meta"),
-                    display_vertical=True,
-                    sortable=True) for gene_set in category["sets"]
-                ]
-            ))
-
-        for category in configuration["genomic_scores"]:
-            table_config["columns"].append(column(
-                category["category"],
-                category["display_name"],
-                visible=category.get("default_visible", True),
-                meta=category.get("meta"),
-                columns=[column(
-                    f"{category['category']}.{genomic_score['score_name']}",
-                    genomic_score["score_name"],
-                    visible=genomic_score.get("default_visible", True),
-                    meta=genomic_score.get("meta"),
-                    display_vertical=True,
-                    sortable=True) for genomic_score in category["scores"]
-                ]
-            ))
-
-        if "datasets" in configuration:
-            for dataset_id, dataset in configuration["datasets"].items():
-                study_wrapper = self.get_wdae_wrapper(dataset_id)
-                if study_wrapper is None:
-                    LOGGER.error("missing dataset %s", dataset_id)
-                    continue
-                display_name = dataset.get("display_name") \
-                    or study_wrapper.config.get("name") \
-                    or dataset_id
-                dataset_col = column(
-                    f"{dataset_id}", display_name,
-                    visible=dataset.get("default_visible", True),
-                    meta=dataset.get("meta"),
+            if configuration.get("order"):
+                category_order = ["geneSymbol", *configuration["order"]]
+                table_config["columns"].sort(
+                    key=lambda col: category_order.index(col["id"])
                 )
-                for person_set in dataset.get("person_sets", []):
-                    set_id = person_set["set_name"]
-                    collection_id = person_set["collection_name"]
-                    person_set_collection = \
-                        study_wrapper.genotype_data.person_set_collections[
-                            collection_id
-                        ]
-                    set_name = \
-                        person_set_collection.person_sets[set_id].name
-                    stats = person_set_collection.get_stats()[set_id]
-                    dataset_col["columns"].append(column(
-                        f"{dataset_id}.{set_id}",
-                        f"{set_name} ({stats['children']})",
-                        visible=person_set.get("default_visible", True),
-                        meta=person_set.get("meta"),
-                        columns=[column(
-                            f"{dataset_id}.{set_id}.{statistic['id']}",
-                            statistic["display_name"],
-                            visible=statistic.get("default_visible", True),
-                            meta=statistic.get("meta"),
-                            clickable="goToQuery",
-                            sortable=True)
 
-                            for statistic in dataset["statistics"]
-                        ]
-                    ))
-                table_config["columns"].append(dataset_col)
-
-        if configuration.get("order"):
-            category_order = ["geneSymbol", *configuration["order"]]
-            table_config["columns"].sort(
-                key=lambda col: category_order.index(col["id"])
-            )
-
-        self._agp_table_configuration = table_config
+            self._agp_table_configuration = table_config
 
 
 def column(


### PR DESCRIPTION
## Background
AGP configuration views were very slow, despite providing data which is static and does not change at runtime

## Aim
We decided to begin caching this data in the GPF instance.

## Related issues
Closes #554.