### PR TITLE
fix nonsym effect type in pheno tool download

### DIFF
--- a/dae/dae/effect_annotation/effect.py
+++ b/dae/dae/effect_annotation/effect.py
@@ -672,6 +672,7 @@ class EffectTypesMixin:
         "CNV": ["CNV+", "CNV-"],
         "CNV+": ["CNV+"],
         "CNV-": ["CNV-"],
+        "Nonsynonymous": ["nonsynonymous"]
     }
 
     EFFECT_TYPES_UI_NAMING = {

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -3,6 +3,7 @@ import math
 import logging
 
 from typing import Dict, List, Optional, Union, cast, Any, Generator
+from dae.effect_annotation.effect import EffectTypesMixin
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -144,6 +145,12 @@ class PhenoToolDownload(PhenoToolView):
         # Return a response instantly and make download more responsive
         yield ""
 
+        data["effectTypes"] = EffectTypesMixin.build_effect_types_list(
+            data["effectTypes"]
+        )
+        data["effectTypes"] = EffectTypesMixin.build_effect_types_groups(
+            data["effectTypes"]
+        )
         effect_groups = list(data["effectTypes"])
 
         data = cast(StudyWrapper, adapter.helper.genotype_data) \

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -3,7 +3,6 @@ import math
 import logging
 
 from typing import Dict, List, Optional, Union, cast, Any, Generator
-from dae.effect_annotation.effect import EffectTypesMixin
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -20,6 +19,7 @@ from datasets_api.permissions import user_has_permission
 
 from dae.pheno.pheno_db import Measure
 from dae.pheno_tool.tool import PhenoResult, PhenoTool, PhenoToolHelper
+from dae.effect_annotation.effect import EffectTypesMixin
 
 from .pheno_tool_adapter import PhenoToolAdapter, RemotePhenoToolAdapter
 


### PR DESCRIPTION
## Background
Nonsynonymous group is not working correctly when downloading in pheno tool. Issue with case sensitivity.

## Aim
Fix non synonymous effect type for pheno tool download.
