### PR TITLE
Pheno browser instant download

### DIFF
--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -1,7 +1,8 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
-import pytest
 from typing import cast
+
+import pytest
 
 from django.test import Client
 from rest_framework import status

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -1,8 +1,11 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
 import pytest
+from typing import cast
 
+from django.test import Client
 from rest_framework import status
+from rest_framework.response import Response
 
 pytestmark = pytest.mark.usefixtures(
     "wdae_gpf_instance", "dae_calc_gene_sets")
@@ -134,6 +137,24 @@ def test_download(admin_client):
     response = admin_client.post(
         DOWNLOAD_URL, json.dumps(data), "application/json"
     )
+
+    assert response.status_code == 200
+
+    header = list(response.streaming_content)[0].decode("utf-8")
+    header = header.split()[0].split(",")
+    assert header[0] == "person_id"
+
+
+def test_download_form(admin_client: Client) -> None:
+    data = {
+        "queryData": (
+            '{"dataset_id": "quads_f1",'
+            '"instrument": "instrument1"}'
+        )
+    }
+    response = cast(Response, admin_client.post(
+        DOWNLOAD_URL, json.dumps(data), "application/json"
+    ))
 
     assert response.status_code == 200
 

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -200,10 +200,6 @@ class PhenoMeasuresDownload(QueryDatasetView):
         else:
             values_iterator = self.csv_value_iterator(dataset, measure_ids)
 
-        # response = FileResponse(
-            # values_iterator, filename="variants.tsv",
-            # as_attachment=True, content_type="text/tsv"
-        # )
         response = StreamingHttpResponse(
             values_iterator, content_type="text/csv")
 

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -7,12 +7,13 @@ from typing import Generator, Union, cast
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
-from django.http.response import StreamingHttpResponse
+from django.http.response import StreamingHttpResponse, FileResponse
 
 from query_base.query_base import QueryDatasetView
 from studies.study_wrapper import RemoteStudyWrapper, StudyWrapper
 
 from utils.streaming_response_util import iterator_to_json
+from utils.query_params import parse_query_params
 
 
 logger = logging.getLogger(__name__)
@@ -162,6 +163,8 @@ class PhenoMeasuresDownload(QueryDatasetView):
 
     def post(self, request: Request) -> Response:
         data = request.data
+        if "queryData" in data:
+            data = parse_query_params(data)
         if "dataset_id" not in data:
             return Response(status=status.HTTP_400_BAD_REQUEST)
         dataset_id = data["dataset_id"]
@@ -197,6 +200,10 @@ class PhenoMeasuresDownload(QueryDatasetView):
         else:
             values_iterator = self.csv_value_iterator(dataset, measure_ids)
 
+        # response = FileResponse(
+            # values_iterator, filename="variants.tsv",
+            # as_attachment=True, content_type="text/tsv"
+        # )
         response = StreamingHttpResponse(
             values_iterator, content_type="text/csv")
 


### PR DESCRIPTION
## Background
Pheno browser download on the frontend was slow and the download prompt appeared when the request was done.
To fix this, the download was made to use an HTML form.

## Aim
Add support for HTML form requests to the pheno browser API download.

## Implementation
Implemented usage of `parse_query_params` utility in the download view.

