### PR TITLE
Fix GP counting bug

### DIFF
--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -74,11 +74,16 @@ def add_variant_count(
         if effect_types is not None:
             skip = True
             for allele in variant.alt_alleles:
-                allele_gene_effects: dict[str, set[str]] = {
-                    eg.symbol: set() for eg in allele.effect_genes
-                }
+                allele_gene_effects: dict[str, set[str]] = {}
                 for eg in allele.effect_genes:
-                    allele_gene_effects[eg.symbol].add(eg.effect)
+                    if eg.symbol is None or eg.effect is None:
+                        continue
+
+                    if eg.symbol in allele_gene_effects:
+                        allele_gene_effects[eg.symbol].add(eg.effect)
+                    else:
+                        allele_gene_effects[eg.symbol] = {eg.effect}
+
                 allele_effects = allele_gene_effects.get(gs)
                 if allele_effects \
                         and allele_effects.intersection(effect_types):

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -74,13 +74,14 @@ def add_variant_count(
         if effect_types is not None:
             skip = True
             for allele in variant.alt_alleles:
-                allele_gene_effects = {
+                allele_gene_effects: dict[str, set[str]] = {
                     eg.symbol: set() for eg in allele.effect_genes
                 }
                 for eg in allele.effect_genes:
                     allele_gene_effects[eg.symbol].add(eg.effect)
                 allele_effects = allele_gene_effects.get(gs)
-                if allele_effects.intersection(effect_types):
+                if allele_effects \
+                        and allele_effects.intersection(effect_types):
                     skip = False
                     break
 

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -75,10 +75,12 @@ def add_variant_count(
             skip = True
             for allele in variant.alt_alleles:
                 allele_gene_effects = {
-                    eg.symbol: eg.effect for eg in allele.effect_genes
+                    eg.symbol: set() for eg in allele.effect_genes
                 }
-                allele_effect = allele_gene_effects.get(gs)
-                if allele_effect and allele_effect in effect_types:
+                for eg in allele.effect_genes:
+                    allele_gene_effects[eg.symbol].add(eg.effect)
+                allele_effects = allele_gene_effects.get(gs)
+                if allele_effects.intersection(effect_types):
                     skip = False
                     break
 


### PR DESCRIPTION
## Background
A new GP counting bug was found with the SHANK2 gene on the e2e build.

## Aim
Investigate and fix the counting bug.

## Implementation
The logic for whether a variant contributes to the count would take the allele's `effect_genes` and make a map of symbol to effect. In our example with the bug, the variant's effect gene list would look like this: `[SHANK2:frame-shift, SHANK2:non-coding-intron]`. In our example the statistic should count, because it is a frame shift, but after making the map, `frame-shift` gets overwritten by `non-coding-intron`, thus skipping the count. The fix made changes the dictionary map from symbol to effect -> symbol to set of effects.

