### PR TITLE
Add AGP page size to config view

### DIFF
--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -475,6 +475,8 @@ class WGPFInstance(GPFInstance):
                 for o in order
             ]
 
+            json_config["pageSize"] = self._autism_gene_profile_db.PAGE_SIZE
+
             self._agp_configuration = json_config
 
         self._agp_table_configuration = {}


### PR DESCRIPTION
## Background
Due to the frontend AGP rework to avoid some of the excess code that is in the backend, there was one parameter which was unobtainable without the table configuration view: the AGP DB page size.

## Aim
Add page size to the regular AGP configuration

## Implementation
Added AGP page size to the prepared AGP config

