### PR TITLE
Remote pheno measure values api

### DIFF
--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -326,6 +326,27 @@ class DbManager:  # pylint: disable=too-many-instance-attributes
                     result_row.db_column_name
         return measure_column_names
 
+    def get_measure_column_names_reverse(
+        self, measure_ids: Optional[list[str]] = None
+    ) -> dict[str, str]:
+        """Return measure column names mapped to their measure IDs."""
+        query = select(
+            self.measures.c.measure_id,
+            self.measures.c.db_column_name,
+        )
+        if measure_ids is not None:
+            print(measure_ids)
+            query = query.where(self.measures.c.measure_id.in_(measure_ids))
+        with self.pheno_engine.connect() as connection:
+            print(query)
+            results = connection.execute(query)
+
+            measure_column_names = {}
+            for result_row in results:
+                measure_column_names[result_row.db_column_name] = \
+                    result_row.measure_id
+        return measure_column_names
+
     def populate_instrument_values_tables(self) -> None:
         """
         Populate the instrument values tables with values.

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -907,7 +907,9 @@ class PhenotypeStudy(PhenotypeData):
 
         assert len(self.db.instrument_values_tables) > 0
 
-        measure_column_names = self.db.get_measure_column_names(measure_ids)
+        measure_column_names = self.db.get_measure_column_names_reverse(
+            measure_ids
+        )
 
         instrument_tables = {}
         instrument_table_columns = {}
@@ -926,7 +928,8 @@ class PhenotypeStudy(PhenotypeData):
             if first_instrument is None:
                 first_instrument = instrument_name
             table_cols = [
-                c for c in table.c if c.name in measure_column_names.values()
+                c.label(measure_column_names[c.name])
+                for c in table.c if c.name in measure_column_names
             ]
 
             instrument_table_columns[instrument_name] = table_cols

--- a/dae/dae/pheno/pheno_db.py
+++ b/dae/dae/pheno/pheno_db.py
@@ -502,7 +502,7 @@ class PhenotypeData(ABC):
 
         return df
 
-    def _get_instrument_measures(self, instrument_name: str) -> list[str]:
+    def get_instrument_measures(self, instrument_name: str) -> list[str]:
         """Return measures for given instrument."""
         assert instrument_name in self.instruments
         instrument = self.instruments[instrument_name]
@@ -526,7 +526,7 @@ class PhenotypeData(ABC):
         (see **get_values_df**)
         """
         if measure_ids is None:
-            measure_ids = self._get_instrument_measures(instrument_name)
+            measure_ids = self.get_instrument_measures(instrument_name)
         res = self.get_values_df(measure_ids, person_ids, family_ids, role)
         return res
 
@@ -545,7 +545,7 @@ class PhenotypeData(ABC):
         (see :func:`get_values`)
         """
         if measure_ids is None:
-            measure_ids = self._get_instrument_measures(instrument_name)
+            measure_ids = self.get_instrument_measures(instrument_name)
         return self.get_values(measure_ids, person_ids, family_ids, role)
 
     @abstractmethod

--- a/dae/dae/pheno/tests/test_pheno_db.py
+++ b/dae/dae/pheno/tests/test_pheno_db.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from dae.pheno.common import MeasureType
 from dae.pheno.pheno_db import Measure, PhenotypeStudy
-from dae.pheno.db import safe_db_name
 
 
 def df_check(
@@ -109,7 +108,7 @@ def test_get_people_measure_values(
     result_it = fake_phenotype_data.get_people_measure_values(query_cols)
     result = list(result_it)
     base_cols = ["person_id", "family_id", "role"]
-    db_query_cols = [safe_db_name(query_col) for query_col in query_cols]
+    db_query_cols = [query_col for query_col in query_cols]
     dict_list_check(result, 195, base_cols + db_query_cols)
 
     result_it = fake_phenotype_data.get_people_measure_values(
@@ -137,8 +136,8 @@ def test_get_people_measure_values_correct_values(
         "person_id": "f1.p1",
         "family_id": "f1",
         "role": "prb",
-        "i1_m1": 34.76285793898369,
-        "i1_m2": 48.44644402952317
+        "i1.m1": 34.76285793898369,
+        "i1.m2": 48.44644402952317
     }
 
 

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -264,12 +264,14 @@ def test_get_specific_measure_values(admin_client):
     assert content[0] == {
         "family_id": "f1",
         "person_id": "sib2",
+        "role": "sib",
         "instrument1.continuous": 4.56,
         "instrument1.categorical": None
     }
     assert content[1] == {
         "family_id": "f1",
         "person_id": "sib1",
+        "role": "sib",
         "instrument1.continuous": 1.23,
         "instrument1.categorical": None
     }
@@ -291,6 +293,7 @@ def test_get_measure_values(admin_client):
     assert content[0] == {
         "family_id": "f1",
         "person_id": "sib2",
+        "role": "sib",
         "instrument1.continuous": 4.56,
         "instrument1.categorical": None,
         "instrument1.ordinal": None,
@@ -299,6 +302,7 @@ def test_get_measure_values(admin_client):
     assert content[2] == {
         "family_id": "f1",
         "person_id": "prb1",
+        "role": "prb",
         "instrument1.continuous": 3.14,
         "instrument1.categorical": "option2",
         "instrument1.ordinal": 5.0,
@@ -307,6 +311,7 @@ def test_get_measure_values(admin_client):
     assert content[4] == {
         "family_id": "f1",
         "person_id": "dad1",
+        "role": "dad",
         "instrument1.continuous": 2.718,
         "instrument1.categorical": None,
         "instrument1.ordinal": None,

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.usefixtures(
 
 URL = "/api/v3/pheno_browser/instruments"
 MEASURES_URL = "/api/v3/pheno_browser/measures"
+MEASURE_VALUES_URL = "/api/v3/pheno_browser/measure_values"
 MEASURES_INFO_URL = "/api/v3/pheno_browser/measures_info"
 MEASURE_DESCRIPTION_URL = "/api/v3/pheno_browser/measure_description"
 DOWNLOAD_URL = "/api/v3/pheno_browser/download"
@@ -245,3 +246,69 @@ def test_measure_details(admin_client):
     assert response.data["measure_name"] == "categorical"
     assert response.data["measure_type"] == "categorical"
     assert response.data["values_domain"] == ["option1", "option2"]
+
+
+def test_get_specific_measure_values(admin_client):
+    data = {
+        "dataset_id": "quads_f1",
+        "instrument": "instrument1",
+        "measure_ids": ["instrument1.continuous", "instrument1.categorical"]
+    }
+    response = admin_client.post(
+        MEASURE_VALUES_URL, json.dumps(data), "application/json"
+    )
+
+    assert response.status_code == 200
+    content = json.loads(b"".join(list(response.streaming_content)))
+
+    assert content[0] == {
+        "family_id": "f1",
+        "person_id": "sib2",
+        "instrument1.continuous": 4.56,
+        "instrument1.categorical": None
+    }
+    assert content[1] == {
+        "family_id": "f1",
+        "person_id": "sib1",
+        "instrument1.continuous": 1.23,
+        "instrument1.categorical": None
+    }
+
+
+def test_get_measure_values(admin_client):
+    data = {
+        "dataset_id": "quads_f1",
+        "instrument": "instrument1",
+    }
+    response = admin_client.post(
+        MEASURE_VALUES_URL, json.dumps(data), "application/json"
+    )
+
+    assert response.status_code == 200
+    content = json.loads(b"".join(list(response.streaming_content)))
+
+    assert len(content) == 5
+    assert content[0] == {
+        "family_id": "f1",
+        "person_id": "sib2",
+        "instrument1.continuous": 4.56,
+        "instrument1.categorical": None,
+        "instrument1.ordinal": None,
+        "instrument1.raw": None
+    }
+    assert content[2] == {
+        "family_id": "f1",
+        "person_id": "prb1",
+        "instrument1.continuous": 3.14,
+        "instrument1.categorical": "option2",
+        "instrument1.ordinal": 5.0,
+        "instrument1.raw": "somevalue"
+    }
+    assert content[4] == {
+        "family_id": "f1",
+        "person_id": "dad1",
+        "instrument1.continuous": 2.718,
+        "instrument1.categorical": None,
+        "instrument1.ordinal": None,
+        "instrument1.raw": "othervalue"
+    }

--- a/wdae/wdae/pheno_browser_api/urls.py
+++ b/wdae/wdae/pheno_browser_api/urls.py
@@ -33,4 +33,9 @@ urlpatterns = [
         views.PhenoMeasuresDownload.as_view(),
         name="pheno_browser_download",
     ),
+    re_path(
+        r"^/measure_values/?$",
+        views.PhenoMeasureValues.as_view(),
+        name="pheno_browser_values",
+    ),
 ]

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -2,7 +2,7 @@ import logging
 
 import csv
 from io import StringIO
-from typing import Generator, Union, cast
+from typing import Generator, Union
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -14,8 +14,6 @@ from studies.study_wrapper import RemoteStudyWrapper, StudyWrapper
 
 from utils.streaming_response_util import iterator_to_json
 from utils.query_params import parse_query_params
-
-from dae.pheno.pheno_db import PhenotypeStudy
 
 
 logger = logging.getLogger(__name__)

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -135,6 +135,7 @@ class PhenoMeasuresView(PhenoBrowserBaseView):
 
 
 class PhenoMeasuresDownload(QueryDatasetView):
+    """Phenotype measure downloads view."""
 
     def csv_value_iterator(
         self,
@@ -189,7 +190,7 @@ class PhenoMeasuresDownload(QueryDatasetView):
                 return Response(status=status.HTTP_404_NOT_FOUND)
 
             instrument_measures = \
-                dataset.phenotype_data._get_instrument_measures(instrument)
+                dataset.phenotype_data.get_instrument_measures(instrument)
             if measure_ids is None:
                 measure_ids = instrument_measures
 
@@ -209,9 +210,10 @@ class PhenoMeasuresDownload(QueryDatasetView):
 
 
 class PhenoMeasureValues(QueryDatasetView):
+    """Phenotype measure values view."""
 
     def post(self, request: Request) -> Response:
-        """Return a CSV file stream for measures."""
+        """Return measure values as stream."""
         data = request.data
         if "dataset_id" not in data:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -231,7 +233,7 @@ class PhenoMeasureValues(QueryDatasetView):
                 return Response(status=status.HTTP_404_NOT_FOUND)
 
             instrument_measures = \
-                dataset.phenotype_data._get_instrument_measures(instrument)
+                dataset.phenotype_data.get_instrument_measures(instrument)
             if measure_ids is None:
                 measure_ids = instrument_measures
 

--- a/wdae/wdae/remote/remote_phenotype_data.py
+++ b/wdae/wdae/remote/remote_phenotype_data.py
@@ -215,7 +215,8 @@ class RemotePhenotypeData(PhenotypeData):
         if roles is not None:
             logger.warning("Unsupported argument used: roles")
 
-        return self.rest_client.post_measures_download(measure_ids=measure_ids)
+        return self.rest_client.post_measures_values(
+            self.remote_dataset_id, measure_ids=measure_ids)
 
     @property
     def instruments(self):

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import List, Dict, Any, Optional, cast, Generator
 
@@ -138,6 +139,7 @@ class RESTClient:
         response: requests.Response,
         _multiple_values: bool = False
     ) -> Generator[Any, None, None]:
+        assert response.status_code == 200
         stream = response.iter_content()
         objects = ijson.sendable_list()
         coro = ijson.items_coro(
@@ -365,6 +367,25 @@ class RESTClient:
             stream=True
         )
         return response.iter_content()
+
+
+    def post_measures_values(
+            self, dataset_id: str,
+            measure_ids: Optional[list[str]] = None,
+            instrument: Optional[str] = None
+    ) -> Any:
+        """Post download request for pheno measures."""
+        response = self._post(
+            "pheno_browser/measure_values",
+            data={
+                "dataset_id": dataset_id,
+                "measure_ids": measure_ids,
+                "instrument": instrument,
+            },
+            stream=True
+        )
+        return self._read_json_list_stream(response)
+
 
     def post_enrichment_test(self, query: dict) -> Any:
         response = self._post(

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import List, Dict, Any, Optional, cast, Generator
 
@@ -368,7 +367,6 @@ class RESTClient:
         )
         return response.iter_content()
 
-
     def post_measures_values(
             self, dataset_id: str,
             measure_ids: Optional[list[str]] = None,
@@ -385,7 +383,6 @@ class RESTClient:
             stream=True
         )
         return self._read_json_list_stream(response)
-
 
     def post_enrichment_test(self, query: dict) -> Any:
         response = self._post(

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -188,8 +188,6 @@ class ResponseTransformer:
             return None
 
         pheno_values = {}
-        measure_column_names = self.study_wrapper.phenotype_data.db\
-            .get_measure_column_names()
 
         for column in self.study_wrapper.config_columns.phenotype.values():
             assert column.role
@@ -198,8 +196,7 @@ class ResponseTransformer:
                 .phenotype_data.get_people_measure_values(
                     [column.source], roles=[column.role])
             for column_value in column_values_iter:
-                col = measure_column_names[column.source]
-                result[column_value["family_id"]] = column_value[col]
+                result[column_value["family_id"]] = column_value[column.source]
 
             pheno_column_name = f"{column.source}.{column.role}"
             pheno_values[pheno_column_name] = result


### PR DESCRIPTION
## Background
The backend code for phenotype browser downloads was rewritten, but the remote download was not taken into account initially. Currently there is a workaround applied for remote downloads.
Before, the download worked with a method in the pheno DB called get_values_streaming_csv which returned a generator with string CSV lines. This method was changed to get_people_measure_values and now returns a list of dictionaries for every row. This list gets transformed into a CSV in the view itself. Because the remote REST API client relies on the view, it currently cannot return the same dictionary in the remote get_people_measure_values method.

## Aim
We should implement a new view in the API, which should stream the rows from get_people_measures_values as JSONs and use it in the remote phenotype DB through the REST API client.

## Related issues
Background and aim provided by the issue: #564