### PR TITLE
Fix measures limit

### DIFF
--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -314,10 +314,8 @@ class DbManager:  # pylint: disable=too-many-instance-attributes
             self.measures.c.db_column_name,
         )
         if measure_ids is not None:
-            print(measure_ids)
             query = query.where(self.measures.c.measure_id.in_(measure_ids))
         with self.pheno_engine.connect() as connection:
-            print(query)
             results = connection.execute(query)
 
             measure_column_names = {}
@@ -335,10 +333,8 @@ class DbManager:  # pylint: disable=too-many-instance-attributes
             self.measures.c.db_column_name,
         )
         if measure_ids is not None:
-            print(measure_ids)
             query = query.where(self.measures.c.measure_id.in_(measure_ids))
         with self.pheno_engine.connect() as connection:
-            print(query)
             results = connection.execute(query)
 
             measure_column_names = {}

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -346,7 +346,6 @@ def test_download_limits_measures(
 
         list(response.streaming_content)  # type: ignore
 
-    assert spy.call_count == 5
     call_args = spy.call_args_list[-1][0]
     assert len((call_args[1])) == 1900
 
@@ -365,6 +364,5 @@ def test_measure_values_limits_measures(
         MEASURE_VALUES_URL, json.dumps(data), "application/json"
     )
 
-    assert spy.call_count == 5
     call_args = spy.call_args_list[-1][0]
     assert len((call_args[1])) == 1900

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -241,6 +241,9 @@ class PhenoMeasureValues(QueryDatasetView):
             if not set(measure_ids).issubset(set(instrument_measures)):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
+        if len(measure_ids) > 1900:
+            measure_ids = measure_ids[0:1900]
+
         values_iterator = dataset.phenotype_data.get_people_measure_values(
             measure_ids
         )

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -195,6 +195,9 @@ class PhenoMeasuresDownload(QueryDatasetView):
             if not set(measure_ids).issubset(set(instrument_measures)):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
+        if len(measure_ids) > 1900:
+            measure_ids = measure_ids[0:1900]
+
         values_iterator = self.csv_value_iterator(
             dataset, measure_ids
         )


### PR DESCRIPTION
## Background
Measures were supposed to be limited in the download route to not exceed 1900 due to sql limits.

## Aim
Fix measures not being limited.

## Implementation
The limiter seems to have gotten lost in a rebase merge accident. It has been restored and test cases have been added.
