### PR TITLE
add back common reports download get api

### DIFF
--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -241,3 +241,26 @@ def test_families_data_download_no_permissions(user_client: Client) -> None:
 
     assert response
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_families_data_all_download(admin_client: Client) -> None:
+    url = "/api/v3/common_reports/families_data/Study1"
+    response = admin_client.get(url)
+
+    assert response
+    assert response.status_code == status.HTTP_200_OK
+
+    streaming_content = list(response.streaming_content)  # type: ignore
+    assert streaming_content
+
+    assert len(streaming_content) == 34
+
+
+def test_families_data_all_download_no_permissions(
+    user_client: Client
+) -> None:
+    url = "/api/v3/common_reports/families_data/study4"
+    response = user_client.get(url)
+
+    assert response
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -189,7 +189,7 @@ class FamiliesDataDownloadView(QueryDatasetView):
         return FamiliesData.from_families(result)
 
     def get(self, _request: Request, dataset_id: str) -> Response:
-        """Return full family data for a specified study and tags."""
+        """Return full family data for a specified study."""
         if not dataset_id:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/wdae/wdae/common_reports_api/views.py
+++ b/wdae/wdae/common_reports_api/views.py
@@ -188,6 +188,28 @@ class FamiliesDataDownloadView(QueryDatasetView):
 
         return FamiliesData.from_families(result)
 
+    def get(self, _request: Request, dataset_id: str) -> Response:
+        """Return full family data for a specified study and tags."""
+        if not dataset_id:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        study = self.gpf_instance.get_genotype_data(dataset_id)
+
+        if study is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        tsv = FamiliesLoader.to_tsv(study.families)
+        lines = map(lambda x: x + "\n", tsv.strip().split("\n"))
+
+        response = StreamingHttpResponse(
+            lines,
+            content_type="text/tab-separated-values"
+        )
+        response["Content-Disposition"] = "attachment; filename=families.ped"
+        response["Expires"] = "0"
+
+        return response
+
     def post(self, request: Request, dataset_id: str) -> Response:
         """Return full family data for a specified study and tags."""
         data = request.data


### PR DESCRIPTION
## Background
Common reports api download was changed to post request, but frontend app still uses "get" requests.

## Aim
Implement the "get" request back so both "post" and "get" are available.

## Implementation
Add "get" to common reports download api.