### PR TITLE
Agp config full test

### DIFF
--- a/dae/dae/autism_gene_profile/db.py
+++ b/dae/dae/autism_gene_profile/db.py
@@ -52,20 +52,22 @@ class AutismGeneProfileDB:
         if configuration is None:
             return {}
         order = configuration.get("order")
+        order_keys = []
+        for gene_set in configuration["gene_sets"]:
+            order_keys.append(gene_set["category"] + "_rank")
+        for genomic_score in configuration["genomic_scores"]:
+            order_keys.append(genomic_score["category"])
+        for dataset_id in configuration["datasets"].keys():
+            order_keys.append(dataset_id)
         if order is None:
-            order = []
-            for gene_set in configuration["gene_sets"]:
-                order.append(gene_set["category"] + "_rank")
-            for genomic_score in configuration["genomic_scores"]:
-                order.append(genomic_score["category"])
-            for dataset_id in configuration["datasets"].keys():
-                order.append(dataset_id)
-            configuration["order"] = order
+            configuration["order"] = order_keys
         else:
             total_categories_count = \
                 len(configuration["gene_sets"]) + \
                 len(configuration["genomic_scores"]) + \
                 len(configuration["datasets"])
+            assert all(x in order_keys for x in order), "Given AGP order " \
+                "has invalid entries"
             assert len(order) == total_categories_count, "Given AGP order " \
                 "is missing items"
 

--- a/dae/dae/gene/gene_term.py
+++ b/dae/dae/gene/gene_term.py
@@ -75,7 +75,9 @@ def read_ewa_set_file(set_files):
     r = GeneTerms()
     r.geneNS = "sym"
     for f in set_files:
-        setname = f.readline().strip()
+        setname = ""
+        while setname == "":
+            setname = f.readline().strip()
         line = f.readline()
         r.tDesc[setname] = line.strip()
         for line in f:


### PR DESCRIPTION
## Background
Test agp generation with bad order and default dataset fields.

## Aim
Create a more comprehensive test that uses most of the agp generation pipeline and not mocks.

## Implementation
Use t4c8 instance to test agp generation properly.
Test generated agp genes data.
Test if generated agp with incomplete config throws error.

## Related issues
Fix using invalid order in agp config. Create a test for this.
Fix ewa files starting with empty line because they are not trimmed. All agp tests test this