### PR TITLE
Update instance adjust tool

### DIFF
--- a/impala2_storage/docker-compose.yaml
+++ b/impala2_storage/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   impala4:
     image: "iossifovlab/iossifovlab-impala4:latest"
     ports:
-    - "35000:25000"
+    - "35001:25000"
     - "8020:8020"
     - "21050:21050"
     - "9870:9870"


### PR DESCRIPTION
## Background

To properly run `gpf_validation_data` build we need some improvements in tools for GPF instance adjustments and validation runner.

## Aim

* Add support for adjusting DuckDb genotype storages in `gpf_instance_adjustments`

* Make comparison of variants and expectations more robust.

## Implementation

Small changes in the tools added.