### PR TITLE
Remote pheno images

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -185,9 +185,7 @@ def check_permissions(
 
     groups = list(groups)
 
-    groups_in = "%s"
-    for _ in range(len(groups) - 1):
-        groups_in += ", %s"
+    groups_in = ", ".join(["%s" for _ in groups])
 
     with connection.cursor() as cursor:
         cursor.execute(

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -87,7 +87,7 @@ class WGPFInstance(GPFInstance):
 
         self._remote_study_db = RemoteStudyDB(self._clients)
 
-    def get_remote_client(self, remote_id) -> Optional[RESTClient]:
+    def get_remote_client(self, remote_id: str) -> Optional[RESTClient]:
         return self._clients.get(remote_id)
 
     @property

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import pathlib
 import os
-from typing import Optional, List, Dict, Any, Union, cast
+from typing import Optional, Dict, Any, Union, cast
 from threading import Lock
 from functools import cached_property
 from box import Box
@@ -43,7 +43,7 @@ class WGPFInstance(GPFInstance):
         **kwargs: dict[str, Any]
     ) -> None:
         self._remote_study_db: Optional[RemoteStudyDB] = None
-        self._clients: List[RESTClient] = []
+        self._clients: Dict[str, RESTClient] = {}
         self._study_wrappers: Dict[
             str, Union[StudyWrapper, RemoteStudyWrapper]
         ] = {}
@@ -79,13 +79,16 @@ class WGPFInstance(GPFInstance):
                         protocol=remote.get("protocol", None),
                         gpf_prefix=remote.get("gpf_prefix", None)
                     )
-                    self._clients.append(client)
+                    self._clients[client.remote_id] = client
 
                 except ConnectionError as err:
                     logger.error(err)
                     logger.error("Failed to create remote %s", remote["id"])
 
         self._remote_study_db = RemoteStudyDB(self._clients)
+
+    def get_remote_client(self, remote_id) -> Optional[RESTClient]:
+        return self._clients.get(remote_id)
 
     @property
     def remote_study_clients(self) -> Dict[str, RESTClient]:

--- a/wdae/wdae/pheno_browser_api/urls.py
+++ b/wdae/wdae/pheno_browser_api/urls.py
@@ -38,4 +38,9 @@ urlpatterns = [
         views.PhenoMeasureValues.as_view(),
         name="pheno_browser_values",
     ),
+    re_path(
+        r"^/remote_images/(?P<remote_id>[^/]+)/(?P<image_path>.+)?",
+        views.PhenoRemoteImages.as_view(),
+        name="pheno_browser_remote_images"
+    ),
 ]

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -7,7 +7,7 @@ from typing import Generator, Union
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import status
-from django.http.response import StreamingHttpResponse
+from django.http.response import StreamingHttpResponse, HttpResponse
 
 from query_base.query_base import QueryDatasetView
 from studies.study_wrapper import RemoteStudyWrapper, StudyWrapper
@@ -255,3 +255,19 @@ class PhenoMeasureValues(QueryDatasetView):
         )
 
         return response
+
+
+class PhenoRemoteImages(QueryDatasetView):
+    """Remote pheno images view."""
+
+    def get(
+        self, request: Request, remote_id: str, image_path: str
+    ) -> HttpResponse:
+        if image_path == "":
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        client = self.gpf_instance.get_remote_client(remote_id)
+
+        image, mimetype = client.get_pheno_image(image_path)
+
+        return HttpResponse(image, content_type=mimetype)

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -261,12 +261,16 @@ class PhenoRemoteImages(QueryDatasetView):
     """Remote pheno images view."""
 
     def get(
-        self, request: Request, remote_id: str, image_path: str
-    ) -> HttpResponse:
+        self, _request: Request, remote_id: str, image_path: str
+    ) -> Union[Response, HttpResponse]:
+        """Return raw image data from a remote GPF instance."""
         if image_path == "":
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         client = self.gpf_instance.get_remote_client(remote_id)
+
+        if client is None:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         image, mimetype = client.get_pheno_image(image_path)
 

--- a/wdae/wdae/remote/denovo_gene_sets_db.py
+++ b/wdae/wdae/remote/denovo_gene_sets_db.py
@@ -69,12 +69,12 @@ class RemoteDenovoGeneSetsDb:
 
     def __init__(
         self,
-        remote_clients: List[RESTClient],
+        remote_clients: Dict[str, RESTClient],
         local_denovo_gene_sets_db: DenovoGeneSetsDb
     ):
         self.remote_denovo_gene_set_collections = dict()
         self._local_dgsdb = local_denovo_gene_sets_db
-        self.remote_clients = remote_clients
+        self.remote_clients = list(remote_clients.values())
 
         self._load_remote_collections()
 

--- a/wdae/wdae/remote/gene_sets_db.py
+++ b/wdae/wdae/remote/gene_sets_db.py
@@ -85,7 +85,8 @@ class RemoteGeneSetsDb(GeneSetsDb):
     """Class for handling remote gene sets."""
 
     def __init__(
-        self, remote_clients: Dict[str, RESTClient], local_gene_sets_db: GeneSetsDb
+        self, remote_clients: Dict[str, RESTClient],
+        local_gene_sets_db: GeneSetsDb
     ):
         super().__init__([])
         self._local_gsdb: GeneSetsDb = local_gene_sets_db

--- a/wdae/wdae/remote/gene_sets_db.py
+++ b/wdae/wdae/remote/gene_sets_db.py
@@ -90,7 +90,7 @@ class RemoteGeneSetsDb(GeneSetsDb):
         super().__init__([])
         self._local_gsdb: GeneSetsDb = local_gene_sets_db
         self.gene_set_collections: Dict[str, GeneSetCollection] = {}
-        self.remote_clients: List[RESTClient] = remote_clients
+        self.remote_clients: List[RESTClient] = list(remote_clients.values())
         self._load_remote_collections()
 
     def _load_remote_collections(self):

--- a/wdae/wdae/remote/gene_sets_db.py
+++ b/wdae/wdae/remote/gene_sets_db.py
@@ -85,7 +85,7 @@ class RemoteGeneSetsDb(GeneSetsDb):
     """Class for handling remote gene sets."""
 
     def __init__(
-        self, remote_clients: List[RESTClient], local_gene_sets_db: GeneSetsDb
+        self, remote_clients: Dict[str, RESTClient], local_gene_sets_db: GeneSetsDb
     ):
         super().__init__([])
         self._local_gsdb: GeneSetsDb = local_gene_sets_db

--- a/wdae/wdae/remote/genomic_scores_registry.py
+++ b/wdae/wdae/remote/genomic_scores_registry.py
@@ -6,13 +6,13 @@ class RemoteGenomicScoresRegistry(GenomicScoresRegistry):
     """Class for automatic fetching and usage of remote genomic scores."""
 
     def __init__(
-        self, rest_clients: list[RESTClient],
+        self, rest_clients: dict[str, RESTClient],
         local_scores_db: GenomicScoresRegistry
     ):
         # pylint: disable=super-init-not-called
         self.remote_scores: dict[str, ScoreDesc] = {}
         self.local_db = local_scores_db
-        for client in rest_clients:
+        for client in rest_clients.values():
             scores = client.get_genomic_scores()
             if scores is not None:
                 for score in scores:

--- a/wdae/wdae/remote/remote_phenotype_data.py
+++ b/wdae/wdae/remote/remote_phenotype_data.py
@@ -242,12 +242,18 @@ class RemotePhenotypeData(PhenotypeData):
     def get_regressions(self):
         return self.rest_client.get_regressions(self.remote_dataset_id)
 
+    @staticmethod
+    def _extract_pheno_dir(url: str) -> str:
+        """Extract the pheno directory from a measures info URL."""
+        url = url.strip("/")
+        pheno_folder = url[url.rindex("/") + 1:]
+        return pheno_folder
+
     def get_measures_info(self):
         output = self.rest_client.get_browser_measures_info(
             self.remote_dataset_id
         )
-        remote_base = output["base_image_url"][:-1]
-        pheno_folder = remote_base[remote_base.rindex("/") + 1:]
+        pheno_folder = self._extract_pheno_dir(output["base_image_url"])
         output["base_image_url"] = (
             "/api/v3/pheno_browser/remote_images/"
             f"{self.rest_client.remote_id}/{pheno_folder}/"

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -1,5 +1,6 @@
 import logging
-from typing import List, Dict, Any, Optional, cast, Generator, Tuple
+from typing import List, Dict, Any, Optional, cast, Generator, Tuple, \
+    Iterable
 
 import requests
 import ijson
@@ -74,7 +75,7 @@ class RESTClient:
             return f"{host_url}/{self.gpf_prefix}{self.base_url}"
         return f"{host_url}{self.base_url}"
 
-    def build_image_url(self, url: str):
+    def build_image_url(self, url: str) -> str:
         """Build a url for accessing remote GPF static images."""
         host_url = self.build_host_url()
         if self.gpf_prefix:
@@ -334,7 +335,7 @@ class RESTClient:
         return response.json()
 
     def get_browser_measures(
-        self, dataset_id: str, instrument: str,
+        self, dataset_id: str, instrument: Optional[str],
         search_term: Optional[str]
     ) -> Any:
         """Get pheno measures that correspond to a search."""
@@ -376,7 +377,7 @@ class RESTClient:
 
     def post_measures_values(
             self, dataset_id: str,
-            measure_ids: Optional[list[str]] = None,
+            measure_ids: Optional[Iterable[str]] = None,
             instrument: Optional[str] = None
     ) -> Any:
         """Post download request for pheno measures."""
@@ -400,15 +401,13 @@ class RESTClient:
 
     def post_pheno_persons(
         self, dataset_id: str,
-        measure_ids: list[str],
-        roles: Optional[list[str]],
-        person_ids: Optional[list[str]],
-        family_ids: Optional[list[str]]
+        roles: Optional[Iterable[str]],
+        person_ids: Optional[Iterable[str]],
+        family_ids: Optional[Iterable[str]]
     ) -> Any:
         """Post a pheno measures person query request."""
         data = {
             "datasetId": dataset_id,
-            "measureIds": measure_ids,
             "roles": roles,
             "personIds": person_ids,
             "familyIds": family_ids,
@@ -421,10 +420,10 @@ class RESTClient:
 
     def post_pheno_persons_values(
         self, dataset_id: str,
-        measure_ids: list[str],
-        roles: Optional[list[str]],
-        person_ids: Optional[list[str]],
-        family_ids: Optional[list[str]]
+        measure_ids: Iterable[str],
+        roles: Optional[Iterable[str]],
+        person_ids: Optional[Iterable[str]],
+        family_ids: Optional[Iterable[str]]
     ) -> Any:
         """Post a pheno measures persons values request."""
         data = {
@@ -480,8 +479,8 @@ class RESTClient:
 
     def get_measures(
         self, dataset_id: str,
-        instrument_name: str,
-        measure_type: str
+        instrument_name: Optional[str],
+        measure_type: Optional[str]
     ) -> Any:
         """Get measures for a dataset."""
         response = self._get(
@@ -515,9 +514,9 @@ class RESTClient:
     def post_measure_values(
         self, dataset_id: str,
         measure_id: str,
-        person_ids: Optional[list[str]],
-        family_ids: Optional[list[str]],
-        roles: Optional[list[str]],
+        person_ids: Optional[Iterable[str]],
+        family_ids: Optional[Iterable[str]],
+        roles: Optional[Iterable[str]],
         default_filter: Optional[str]
     ) -> Any:
         """Post pheno measure values request."""
@@ -563,10 +562,10 @@ class RESTClient:
     def post_instrument_values(
         self, dataset_id: str,
         instrument_name: str,
-        person_ids: Optional[list[str]],
-        family_ids: Optional[list[str]],
-        roles: Optional[list[str]],
-        measures: Optional[list[str]]
+        person_ids: Optional[Iterable[str]],
+        family_ids: Optional[Iterable[str]],
+        roles: Optional[Iterable[str]],
+        measures: Optional[Iterable[str]]
     ) -> Any:
         """Post pheno instrument measures query request."""
         data = {
@@ -698,6 +697,11 @@ class RESTClient:
     def get_pheno_image(
         self, image_path: str
     ) -> Tuple[Optional[bytes], Optional[str]]:
+        """
+        Return tuple of image bytes and image type from remote.
+
+        Accesses static files on the remote GPF instance.
+        """
         url = self.build_image_url(image_path)
         response = requests.get(url, timeout=self.DEFAULT_TIMEOUT)
         if response.status_code != 200:

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Dict, Any, Optional, cast, Generator
+from typing import List, Dict, Any, Optional, cast, Generator, Tuple
 
 import requests
 import ijson
@@ -73,6 +73,13 @@ class RESTClient:
         if self.gpf_prefix:
             return f"{host_url}/{self.gpf_prefix}{self.base_url}"
         return f"{host_url}{self.base_url}"
+
+    def build_image_url(self, url: str):
+        """Build a url for accessing remote GPF static images."""
+        host_url = self.build_host_url()
+        if self.gpf_prefix:
+            return f"{host_url}/{self.gpf_prefix}/static/images/{url}"
+        return f"{host_url}/static/images/{url}"
 
     def _build_url(
         self, url: str, query_values: Optional[dict] = None
@@ -687,3 +694,13 @@ class RESTClient:
         if response.status_code != 200:
             return None
         return cast(dict[str, Any], response.json()[0])
+
+    def get_pheno_image(
+        self, image_path: str
+    ) -> Tuple[Optional[bytes], Optional[str]]:
+        url = self.build_image_url(image_path)
+        response = requests.get(url, timeout=self.DEFAULT_TIMEOUT)
+        if response.status_code != 200:
+            return None, None
+
+        return response.content, response.headers["content-type"]

--- a/wdae/wdae/remote/tests/test_remote_genomic_scores.py
+++ b/wdae/wdae/remote/tests/test_remote_genomic_scores.py
@@ -59,7 +59,7 @@ def test_remote_genomic_scores(
     }]
     local_db = wdae_gpf_instance.genomic_scores
 
-    db = RemoteGenomicScoresRegistry([rest_client], local_db)
+    db = RemoteGenomicScoresRegistry({"remote": rest_client}, local_db)
     assert len(db.remote_scores) == 1
     assert "attr_dest" in db.remote_scores
     score = db.remote_scores["attr_dest"]

--- a/wdae/wdae/remote/tests/test_remote_pheno_db.py
+++ b/wdae/wdae/remote/tests/test_remote_pheno_db.py
@@ -1,7 +1,8 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 from remote.remote_phenotype_data import RemotePhenotypeData
 
-def test_extract_url():
+
+def test_extract_url() -> None:
     extracted = RemotePhenotypeData._extract_pheno_dir(
         "testing/static/images/pheno_id"
     )

--- a/wdae/wdae/remote/tests/test_remote_pheno_db.py
+++ b/wdae/wdae/remote/tests/test_remote_pheno_db.py
@@ -1,0 +1,13 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+from remote.remote_phenotype_data import RemotePhenotypeData
+
+def test_extract_url():
+    extracted = RemotePhenotypeData._extract_pheno_dir(
+        "testing/static/images/pheno_id"
+    )
+    assert extracted == "pheno_id"
+
+    extracted = RemotePhenotypeData._extract_pheno_dir(
+        "testing/static/images/pheno_id///"
+    )
+    assert extracted == "pheno_id"

--- a/wdae/wdae/remote/tests/test_rest_api_client.py
+++ b/wdae/wdae/remote/tests/test_rest_api_client.py
@@ -93,7 +93,6 @@ def test_post_enrichment_test(rest_client: RESTClient) -> None:
 def test_post_pheno_persons(rest_client: RESTClient) -> None:
     pheno_persons = rest_client.post_pheno_persons(
         "iossifov_2014",
-        ["i1.m1"],
         None,
         None,
         None

--- a/wdae/wdae/studies/remote_study_db.py
+++ b/wdae/wdae/studies/remote_study_db.py
@@ -1,7 +1,7 @@
 """Provides class for handling of remote studies."""
 
 import logging
-from typing import List, Dict, Optional
+from typing import Dict, Optional
 
 from box import Box
 
@@ -14,12 +14,12 @@ logger = logging.getLogger(__name__)
 class RemoteStudyDB:
     """Class to manage remote studies."""
 
-    def __init__(self, clients: List[RESTClient]) -> None:
+    def __init__(self, clients: Dict[str, RESTClient]) -> None:
         self.remote_study_clients: Dict[str, RESTClient] = {}
         self.remote_study_ids: Dict[str, str] = {}
         self.remote_genotype_data: Dict[str, RemoteGenotypeData] = {}
 
-        for client in clients:
+        for client in clients.values():
             try:
                 self._fetch_remote_studies(client)
             except RESTClientRequestError as err:


### PR DESCRIPTION
## Background
Phenotype browser images had an implementation, where the links were matched to lead directly to the remote server's static files route, but this ended up not working because of cross site policies. The images for remotes needed a different implementation to work.

## Aim
Write an alternative solution to displaying remote phenotype browser images.

## Implementation
The policy is circumvented by fetching the images in the backend via the remote REST API client. A new view has been made to serve raw images from remotes. The old implementation of matching the base URL to the remote has been removed and now the base URL leads to the correct remote images view with the correct remote ID. Remote clients were also loaded in a list in the WDAE GPF instance and later mapped to the loaded in remote studies. This worked until now because almost every site functionality is dependent on a dataset ID. Because images are tied to a specific remote and specific pheno directory and not a study, this old way of getting REST clients suddenly stopped making sense. REST clients are now loaded in a dictionary, mapped to their remote IDs.