### PR TITLE
Optimize memory usage of pheno browser download

### DIFF
--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -277,7 +277,7 @@ class PhenotypeData(ABC):
     def get_measures(
             self,
             instrument_name: Optional[str] = None,
-            measure_type: Optional[str] = None) -> Dict[str, Measure]:
+            measure_type: Optional[MeasureType] = None) -> Dict[str, Measure]:
         """
         Return a dictionary of measures objects.
 
@@ -301,7 +301,7 @@ class PhenotypeData(ABC):
         if measure_type is not None:
             measure_type = MeasureType.from_str(measure_type)
 
-        for instrument_name, instrument in instruments.items():
+        for _, instrument in instruments.items():
             for measure in instrument.measures.values():
                 if measure_type is not None and \
                         measure.measure_type != measure_type:
@@ -490,7 +490,7 @@ class PhenotypeData(ABC):
             value_df.set_index("person_id"),
             on="person_id",
             how="right",
-            rsuffix="_val")  # type: ignore
+            rsuffix="_val")
         df = df.set_index("person_id")
         df = df.reset_index()
 
@@ -854,7 +854,7 @@ class PhenotypeStudy(PhenotypeData):
         """
         assert isinstance(measure_ids, list)
         assert len(measure_ids) >= 1
-        assert all([self.has_measure(m) for m in measure_ids])
+        assert all(self.has_measure(m) for m in measure_ids)
 
         dfs = [
             self.get_measure_values_df(
@@ -1201,7 +1201,7 @@ class PhenotypeGroup(PhenotypeData):
             roles: Optional[Iterable[Role]] = None,
             default_filter: str = "apply") -> pd.DataFrame:
 
-        assert all([self.has_measure(mid) for mid in measure_ids]), measure_ids
+        assert all(self.has_measure(mid) for mid in measure_ids), measure_ids
 
         dfs = []
         for pheno in self.phenotype_data:
@@ -1266,7 +1266,7 @@ class PhenotypeGroup(PhenotypeData):
         person_ids: Optional[list[str]] = None,
         family_ids: Optional[list[str]] = None,
         roles: Optional[list[str]] = None,
-    ) -> Generator[str, None, None]:
+    ) -> Generator[dict[str, Any], None, None]:
         raise NotImplementedError()
 
 

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from itertools import chain
 
 import pandas as pd
-from sqlalchemy.sql import select, text
+from sqlalchemy.sql import select, text, Select
 from sqlalchemy import not_, desc, Column
 
 from dae.pedigrees.family import Person
@@ -881,7 +881,7 @@ class PhenotypeStudy(PhenotypeData):
         person_ids: Optional[list[str]] = None,
         family_ids: Optional[list[str]] = None,
         roles: Optional[list[str]] = None,
-    ):
+    ) -> Select:
         select_columns = [
             self.db.person.c.person_id
         ]
@@ -956,8 +956,8 @@ class PhenotypeStudy(PhenotypeData):
                 self.db.measure.c.id, self.db.measure.c.measure_id
             ).where(self.db.measure.c.measure_id.in_(measure_ids))
             results = connection.execute(query)
-            for row in results:
-                measure_id_map[row.measure_id] = row.id
+            for result_row in results:
+                measure_id_map[result_row.measure_id] = result_row.id
 
         measure_groups = self._split_measures_into_groups(measure_ids)
 
@@ -975,8 +975,8 @@ class PhenotypeStudy(PhenotypeData):
             query_results = []
             for query in queries:
                 query_results.append(connection.execute(query))
-            for row in query_results[0]:
-                row = row._mapping  # pylint: disable=protected-access
+            for result_row in query_results[0]:
+                row = result_row._mapping  # pylint: disable=protected-access
                 output = {**row}
                 skip = True
                 for measure_id in measure_groups[0]:

--- a/dae/dae/pheno/tests/test_pheno_db.py
+++ b/dae/dae/pheno/tests/test_pheno_db.py
@@ -105,7 +105,7 @@ def test_get_people_measure_values_correct_values(fake_phenotype_data):
 
 
 def test_split_into_groups(fake_phenotype_data):
-    measures = [f"measure_{i}" for i in range (1, 101)]
+    measures = [f"measure_{i}" for i in range(1, 101)]
     groups = fake_phenotype_data._split_measures_into_groups(measures)
     assert len(groups) == 2
     assert len(groups[0]) == 60

--- a/dae/dae/pheno/tests/test_pheno_db.py
+++ b/dae/dae/pheno/tests/test_pheno_db.py
@@ -31,6 +31,13 @@ def str_check(str_, expected_count, expected_cols):
     assert len(values_lines) == expected_count
 
 
+def dict_list_check(dict_list, expected_count, expected_cols):
+    assert isinstance(dict_list, list)
+    for dict_ in dict_list:
+        assert set(dict_.keys()) == set(expected_cols)
+    assert len(dict_list) == expected_count
+
+
 def dict_check_measure(dict_, expected_count, *args):
     assert isinstance(dict_, dict)
     for _id, measure in dict_.items():
@@ -66,31 +73,96 @@ def test_get_values(fake_phenotype_data, query_cols, get, check):
 
 
 @pytest.mark.parametrize("query_cols", [(["i1.m1"]), (["i1.m1", "i1.m2"])])
-def test_get_values_streaming_csv(fake_phenotype_data, query_cols):
-    result_it = fake_phenotype_data.get_values_streaming_csv(query_cols)
-    result = "".join(list(result_it))
-    str_check(result, 195, query_cols)
+def test_get_people_measure_values(fake_phenotype_data, query_cols):
+    result_it = fake_phenotype_data.get_people_measure_values(query_cols)
+    result = list(result_it)
+    dict_list_check(result, 195, ["person_id"] + query_cols)
 
-    result_it = fake_phenotype_data.get_values_streaming_csv(
+    result_it = fake_phenotype_data.get_people_measure_values(
         query_cols, ["f20.p1"])
-    result = "".join(list(result_it))
-    str_check(result, 1, query_cols)
+    result = list(result_it)
+    dict_list_check(result, 1, ["person_id"] + query_cols)
 
-    result_it = fake_phenotype_data.get_values_streaming_csv(
+    result_it = fake_phenotype_data.get_people_measure_values(
         query_cols, ["f20.p1", "f21.p1"])
-    result = "".join(list(result_it))
-    str_check(result, 2, query_cols)
+    result = list(result_it)
+    dict_list_check(result, 2, ["person_id"] + query_cols)
 
-    result_it = fake_phenotype_data.get_values_streaming_csv(
+    result_it = fake_phenotype_data.get_people_measure_values(
         query_cols, roles=["prb"])
-    result = "".join(list(result_it))
-    str_check(result, 39, query_cols)
+    result = list(result_it)
+    dict_list_check(result, 39, ["person_id"] + query_cols)
 
 
-def test_get_values_streaming_csv_correct_values(fake_phenotype_data):
-    result_list = list(fake_phenotype_data.get_values_streaming_csv(
+def test_get_people_measure_values_correct_values(fake_phenotype_data):
+    result_list = list(fake_phenotype_data.get_people_measure_values(
         ["i1.m1", "i1.m2"], roles=["prb"]))
-    assert result_list[-1] == "f1.p1,34.76285793898369,48.44644402952317\r\n"
+    assert result_list[-1] == {
+        "person_id": "f1.p1",
+        "i1.m1": 34.76285793898369,
+        "i1.m2": 48.44644402952317
+    }
+
+
+def test_split_into_groups(fake_phenotype_data):
+    measures = [f"measure_{i}" for i in range (1, 101)]
+    groups = fake_phenotype_data._split_measures_into_groups(measures)
+    assert len(groups) == 2
+    assert len(groups[0]) == 60
+    assert groups[0][0] == "measure_1"
+    assert groups[0][-1] == "measure_60"
+    assert len(groups[1]) == 40
+    assert groups[1][0] == "measure_61"
+    assert groups[1][-1] == "measure_100"
+
+    groups = fake_phenotype_data._split_measures_into_groups(
+        measures, group_size=25
+    )
+    assert len(groups) == 4
+    assert len(groups[0]) == 25
+    assert groups[0][0] == "measure_1"
+    assert groups[0][-1] == "measure_25"
+    assert len(groups[1]) == 25
+    assert groups[1][0] == "measure_26"
+    assert groups[1][-1] == "measure_50"
+    assert len(groups[2]) == 25
+    assert groups[2][0] == "measure_51"
+    assert groups[2][-1] == "measure_75"
+    assert len(groups[3]) == 25
+    assert groups[3][0] == "measure_76"
+    assert groups[3][-1] == "measure_100"
+
+
+def test_subquery_generation(fake_phenotype_data):
+    fake_measures_ids = {
+        "i1.m1": "1",
+        "i1.m2": "2"
+    }
+    query = str(fake_phenotype_data._build_measures_subquery(
+        fake_measures_ids,
+        fake_measures_ids.keys(),
+        person_ids=["person1", "person2"],
+        family_ids=["family1"],
+        roles=["unaffected"]
+    ))
+
+    print(query)
+    expected = (
+        "SELECT person.person_id, \"i1.m1_value\".value AS 'i1.m1', "
+        "\"i1.m2_value\".value AS 'i1.m2' \n"
+        "FROM person JOIN family ON family.id = person.family_id "
+        'LEFT OUTER JOIN value_continuous as "i1.m1_value" '
+        'ON "i1.m1_value".person_id = person.id '
+        'AND "i1.m1_value".measure_id = 1 '
+        'LEFT OUTER JOIN value_continuous as "i1.m2_value" '
+        'ON "i1.m2_value".person_id = person.id '
+        'AND "i1.m2_value".measure_id = 2 \n'
+        "WHERE person.role IN (__[POSTCOMPILE_role_1]) "
+        "AND person.person_id IN (__[POSTCOMPILE_person_id_1]) "
+        "AND family.family_id IN (__[POSTCOMPILE_family_id_1]) "
+        "ORDER BY person.person_id DESC"
+    )
+    assert query == expected
 
 
 @pytest.mark.parametrize(

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -32,7 +32,6 @@ dependencies:
   - django-stubs=4.2
   - types-pyyaml=6.0.12.2
   - types-setuptools=67
-  - sqlalchemy-stubs=0.4
   - types-toml=0.10.3
   - types-python-dateutil=2.8.9
   - types-requests=2.27.30

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -180,7 +180,12 @@ class PhenoMeasuresDownload(QueryDatasetView):
             if not set(measure_ids).issubset(set(instrument_measures)):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        values_iterator = self.csv_value_iterator(dataset, measure_ids)
+        if dataset.is_remote:
+            values_iterator = dataset.phenotype_data.get_people_measure_values(
+                measure_ids
+            )
+        else:
+            values_iterator = self.csv_value_iterator(dataset, measure_ids)
 
         response = StreamingHttpResponse(
             values_iterator, content_type="text/csv")

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -1,5 +1,8 @@
 import logging
 
+import csv
+from io import StringIO
+
 from rest_framework.response import Response
 from rest_framework import status
 from django.http.response import StreamingHttpResponse
@@ -126,6 +129,30 @@ class PhenoMeasuresView(PhenoBrowserBaseView):
 
 
 class PhenoMeasuresDownload(QueryDatasetView):
+
+    def csv_value_iterator(self, dataset, measure_ids):
+        header = ["person_id"] + measure_ids
+        buffer = StringIO()
+        writer = csv.writer(buffer, delimiter=",")
+        writer.writerow(header)
+        yield buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate(0)
+
+        values_iterator = dataset.phenotype_data.get_people_measure_values(
+            measure_ids)
+
+        for values_dict in values_iterator:
+            output = []
+            for col in header:
+                output.append(values_dict[col])
+            writer.writerow(output)
+            yield buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+        buffer.close()
+
     def post(self, request):
         data = request.data
         if "dataset_id" not in data:
@@ -153,8 +180,8 @@ class PhenoMeasuresDownload(QueryDatasetView):
             if not set(measure_ids).issubset(set(instrument_measures)):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        values_iterator = dataset.phenotype_data.get_values_streaming_csv(
-            measure_ids)
+        values_iterator = self.csv_value_iterator(dataset, measure_ids)
+
         response = StreamingHttpResponse(
             values_iterator, content_type="text/csv")
 

--- a/wdae/wdae/remote/remote_phenotype_data.py
+++ b/wdae/wdae/remote/remote_phenotype_data.py
@@ -201,7 +201,7 @@ class RemotePhenotypeData(PhenotypeData):
 
         return instrument_values
 
-    def get_values_streaming_csv(
+    def get_people_measure_values(
         self,
         measure_ids,
         person_ids=None,


### PR DESCRIPTION
## Background
When downloading pheno measures, the entire CSV file would be stored in memory and in some cases this meant running out of memory.

## Aim
Reduce memory usage of pheno browser downloads by changing the SQL request.

## Implementation
Every single row was stored in memory, because we were building them all together, since each type of measure value has its' own table and iterating through the tables meant we were iterating through the rows 4 times, instead of once.
The  request was remade to iterate through all people only once, joining with each measure's appropriate value table once, so that it matches the output CSV format 1:1, therefore eliminating the need for storing every row in memory. This managed to hit an SQLite hard limit of 64 tables max in a join, so the solution was to split the SQL query into multiple groups of 60 by measures.

## Related issues
Closes #561 