### PR TITLE
Add new tag filter functionality

### DIFF
--- a/dae/dae/pedigrees/family_tag_builder.py
+++ b/dae/dae/pedigrees/family_tag_builder.py
@@ -58,6 +58,30 @@ def check_tag(family: Family, tag: FamilyTag) -> bool:
     return True
 
 
+def check_family_tags_query(
+    family: Family, or_mode: bool,
+    include_tags: set[FamilyTag],
+    exclude_tags: set[FamilyTag]
+) -> bool:
+    """Check if a family passes specified filters."""
+    if or_mode:
+        for tag in include_tags:
+            if check_tag(family, tag):
+                return True
+        for tag in exclude_tags:
+            if not check_tag(family, tag):
+                return True
+        return False
+
+    for tag in include_tags:
+        if not check_tag(family, tag):
+            return False
+    for tag in exclude_tags:
+        if check_tag(family, tag):
+            return False
+    return True
+
+
 def check_nuclear_family(family: Family) -> bool:
     """Check if the family is a nuclear family."""
     mom = _get_mom(family)

--- a/dae/dae/pedigrees/tests/test_family_tags.py
+++ b/dae/dae/pedigrees/tests/test_family_tags.py
@@ -22,7 +22,8 @@ from dae.pedigrees.family_tag_builder import check_tag, \
     tag_male_prb_family, \
     tag_female_prb_family, \
     tag_missing_mom_family, \
-    tag_missing_dad_family
+    tag_missing_dad_family, \
+    check_family_tags_query
 from dae.pedigrees.testing import build_family
 
 
@@ -427,3 +428,52 @@ def test_tag_missing_dad_family_again() -> None:
 
     assert tag_missing_dad_family(fam)
     assert check_tag(fam, FamilyTag.MISSING_DAD)
+
+
+@pytest.mark.parametrize(
+    "or_mode,included_tags,excluded_tags,expected",
+    [
+        (False, {FamilyTag.NUCLEAR}, {}, True),
+        (False, {FamilyTag.QUAD}, {}, True),
+        (False, {FamilyTag.NUCLEAR, FamilyTag.QUAD}, {}, True),
+        (
+            False, 
+            {FamilyTag.NUCLEAR, FamilyTag.QUAD, FamilyTag.MALE_PRB},
+            {},
+            False
+        ),
+        (False, {FamilyTag.NUCLEAR}, {FamilyTag.QUAD}, False),
+        (False, {}, {FamilyTag.MISSING_DAD}, True),
+        (False, {FamilyTag.NUCLEAR}, {FamilyTag.MISSING_DAD}, True),
+        (True, {FamilyTag.QUAD}, {FamilyTag.TRIO}, True),
+        (True, {FamilyTag.QUAD}, {}, True),
+        (True, {FamilyTag.QUAD, FamilyTag.NUCLEAR}, {}, True),
+        (True, {FamilyTag.QUAD}, {FamilyTag.NUCLEAR}, True),
+        (True, {}, {FamilyTag.TRIO}, True),
+        (True, {}, {FamilyTag.QUAD}, False),
+        (True, {FamilyTag.MISSING_DAD}, {FamilyTag.QUAD}, False),
+        (
+            True, 
+            {FamilyTag.NUCLEAR, FamilyTag.QUAD, FamilyTag.MALE_PRB},
+            {},
+            True
+        ),
+    ]
+)
+def test_tag_query(
+    fam1_fixture: Family,
+    or_mode: bool,
+    included_tags: set[FamilyTag],
+    excluded_tags: set[FamilyTag],
+    expected: bool
+) -> None:
+
+    assert tag_nuclear_family(fam1_fixture)
+    assert tag_quad_family(fam1_fixture)
+
+    assert check_family_tags_query(
+        fam1_fixture,
+        or_mode,
+        included_tags,
+        excluded_tags
+    ) == expected

--- a/wdae/wdae/common_reports_api/tests/test_remote_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_remote_common_reports_api.py
@@ -21,7 +21,7 @@ def test_remote_variant_reports(admin_client: Client) -> None:
 
 def test_remote_families_data_download(admin_client: Client) -> None:
     url = "/api/v3/common_reports/families_data/TEST_REMOTE_iossifov_2014"
-    response = admin_client.get(url)
+    response = admin_client.post(url)
 
     assert response
     assert response.status_code == status.HTTP_200_OK

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -191,6 +191,8 @@ class FamiliesDataDownloadView(QueryDatasetView):
     def post(self, request: Request, dataset_id: str) -> Response:
         """Return full family data for a specified study and tags."""
         data = request.data
+        if "queryData" in data:
+            data = parse_query_params(data)
 
         tags_query = data.get("tagsQuery")
 

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -312,7 +312,7 @@ class RESTClient:
         self, common_report_id: str
     ) -> Any:
         """Get families part of the common report for a study."""
-        response = self._get(
+        response = self._post(
             f"common_reports/families_data/{common_report_id}",
             stream=True
         )


### PR DESCRIPTION
## Background
Pedigree tag functionality was recently expanded in the frontend to support and/or and tag exclusion. The download however needs to be updated.

## Aim
Update the backend download handling of pedigrees to support the new tag filtering.

## Implementation
The old download was a GET request, due to the more complicated data being sent, this is now a POST request. The requests expects either an empty body to download all families or the following format.
```json
{
    "tagsQuery": {
        "orMode": true/false,
        "includeTags": [],
        "excludeTags": []
    }
}
```
A new utility was written to handle this tag query format. This format could be made more robust for future use in different parts of the system.