### PR TITLE
More responsive downloads

### DIFF
--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -1,13 +1,15 @@
-from typing import cast
+from typing import Generator, cast
 import logging
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.request import Request
 from django.http.response import FileResponse
 from query_base.query_base import QueryDatasetView
 from studies.study_wrapper import StudyWrapper
 from utils.logger import request_logging
 from utils.query_params import parse_query_params
 from utils.expand_gene_set import expand_gene_set
+from django.contrib.auth.models import User
 
 from datasets_api.permissions import \
     handle_partial_permissions
@@ -67,8 +69,33 @@ class QueryVariantsView(QueryDatasetView):
 class DownloadSummaryVariantsView(QueryDatasetView):
     DOWNLOAD_LIMIT = 10000
 
+    def generate_variants(
+            self,
+            data: dict,
+            user: User,
+            dataset: StudyWrapper,
+            dataset_id: str
+    ) -> Generator[str, None, None]:
+        # Return a response instantly and make download more responsive
+        yield ""
+        handle_partial_permissions(user, dataset_id, data)
+
+        download_limit = None
+        if not (user.is_authenticated and user.has_unlimited_download):
+            download_limit = self.DOWNLOAD_LIMIT
+        data.update({"limit": download_limit})
+
+        config = dataset.config.gene_browser
+        freq_col = config.frequency_column
+
+        variants = dataset.get_gene_view_summary_variants_download(
+            freq_col, **data)
+
+        for variant in variants:
+            yield variant
+
     @request_logging(LOGGER)
-    def post(self, request):
+    def post(self, request: Request) -> Request:
         data = expand_gene_set(parse_query_params(request.data), request.user)
         dataset_id = data.pop("datasetId", None)
         if dataset_id is None:
@@ -84,21 +111,10 @@ class DownloadSummaryVariantsView(QueryDatasetView):
 
         dataset = cast(StudyWrapper, dataset)
 
-        user = request.user
-        user = request.user
-        handle_partial_permissions(user, dataset_id, data)
-
-        download_limit = None
-        if not (user.is_authenticated and user.has_unlimited_download):
-            download_limit = self.DOWNLOAD_LIMIT
-        data.update({"limit": download_limit})
-
-        config = dataset.config.gene_browser
-        freq_col = config.frequency_column
-
-        variants = dataset.get_gene_view_summary_variants_download(
-            freq_col, **data)
-        response = FileResponse(variants, content_type="text/tsv")
+        response = FileResponse(
+            self.generate_variants(data, request.user, dataset, dataset_id),
+            content_type="text/tsv"
+        )
         response["Content-Disposition"] = \
             "attachment; filename=summary_variants.tsv"
         response["Expires"] = "0"

--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -4,12 +4,12 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.request import Request
 from django.http.response import FileResponse
+from django.contrib.auth.models import User
 from query_base.query_base import QueryDatasetView
 from studies.study_wrapper import StudyWrapper
 from utils.logger import request_logging
 from utils.query_params import parse_query_params
 from utils.expand_gene_set import expand_gene_set
-from django.contrib.auth.models import User
 
 from datasets_api.permissions import \
     handle_partial_permissions
@@ -67,6 +67,8 @@ class QueryVariantsView(QueryDatasetView):
 
 
 class DownloadSummaryVariantsView(QueryDatasetView):
+    """Summary download view."""
+
     DOWNLOAD_LIMIT = 10000
 
     def generate_variants(
@@ -76,6 +78,7 @@ class DownloadSummaryVariantsView(QueryDatasetView):
             dataset: StudyWrapper,
             dataset_id: str
     ) -> Generator[str, None, None]:
+        """Summary variants generator."""
         # Return a response instantly and make download more responsive
         yield ""
         handle_partial_permissions(user, dataset_id, data)
@@ -95,7 +98,8 @@ class DownloadSummaryVariantsView(QueryDatasetView):
             yield variant
 
     @request_logging(LOGGER)
-    def post(self, request: Request) -> Request:
+    def post(self, request: Request) -> Response:
+        """Summary variants download."""
         data = expand_gene_set(parse_query_params(request.data), request.user)
         dataset_id = data.pop("datasetId", None)
         if dataset_id is None:

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -1,8 +1,9 @@
+from io import StringIO
 import math
 import logging
-from typing import cast, Any
-
-from rest_framework.response import Response  # type: ignore
+from typing import Generator, cast, Any
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework import status  # type: ignore
 
 from django.http.response import StreamingHttpResponse
@@ -110,15 +111,13 @@ class PhenoToolView(QueryDatasetView):
 
 
 class PhenoToolDownload(PhenoToolView):
-    def post(self, request):
-        data = expand_gene_set(parse_query_params(request.data), request.user)
-        adapter = self.prepare_pheno_tool_adapter(data)
-        if not adapter:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        if not user_has_permission(request.user, data["datasetId"]):
-            return Response(status=status.HTTP_403_FORBIDDEN)
-
+    def generate_columns(
+            self,
+            adapter: PhenoToolAdapter,
+            data: dict
+    ) -> Generator[str, None, None]:
+        # Return a response instantly and make download more responsive
+        yield ""
         effect_groups = [effect for effect in data["effectTypes"]]
 
         data = adapter.helper.genotype_data.transform_request(data)
@@ -157,8 +156,28 @@ class PhenoToolDownload(PhenoToolView):
             + columns[3:-effect_types_count]
         )
 
+        csv_buffer = StringIO()
+        result_df.to_csv(csv_buffer, index=False, columns=columns)
+        csv_buffer.seek(0)
+        for row in csv_buffer.readlines():
+            yield row
+        # for row in result_df.to_csv(index=False, columns=columns).splitlines():
+        #     yield row + "\n"
+
+    def post(self, request: Request) -> Response:
+        data = expand_gene_set(parse_query_params(request.data), request.user)
+
+        if not user_has_permission(request.user, data["datasetId"]):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        adapter = self.prepare_pheno_tool_adapter(data)
+        print("adapter finished")
+
+        if not adapter:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
         response = StreamingHttpResponse(
-            result_df.to_csv(index=False, columns=columns),
+            self.generate_columns(adapter, data),
             content_type="text/csv",
         )
         response[

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -111,11 +111,14 @@ class PhenoToolView(QueryDatasetView):
 
 
 class PhenoToolDownload(PhenoToolView):
+    """Pheno tool download view."""
+
     def generate_columns(
             self,
             adapter: PhenoToolAdapter,
             data: dict
     ) -> Generator[str, None, None]:
+        """Pheno tool download generator function."""
         # Return a response instantly and make download more responsive
         yield ""
         effect_groups = [effect for effect in data["effectTypes"]]
@@ -161,10 +164,9 @@ class PhenoToolDownload(PhenoToolView):
         csv_buffer.seek(0)
         for row in csv_buffer.readlines():
             yield row
-        # for row in result_df.to_csv(index=False, columns=columns).splitlines():
-        #     yield row + "\n"
 
     def post(self, request: Request) -> Response:
+        """Pheno tool download."""
         data = expand_gene_set(parse_query_params(request.data), request.user)
 
         if not user_has_permission(request.user, data["datasetId"]):


### PR DESCRIPTION
## Background
Pheno tool and gene view downloads were not responsive enough.

## Aim
Speed up response time so the download pop-ups appear faster.

## Implementation
Transferring some of the views logic in generator functions that yield results faster. Initially the generators were waiting until some of the response content is generated before they yielded something. Inner DJango logic caused this and made the generators not a suitable solution. To circumvent this a hack was used where the generator functions yield empty values before the real content was generated. 

This way when downloading, the request announces that it's going to stream results faster and the user sees the download dialog almost immediately.

Another solution with the generator functions would be to delve deeper into how to change the inner DJango logic that edits these generator functions.
