### PR TITLE
Dataset description hierarchy

### DIFF
--- a/dae_conftests/dae_conftests/tests/fixtures/gpf_instance.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/gpf_instance.yaml
@@ -92,3 +92,8 @@ enrichment:
 gpfjs:
   permission_denied_prompt_file: "permissionDeniedPrompt.md"
 
+gpfjs:
+  visible_datasets:
+  - Dataset1
+  - Study1
+  - Study3

--- a/dae_conftests/dae_conftests/tests/fixtures/gpf_instance.yaml
+++ b/dae_conftests/dae_conftests/tests/fixtures/gpf_instance.yaml
@@ -91,8 +91,6 @@ enrichment:
 
 gpfjs:
   permission_denied_prompt_file: "permissionDeniedPrompt.md"
-
-gpfjs:
   visible_datasets:
   - Dataset1
   - Study1

--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
+from pprint import pprint
 
 import pytest
 from django.test.client import Client
@@ -59,6 +60,27 @@ def test_datasets_api_get_404(admin_client: Client) -> None:
 
     data = response.data  # type: ignore
     assert data["error"] == "Dataset alabala not found"
+
+
+def test_datasets_api_get_dataset_with_hierarchy_description(admin_client: Client) -> None:
+    response = admin_client.get("/api/v3/datasets/Dataset1")
+
+    assert response
+    data = response.data  # type: ignore
+    pprint(data["data"]["description"])
+    assert data["data"]["description"] == (
+         '\n- **<a href="datasets/Study1">Study1</a>**'
+         '\n- **<a href="datasets/Study3">Study3</a>**'
+    )
+
+    response = admin_client.get("/api/v3/datasets/Study1")
+
+    assert response
+    data = response.data  # type: ignore
+    pprint(data["data"]["description"])
+    assert data["data"]["description"] == (
+        "some new description"
+    )
 
 
 def test_datasets_api_get_forbidden(user_client: Client) -> None:

--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -62,24 +62,17 @@ def test_datasets_api_get_404(admin_client: Client) -> None:
     assert data["error"] == "Dataset alabala not found"
 
 
-def test_datasets_api_get_dataset_with_hierarchy_description(admin_client: Client) -> None:
+def test_datasets_api_get_dataset_with_hierarchy_description(
+    admin_client: Client
+) -> None:
     response = admin_client.get("/api/v3/datasets/Dataset1")
 
     assert response
     data = response.data  # type: ignore
-    pprint(data["data"]["description"])
-    assert data["data"]["description"] == (
-         '\n- **<a href="datasets/Study1">Study1</a>**'
-         '\n- **<a href="datasets/Study3">Study3</a>**'
-    )
-
-    response = admin_client.get("/api/v3/datasets/Study1")
-
-    assert response
-    data = response.data  # type: ignore
-    pprint(data["data"]["description"])
-    assert data["data"]["description"] == (
-        "some new description"
+    assert data["data"]["children_description"] == (
+        "\nThis dataset includes:\n"
+        "- **[Study1](Study1)** some new description\n\n"
+        "- **[Study3](Study3)** \n"
     )
 
 
@@ -245,6 +238,7 @@ def test_datasets_hierarchy(
 
     data = response.data  # type: ignore
     assert data
+    pprint(data)
     assert len(data["data"]) == 22
     dataset1 = next(filter(
         lambda x: x["dataset"] == "Dataset1", data["data"],

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -1,8 +1,7 @@
 import logging
 import os
 import re
-from pprint import pprint
-from typing import Any, Optional, cast
+from typing import Any, Optional, Union, cast
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -67,10 +66,15 @@ def produce_description_hierarchy(
         indent = "\t" * indent_level
         for child in dataset.studies:
             if child.study_id in selected:
+                child_descriptions = produce_description_hierarchy(
+                    child,
+                    selected,
+                    indent_level + 1
+                )
                 res.append(
                     f"{indent}- **[{child.name}]({child.study_id})** "
                     f"{get_first_paragraph(child.description)}\n"
-                    f"{produce_description_hierarchy(child, selected, indent_level+1)}"
+                    f"{child_descriptions}"
                 )
         return "\n".join(res)
 
@@ -78,7 +82,7 @@ def produce_description_hierarchy(
 
 
 def get_first_paragraph(
-    text: str | None,
+    text: Union[str, None],
 ) -> str:
     """Get first paragraph of text."""
     result = ""

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -82,15 +82,16 @@ def produce_description_hierarchy(
 def get_first_paragraph(
     text: str,
 ) -> str:
-    if not text:
-        return ""
-
-    paragraphs = text.split("\n\n")
-    if "#" in paragraphs[0]:
-        title_match = re.match("^##((?:\n|.)*?)$\n", paragraphs[0])
-        return re.sub("^##((?:\n|.)*?)$\n", paragraphs[0]) if title_match else paragraphs[1]
-
-    return paragraphs[0]
+    result = ""
+    if text:
+        paragraphs = text.split("\n\n")
+        if "#" in paragraphs[0]:
+            title_match = re.match("^##((?:\n|.)*?)$\n", paragraphs[0])
+            result = re.sub("^##((?:\n|.)*?)$\n", paragraphs[0]) if title_match else paragraphs[1]
+        else: 
+            result = paragraphs[0]
+    
+    return result.replace("\n", " ")
 
 
 class DatasetView(QueryBaseView):
@@ -169,7 +170,7 @@ class DatasetView(QueryBaseView):
             else dataset.remote_genotype_data
         if dataset.is_group:
             genotype_data_ids = self.gpf_instance.get_genotype_data_ids()
-            res["children_description"] = "\n\nThis dataset includes:" \
+            res["children_description"] = "\nThis dataset includes:" \
                 + produce_description_hierarchy(
                     rawStudy,
                     genotype_data_ids


### PR DESCRIPTION
## Background
Add to dataset description children study short descriptions. 

## Aim
Add new children description section to dataset api. Populate the description with the first paragraph of the study's child studies (and their children), in such a way that the hierarchy between groups/studies is clearly visible.

## Implementation
Recursively pick first paragraph of every child study/group and show their hierarchy by increasing tabulation of paragraph depending how deep it is.

## Related branches
https://github.com/iossifovlab/gpfjs/tree/dataset-description-hierarchy

