### PR TITLE
Generate gene profiles review

### DIFF
--- a/dae/dae/annotation/annotate_columns.py
+++ b/dae/dae/annotation/annotate_columns.py
@@ -64,7 +64,7 @@ def configure_argument_parser() -> argparse.ArgumentParser:
     CLIAnnotationContext.add_context_arguments(parser)
     add_record_to_annotable_arguments(parser)
     TaskGraphCli.add_arguments(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     return parser
 
 

--- a/dae/dae/annotation/annotate_doc.py
+++ b/dae/dae/annotation/annotate_doc.py
@@ -29,7 +29,7 @@ def configure_argument_parser() -> argparse.ArgumentParser:
                         help="Filename of the output VCF result",
                         default=None)
     CLIAnnotationContext.add_context_arguments(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     return parser
 
 

--- a/dae/dae/annotation/annotate_vcf.py
+++ b/dae/dae/annotation/annotate_vcf.py
@@ -57,7 +57,7 @@ def configure_argument_parser() -> argparse.ArgumentParser:
 
     CLIAnnotationContext.add_context_arguments(parser)
     TaskGraphCli.add_arguments(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     return parser
 
 

--- a/dae/dae/common_reports/generate_common_report.py
+++ b/dae/dae/common_reports/generate_common_report.py
@@ -20,7 +20,7 @@ def main(
     """Command line tool to generate dataset statistics."""
     description = "Generate common reports tool"
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--show-studies",

--- a/dae/dae/effect_annotation/cli.py
+++ b/dae/dae/effect_annotation/cli.py
@@ -298,7 +298,7 @@ def cli_columns():
     parser = ArgumentParser(
         description="Annotate Variant Effects in a Column File.")
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     EffectAnnotatorBuilder.set_arguments(parser)
     VariantColumnInputFile.set_argument(parser)
     VariantColumnOutputFile.set_argument(parser)
@@ -329,7 +329,7 @@ def cli_vcf():
     parser = ArgumentParser(
         description="Annotate Variant Effects in a VCF file.")
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     EffectAnnotatorBuilder.set_arguments(parser)
     AnnotationAttributes.set_argument(
         parser,

--- a/dae/dae/enrichment_tool/build_coding_length_enrichment_background.py
+++ b/dae/dae/enrichment_tool/build_coding_length_enrichment_background.py
@@ -25,7 +25,7 @@ def cli(argv: Optional[list[str]] = None) -> None:
     description = "Command line tool to create coding length enrichment " \
         "background"
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--grr", "--definition", "-g", type=str,

--- a/dae/dae/enrichment_tool/build_ur_synonymous_enrichment_background.py
+++ b/dae/dae/enrichment_tool/build_ur_synonymous_enrichment_background.py
@@ -22,7 +22,7 @@ def cli(
     description = "Command line tool to create UR synonymous enrichment " \
         "background."
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         dest="study_id",

--- a/dae/dae/enrichment_tool/enrichment_cache_builder.py
+++ b/dae/dae/enrichment_tool/enrichment_cache_builder.py
@@ -18,7 +18,7 @@ def cli(
     """Generate enrichment tool cache."""
     description = "Generate enrichment tool cache"
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--show-studies",

--- a/dae/dae/gene_profile/exporter.py
+++ b/dae/dae/gene_profile/exporter.py
@@ -24,7 +24,7 @@ def cli_export(
     parser.add_argument(
         "--version", action="store_true", default=False,
         help="Prints GPF version and exists.")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     parser.add_argument(
         "--gpf", "-G", type=str, default=None,
         help="Path to GPF instance configuration file.")

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -6,6 +6,7 @@ import logging
 from typing import Dict, Any, Set, cast, Iterable, Optional
 from box import Box
 
+from dae.utils.verbosity_configuration import VerbosityConfiguration
 from dae.gene.gene_sets_db import GeneSet
 from dae.gpf_instance.gpf_instance import GPFInstance
 from dae.gene_profile.statistic import GPStatistic
@@ -117,7 +118,7 @@ def calculate_table_values(
             set_name = ps.set_name
             person_set = psc.person_sets[set_name]
 
-            children_count = len(list(person_set.get_children()))
+            children_count = person_set.get_children_count()
 
             for statistic in filters.statistics:
                 stat_id = statistic["id"]
@@ -254,7 +255,7 @@ def main(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     description = "Generate gene profile statistics tool"
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--verbose", "-V", "-v", action="count", default=0)
+    VerbosityConfiguration.set_arguments(parser)
     default_dbfile = os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb")
     parser.add_argument("--dbfile", default=default_dbfile)
     parser.add_argument(
@@ -269,15 +270,7 @@ def main(
     parser.add_argument("--drop", action="store_true")
 
     args = parser.parse_args(argv)
-    if args.verbose == 1:
-        logging.basicConfig(level=logging.WARNING)
-    elif args.verbose == 2:
-        logging.basicConfig(level=logging.INFO)
-    elif args.verbose >= 3:
-        logging.basicConfig(level=logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.ERROR)
-    logging.getLogger("impala").setLevel(logging.WARNING)
+    VerbosityConfiguration.set(args)
 
     start = time.time()
     if gpf_instance is None:

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -130,7 +130,7 @@ def _configure_list_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--hr", default=False, action="store_true",
         help="Projects the size in human-readable format.")
     _add_repository_resource_parameters_group(parser, use_resource=False)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
 
 def _run_list_command(
@@ -167,7 +167,7 @@ def _configure_repo_init_subparser(
 
     _add_repository_resource_parameters_group(parser, use_resource=False)
     _add_dry_run_and_force_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
 
 def _run_repo_init_command(**kwargs: str) -> None:
@@ -201,7 +201,7 @@ def _configure_repo_manifest_subparser(
     _add_repository_resource_parameters_group(parser, use_resource=False)
     _add_dry_run_and_force_parameters_group(parser)
     _add_dvc_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
 
 def _configure_resource_manifest_subparser(
@@ -212,7 +212,7 @@ def _configure_resource_manifest_subparser(
     _add_repository_resource_parameters_group(parser)
     _add_dry_run_and_force_parameters_group(parser)
     _add_dvc_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
 
 def _configure_repo_stats_subparser(
@@ -225,7 +225,7 @@ def _configure_repo_stats_subparser(
     _add_dry_run_and_force_parameters_group(parser)
     _add_dvc_parameters_group(parser)
     _add_hist_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     TaskGraphCli.add_arguments(parser, use_commands=False, force_mode="always")
 
@@ -240,7 +240,7 @@ def _configure_resource_stats_subparser(
     _add_dry_run_and_force_parameters_group(parser)
     _add_dvc_parameters_group(parser)
     _add_hist_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     TaskGraphCli.add_arguments(parser, use_commands=False, force_mode="always")
 
@@ -254,7 +254,7 @@ def _configure_repo_repair_subparser(
     _add_dry_run_and_force_parameters_group(parser)
     _add_dvc_parameters_group(parser)
     _add_hist_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     TaskGraphCli.add_arguments(parser, use_commands=False, force_mode="always")
 
@@ -268,7 +268,7 @@ def _configure_resource_repair_subparser(
     _add_dry_run_and_force_parameters_group(parser)
     _add_dvc_parameters_group(parser)
     _add_hist_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     TaskGraphCli.add_arguments(parser, use_commands=False, force_mode="always")
 
@@ -279,7 +279,7 @@ def _configure_repo_info_subparser(
         "repo-info", help="Build the index.html for the whole GRR"
     )
     _add_repository_resource_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     TaskGraphCli.add_arguments(parser, use_commands=False, force_mode="always")
 
@@ -290,7 +290,7 @@ def _configure_resource_info_subparser(
         "resource-info", help="Build the index.html for the specific resource"
     )
     _add_repository_resource_parameters_group(parser)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     TaskGraphCli.add_arguments(parser, use_commands=False, force_mode="always")
 
@@ -703,7 +703,7 @@ def cli_manage(cli_args: Optional[list[str]] = None) -> None:
     parser.add_argument(
         "--version", action="store_true", default=False,
         help="Prints GPF version and exists.")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     commands_parser: argparse._SubParsersAction = parser.add_subparsers(
         dest="command", help="Command to execute")
@@ -830,7 +830,7 @@ def cli_browse(cli_args: Optional[list[str]] = None) -> None:
     parser.add_argument(
         "--version", action="store_true", default=False,
         help="Prints GPF version and exists.")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     group = parser.add_argument_group(title="Repository/Resource")
     group.add_argument(

--- a/dae/dae/import_tools/cli.py
+++ b/dae/dae/import_tools/cli.py
@@ -22,7 +22,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("config", type=str,
                         help="Path to the import configuration")
     TaskGraphCli.add_arguments(parser, default_task_status_dir=None)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     args = parser.parse_args(argv or sys.argv[1:])
     VerbosityConfiguration.set(args)
 

--- a/dae/dae/pedigrees/generate_families_cache.py
+++ b/dae/dae/pedigrees/generate_families_cache.py
@@ -19,7 +19,7 @@ def main(
     """Command line tool to create genotype groups families cache."""
     description = "Create genotype groups families cache"
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--show-groups",

--- a/dae/dae/person_sets.py
+++ b/dae/dae/person_sets.py
@@ -59,6 +59,8 @@ class PersonSet:
         self.persons: dict[tuple[str, str], Person] = persons
         self._children_by_sex: Optional[ChildrenBySex] = None
         self._children_stats: Optional[ChildrenStats] = None
+        self._children: Optional[list[Person]] = None
+        self._children_count: Optional[int] = None
 
     def __repr__(self) -> str:
         return f"PersonSet({self.id}: {self.name}, {len(self.persons)})"
@@ -66,10 +68,19 @@ class PersonSet:
     def __len__(self) -> int:
         return len(self.persons)
 
-    def get_children(self) -> Generator[Person, None, None]:
-        for person in self.persons.values():
-            if person.is_child():
-                yield person
+    def get_children(self) -> list[Person]:
+        """Return all children in the person set."""
+        if self._children is None:
+            self._children = []
+            for person in self.persons.values():
+                if person.is_child():
+                    self._children.append(person)
+        return self._children
+
+    def get_children_count(self) -> int:
+        if self._children_count is None:
+            self._children_count = len(self.get_children())
+        return self._children_count
 
     def get_children_by_sex(self) -> ChildrenBySex:
         """Return all children in the person set splitted by sex."""

--- a/dae/dae/task_graph/demo_graphs_cli.py
+++ b/dae/dae/task_graph/demo_graphs_cli.py
@@ -168,7 +168,7 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     parser.add_argument("graph", type=str, help="Demo graph",
                         default="A", nargs="?")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument("--graph-params", "-gp", type=str, nargs="+")
 

--- a/dae/dae/tools/cnv_liftover.py
+++ b/dae/dae/tools/cnv_liftover.py
@@ -29,7 +29,7 @@ def parse_cli_arguments(argv: list[str]) -> argparse.Namespace:
     """Create CLI parser."""
     parser = argparse.ArgumentParser(description="liftover CNV variants")
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     FamiliesLoader.cli_arguments(parser)
     CNVLoader.cli_arguments(parser)
 

--- a/dae/dae/tools/dae_liftover.py
+++ b/dae/dae/tools/dae_liftover.py
@@ -33,7 +33,7 @@ def parse_cli_arguments() -> argparse.ArgumentParser:
     """Create CLI parser."""
     parser = argparse.ArgumentParser(
         description="liftover denovo variants to hg38")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     FamiliesLoader.cli_arguments(parser)
     DaeTransmittedLoader.cli_arguments(parser)
 

--- a/dae/dae/tools/denovo_liftover.py
+++ b/dae/dae/tools/denovo_liftover.py
@@ -32,7 +32,7 @@ def parse_cli_arguments(argv: list[str]) -> argparse.Namespace:
     """Create CLI parser."""
     parser = argparse.ArgumentParser(description="liftover denovo variants")
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     FamiliesLoader.cli_arguments(parser)
     DenovoLoader.cli_arguments(parser)
 

--- a/dae/dae/tools/generate_denovo_gene_sets.py
+++ b/dae/dae/tools/generate_denovo_gene_sets.py
@@ -14,7 +14,7 @@ def main(
     """Generate denovo gene sets CLI."""
     description = "Generate genovo gene sets tool"
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--show-studies",

--- a/dae/dae/tools/gpf_convert_study_config.py
+++ b/dae/dae/tools/gpf_convert_study_config.py
@@ -28,7 +28,7 @@ def main(
     """Convert GPF genotype data configuration to YAML."""
     description = "Tool to convert GPF genotype data configuration to YAML"
     parser = argparse.ArgumentParser(description=description)
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--show-studies",

--- a/dae/dae/tools/gpf_instance_adjustments.py
+++ b/dae/dae/tools/gpf_instance_adjustments.py
@@ -332,7 +332,7 @@ def cli(argv: Optional[list[str]] = None) -> None:
     argv = argv or sys.argv[1:]
     parser = argparse.ArgumentParser(
         description="adjustments in GPF instance configuration")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     parser.add_argument("-i", "--instance", type=str, default=None)
 
     subparsers = parser.add_subparsers(dest="command",

--- a/dae/dae/tools/gpf_validation_runner.py
+++ b/dae/dae/tools/gpf_validation_runner.py
@@ -912,7 +912,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         help="Comma separated list of columns to skip when comparing with "
         "expectations")
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     args = parser.parse_args(argv)
     if args.skip_columns is None:

--- a/dae/dae/tools/grr_cache_repo.py
+++ b/dae/dae/tools/grr_cache_repo.py
@@ -44,7 +44,7 @@ def cli_cache_repo(argv: Optional[list[str]] = None) -> None:
         "--annotation", "-a", default=None,
         help="annotation.yaml to use for selective cache"
     )
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     args = parser.parse_args(argv)
     VerbosityConfiguration.set(args)

--- a/dae/dae/tools/migrate_pheno_measures.py
+++ b/dae/dae/tools/migrate_pheno_measures.py
@@ -58,7 +58,7 @@ def main(  # pylint: disable=too-many-locals
         argv = sys.argv[1:]
 
     parser = measures_cli_parser()
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     args = parser.parse_args(argv)
     VerbosityConfiguration.set(args)

--- a/dae/dae/tools/ped2ped.py
+++ b/dae/dae/tools/ped2ped.py
@@ -66,7 +66,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     It should be called from the command line.
     """
     parser = argparse.ArgumentParser()
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     FamiliesLoader.cli_arguments(parser)
     VcfLoader.cli_arguments(parser, options_only=True)
     CLIGenomicContext.add_context_arguments(parser)

--- a/dae/dae/tools/simple_study_import.py
+++ b/dae/dae/tools/simple_study_import.py
@@ -49,7 +49,7 @@ def cli_arguments(
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     FamiliesLoader.cli_arguments(parser)
 
     parser.add_argument(

--- a/dae/dae/tools/stats_liftover.py
+++ b/dae/dae/tools/stats_liftover.py
@@ -21,7 +21,7 @@ def parse_cli_arguments():
     parser = argparse.ArgumentParser(
         description="merge liftover stats")
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--stats", help="filename to store liftover statistics",

--- a/dae/dae/utils/verbosity_configuration.py
+++ b/dae/dae/utils/verbosity_configuration.py
@@ -7,7 +7,7 @@ class VerbosityConfiguration:
     """Defines common configuration of verbosity for loggers."""
 
     @staticmethod
-    def set_argumnets(parser: argparse.ArgumentParser) -> None:
+    def set_arguments(parser: argparse.ArgumentParser) -> None:
         """Add verbosity arguments to argument parser."""
         parser.add_argument("--verbose", "-v", "-V", action="count", default=0)
 

--- a/impala_storage/impala_storage/tools/impala_tables_stats.py
+++ b/impala_storage/impala_storage/tools/impala_tables_stats.py
@@ -24,7 +24,7 @@ def parse_cli_arguments(argv: list[str]) -> argparse.Namespace:
         conflict_handler="resolve",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     parser.add_argument(
         "--studies",

--- a/impala_storage/impala_storage/tools/impala_tables_summary_variants.py
+++ b/impala_storage/impala_storage/tools/impala_tables_summary_variants.py
@@ -29,7 +29,7 @@ def parse_cli_arguments(
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
     parser.add_argument(
         "--studies",
         type=str,

--- a/impala_storage/impala_storage/tools/ped2parquet.py
+++ b/impala_storage/impala_storage/tools/ped2parquet.py
@@ -15,7 +15,7 @@ def main(argv: list[str]) -> None:
     """Entry point for ped2parquet."""
     parser = argparse.ArgumentParser()
 
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     FamiliesLoader.cli_arguments(parser)
     parser.add_argument(

--- a/scripts/experimental_duckdb_queries.md
+++ b/scripts/experimental_duckdb_queries.md
@@ -2364,3 +2364,227 @@ JOIN family AS fa
   USING (bucket_index, summary_index, allele_index)
 LIMIT 10
 ```
+
+
+```sql
+EXPLAIN ANALYZE WITH summary AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies/AGRE_WG38_859/OUTPUT2.2/AGRE_WG38_CSHL_859_SCHEMA2/summary/*/*/*/*.parquet'
+  ) AS sa
+  WHERE
+    sa.allele_index > 0
+), family_bins AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies/AGRE_WG38_859/OUTPUT2.2/AGRE_WG38_CSHL_859_SCHEMA2/family/*/*/*/*/*.parquet'
+  ) AS fa
+  WHERE
+    fa.family_bin = 2
+), family AS (
+  SELECT
+    *
+  FROM family_bins AS fa
+  WHERE
+    fa.family_id IN ('AU1213202_AU1213201')
+    AND fa.allele_index > 0
+)
+SELECT
+  fa.bucket_index,
+  fa.summary_index,
+  fa.family_index,
+  sa.allele_index,
+  sa.summary_variant_data,
+  fa.family_variant_data
+FROM summary AS sa
+JOIN family AS fa
+  USING (sj_index, region_bin)
+WHERE region_bin = 'chr1_0'
+LIMIT 10010
+```
+
+
+```sql
+EXPLAIN ANALYZE WITH summary AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies/AGRE_WG38_859/OUTPUT2.2/AGRE_WG38_CSHL_859_SCHEMA2/summary/*/*/*/*.parquet'
+  ) AS sa
+  WHERE
+    sa.allele_index > 0
+), family_bins AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies/AGRE_WG38_859/OUTPUT2.2/AGRE_WG38_CSHL_859_SCHEMA2/family/*/*/*/*/*.parquet'
+  ) AS fa
+), family AS (
+  SELECT
+    *
+  FROM family_bins AS fa
+  WHERE
+    fa.allele_index > 0
+)
+SELECT
+  fa.bucket_index,
+  fa.summary_index,
+  fa.family_index,
+  sa.allele_index,
+  sa.summary_variant_data,
+  fa.family_variant_data
+FROM summary AS sa
+JOIN family AS fa
+  USING (sj_index, region_bin)
+WHERE region_bin = 'chr1_0'
+LIMIT 10010
+```
+
+```sql
+EXPLAIN WITH summary AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies/AGRE_WG38_859/OUTPUT2.2/AGRE_WG38_CSHL_859_SCHEMA2/summary/*/*/*/*.parquet'
+  ) AS sa
+  WHERE
+    sa.allele_index > 0
+), family AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies/AGRE_WG38_859/OUTPUT2.2/AGRE_WG38_CSHL_859_SCHEMA2/family/*/*/*/*/*.parquet'
+  ) AS fa
+  WHERE fa.allele_index > 0
+)
+SELECT
+  fa.bucket_index,
+  fa.summary_index,
+  fa.family_index,
+  sa.allele_index,
+  sa.summary_variant_data,
+  fa.family_variant_data
+FROM summary AS sa
+JOIN family AS fa
+  USING (region_bin, sj_index)
+LIMIT 10
+```
+
+```sql
+EXPLAIN WITH summary AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies_liftover/w1202s766e611_liftover/OUTPUT2.4/w1202s766e611_liftover/summary/*/*/*/*.parquet'
+  ) AS sa
+  WHERE
+    sa.allele_index > 0
+), family AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies_liftover/w1202s766e611_liftover/OUTPUT2.4/w1202s766e611_liftover/family/*/*/*/*/*.parquet'
+  ) AS fa
+  WHERE fa.allele_index > 0
+)
+SELECT
+  fa.bucket_index,
+  fa.summary_index,
+  fa.family_index,
+  sa.allele_index,
+  sa.summary_variant_data,
+  fa.family_variant_data
+FROM summary AS sa
+JOIN family AS fa
+  USING (region_bin, sj_index)
+LIMIT 10
+```
+
+```sql
+EXPLAIN WITH summary AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies_liftover/w1202s766e611_liftover/OUTPUT2.4/w1202s766e611_liftover/summary/*/*/*/*.parquet'
+  ) AS sa
+  WHERE
+    sa.allele_index > 0
+), family AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies_liftover/w1202s766e611_liftover/OUTPUT2.4/w1202s766e611_liftover/family/*/*/*/*/*.parquet'
+  ) AS fa
+  WHERE fa.allele_index > 0
+), family_variants(sv_data, fv_data) AS (
+    SELECT
+        sa.summary_variant_data,
+        fa.family_variant_data,
+    FROM summary AS sa
+    JOIN family AS fa
+    USING (region_bin, sj_index)
+    WHERE region_bin = 'chr1_0'
+)
+SELECT sv_data, fv_data 
+FROM family_variants
+LIMIT 10;
+```
+
+```sql
+WITH RECURSIVE cte_numbers(n, weekday) 
+AS (
+    SELECT 
+        0, 
+        't'
+    UNION ALL
+    SELECT    
+        n + 1, 
+        't'
+    FROM    
+        cte_numbers
+    WHERE n < 6
+)
+SELECT 
+    weekday
+FROM 
+    cte_numbers;
+```
+
+
+```sql
+WITH summary AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies_liftover/w1202s766e611_liftover/OUTPUT2.4/w1202s766e611_liftover/summary/*/*/*/*.parquet'
+  ) AS sa
+  WHERE
+    sa.allele_index > 0
+), family AS (
+  SELECT
+    *
+  FROM PARQUET_SCAN(
+    '/data/lubo/seq-pipeline/sequencing-de-novo/gpf_validation_data/data_hg38/studies_liftover/w1202s766e611_liftover/OUTPUT2.4/w1202s766e611_liftover/family/*/*/*/*/*.parquet'
+  ) AS fa
+  WHERE fa.allele_index > 0
+), RECURSIVE family_variants(sv_data, fv_data, regions) AS (
+    SELECT
+        sa.summary_variant_data as sv_data,
+        fa.family_variant_data as fv_data,
+        (select (['chr1_0', 'chr2_0', 'chr3_0'])) as regions
+    FROM summary AS sa
+    JOIN family AS fa
+    USING (region_bin, sj_index)
+    WHERE region_bin = regions[1]
+    UNION ALL
+    SELECT sv_data, fv_data, regions[2:]
+    FROM family_variants
+    WHERE length(regions) > 0
+)
+SELECT sv_data, fv_data 
+FROM family_variants
+LIMIT 10;
+
+```

--- a/wdae/wdae/wdae/wgpf.py
+++ b/wdae/wdae/wdae/wgpf.py
@@ -149,7 +149,7 @@ def cli(argv: Optional[list[str]] = None) -> None:
     parser.add_argument(
         "--version", action="store_true", default=False,
         help="Prints GPF version and exists.")
-    VerbosityConfiguration.set_argumnets(parser)
+    VerbosityConfiguration.set_arguments(parser)
 
     commands_parser = parser.add_subparsers(
         dest="command", help="Command to execute")


### PR DESCRIPTION
## Background

Calculation of gene profiles cache for production HG38 data takes ~4.5 hours.

## Aim

We want to make the calculation of these gene profile caches faster.

## Implementation

The implementation of `PersonSet.get_children()` changed to cache the result. A new `PersonSet.get_children_count()` method was added to return the number of children used in the calculation of variant rates.

After this change, the calculation of the gene profiles cache takes ~1 hour.