### PR TITLE
update response transformer genes to be only ones with worst effect

### DIFF
--- a/dae/dae/effect_annotation/effect.py
+++ b/dae/dae/effect_annotation/effect.py
@@ -847,6 +847,21 @@ def gene_effect_get_worst_effect(
     return ",".join([gene_effects.worst])
 
 
+def gene_effect_get_genes_worst(
+    gene_effects: Optional[AlleleEffects]
+) -> str:
+    """Return command separted list of genes."""
+    if gene_effects is None:
+        return ""
+    genes_set: set[str] = set(
+        x.symbol for x in gene_effects.genes
+        if x.symbol is not None and x.effect == gene_effects.worst
+    )
+    genes = sorted(list(genes_set))
+
+    return ";".join(genes)
+
+
 def gene_effect_get_genes(
     gene_effects: Optional[AlleleEffects]
 ) -> str:

--- a/dae/dae/effect_annotation/effect.py
+++ b/dae/dae/effect_annotation/effect.py
@@ -850,7 +850,7 @@ def gene_effect_get_worst_effect(
 def gene_effect_get_genes_worst(
     gene_effects: Optional[AlleleEffects]
 ) -> str:
-    """Return command separted list of genes."""
+    """Return comma separted list of genes."""
     if gene_effects is None:
         return ""
     genes_set: set[str] = set(
@@ -865,7 +865,7 @@ def gene_effect_get_genes_worst(
 def gene_effect_get_genes(
     gene_effects: Optional[AlleleEffects]
 ) -> str:
-    """Return command separted list of genes."""
+    """Return comma separted list of genes."""
     if gene_effects is None:
         return ""
     genes_set: set[str] = set(

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -9,7 +9,7 @@ from typing import Optional, Any, Union, Generator, Iterator, Iterable, \
 from dae.utils.dae_utils import join_line, split_iterable
 from dae.utils.variant_utils import mat2str, fgt2str
 from dae.effect_annotation.effect import ge2str, \
-    gd2str, \
+    gd2str, gene_effect_get_genes_worst, \
     gene_effect_get_worst_effect, \
     gene_effect_get_genes
 from dae.variants.attributes import Inheritance
@@ -117,7 +117,7 @@ class ResponseTransformer:
         lambda v: [repr(e) for e in v.effects],
 
         "genes":
-        lambda v: [gene_effect_get_genes(e) for e in v.effects],
+        lambda v: [gene_effect_get_genes_worst(e) for e in v.effects],
 
         "worst_effect":
         lambda v: [gene_effect_get_worst_effect(e) for e in v.effects],

--- a/wdae/wdae/studies/response_transformer.py
+++ b/wdae/wdae/studies/response_transformer.py
@@ -125,6 +125,14 @@ class ResponseTransformer:
         "effect_details":
         lambda v: [gd2str(e) for e in v.effects],
 
+        "full_effect_details":
+        lambda v: (
+            [v.family_id]
+            + v.cshl_location
+            + [gd2str(e) for e in v.effects]
+            + [ge2str(e) for e in v.effects]
+        ),
+
         "seen_in_affected":
         lambda v: bool(v.get_attribute("seen_in_status") in {2, 3}),
 


### PR DESCRIPTION
## Background
Genes shown in genotype browser effect column are not only the ones that have the worst effect shown in the same column.

## Aim
Update response transformer genes to be the only ones that have the worst effect.
