### PR TITLE
Restore the `/api/v3/users/{user_id}/reset_password` endpoint.

### DIFF
--- a/wdae/wdae/users_api/tests/test_users_rest.py
+++ b/wdae/wdae/users_api/tests/test_users_rest.py
@@ -545,6 +545,17 @@ def test_admin_can_reset_password(
     assert response.status_code is status.HTTP_204_NO_CONTENT
 
 
+def test_non_admin_can_not_reset_password(
+    user_client: Client, active_user: WdaeUser, user_model: Type[WdaeUser]
+) -> None:
+
+    url = f"/api/v3/users/{active_user.id}/reset_password"
+    response = user_client.post(
+        url, content_type="application/json", format="json"
+    )
+    assert response.status_code is status.HTTP_403_FORBIDDEN
+
+
 def test_admin_reset_password_of_nonexiting_user_fails(
     admin_client: Client, active_user: WdaeUser, user_model: Type[WdaeUser]
 ) -> None:

--- a/wdae/wdae/users_api/tests/test_users_rest.py
+++ b/wdae/wdae/users_api/tests/test_users_rest.py
@@ -532,3 +532,25 @@ def test_admin_cannot_delete_own_user(
     response = admin_client.delete(url)
     assert response.status_code is status.HTTP_400_BAD_REQUEST
     assert user_model.objects.filter(pk=admin.id).exists()
+
+
+def test_admin_can_reset_password(
+    admin_client: Client, active_user: WdaeUser, user_model: Type[WdaeUser]
+) -> None:
+
+    url = f"/api/v3/users/{active_user.id}/reset_password"
+    response = admin_client.post(
+        url, content_type="application/json", format="json"
+    )
+    assert response.status_code is status.HTTP_204_NO_CONTENT
+
+
+def test_admin_reset_password_of_nonexiting_user_fails(
+    admin_client: Client, active_user: WdaeUser, user_model: Type[WdaeUser]
+) -> None:
+
+    url = "/api/v3/users/0/reset_password"
+    response = admin_client.post(
+        url, content_type="application/json", format="json"
+    )
+    assert response.status_code is status.HTTP_404_NOT_FOUND

--- a/wdae/wdae/users_api/views.py
+++ b/wdae/wdae/users_api/views.py
@@ -165,6 +165,20 @@ class UserViewSet(viewsets.ModelViewSet):  # pylint: disable=too-many-ancestors
             content_type="text/event-stream",
         )
 
+    @request_logging(LOGGER)
+    @action(detail=True, methods=["get", "post"])
+    def reset_password(self, request: Request, pk: int) -> Response:
+        """Reset the password for a user."""
+        self.check_permissions(request)
+        user_model = get_user_model()
+        try:
+            user = user_model.objects.get(pk=pk)
+            user.reset_password()
+            user.deauthenticate()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except user_model.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
 
 class ForgotPassword(views.APIView):
     """View for forgotten password."""


### PR DESCRIPTION
## Background

SFARI base uses the `/api/v3/users/{user_id}/reset_password` endpoint to initiate a password reset for newly created users.

## Aim

Restoring of this REST API endpoint.

## Implementation

This endpoint is implemented as part of `users_api.views.UserViewSet`.

