### PR TITLE
Fix top level permissions

### DIFF
--- a/wdae/wdae/datasets_api/models.py
+++ b/wdae/wdae/datasets_api/models.py
@@ -104,7 +104,7 @@ class DatasetHierarchy(models.Model):
         """
         return len(cls.objects.filter(
             instance_id=instance_id, ancestor_id=dataset.id
-        )) == 0
+        ).exclude(descendant_id=dataset.id)) == 0
 
     @classmethod
     def get_parents(
@@ -114,11 +114,11 @@ class DatasetHierarchy(models.Model):
         if direct is True:
             relations = cls.objects.filter(
                 instance_id=instance_id, descendant_id=dataset.id, direct=True
-            )
+            ).exclude(ancestor_id=dataset.id)
         else:
             relations = cls.objects.filter(
                 instance_id=instance_id, descendant_id=dataset.id
-            )
+            ).exclude(ancestor_id=dataset.id)
         return [relation.ancestor for relation in relations]
 
     @classmethod
@@ -129,9 +129,9 @@ class DatasetHierarchy(models.Model):
         if direct is True:
             relations = cls.objects.filter(
                 instance_id=instance_id, ancestor_id=dataset.id, direct=True
-            )
+            ).exclude(descendant_id=dataset.id)
         else:
             relations = cls.objects.filter(
                 instance_id=instance_id, ancestor_id=dataset.id
-            )
+            ).exclude(descendant_id=dataset.id)
         return [relation.descendant for relation in relations]

--- a/wdae/wdae/datasets_api/tests/test_permissions.py
+++ b/wdae/wdae/datasets_api/tests/test_permissions.py
@@ -190,6 +190,15 @@ def test_study1_and_dataset2_rights_allowed_datasets(
     assert result == set(["Study1", "Study2"])
 
 
+def test_top_level_study_access(
+    user: User,
+    wdae_gpf_instance: WGPFInstance
+) -> None:
+    assert not user_has_permission("test_data", user, "comp")
+    add_group_perm_to_user("comp", user)
+    assert user_has_permission("test_data", user, "comp")
+
+
 def test_dataset_group_rights(
     user: User, dataset_wrapper: StudyWrapper
 ) -> None:

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -580,6 +580,9 @@ def reload_datasets(gpf_instance: WGPFInstance) -> None:
             logger.error(
                 "unable to find study %s; skipping...", genotype_data_id)
             continue
+        DatasetHierarchy.add_relation(
+            gpf_instance.instance_id, genotype_data_id, genotype_data_id
+        )
         direct_descendants = genotype_data.get_studies_ids(leaves=False)
         for study_id in genotype_data.get_studies_ids():
             if study_id == genotype_data_id:


### PR DESCRIPTION
## Background
There is a bug with the dataset hierarchy table permissions, where if we have lone studies on the top level of the hierarchy, they do not have records in the hierarchy table, because only studies with descendants or ancestors get written to it, therefore access rights were broken on them.

## Aim
Fix access rights for top level studies.

## Implementation
The dataset hierarchy table now has a special entry for every single study, where it references itself as both ancestor and descendant. This way, lone studies will be factored in for permissions and can be filtered out for the other permission logic.