### PR TITLE
Pheno fixes

### DIFF
--- a/dae/dae/pheno/prepare/measure_classifier.py
+++ b/dae/dae/pheno/prepare/measure_classifier.py
@@ -405,7 +405,7 @@ class MeasureClassifier:
                 cursor, table_name, measure_name, column_type, report,
             )
 
-        if column_type in ["VARCHAR", "DATE"]:
+        if column_type in ["VARCHAR", "DATE", "TIMESTAMP"]:
             return MeasureClassifier._meta_measures_text(
                 cursor, table_name, measure_name, report,
             )

--- a/dae/dae/pheno/prepare/pheno_prepare.py
+++ b/dae/dae/pheno/prepare/pheno_prepare.py
@@ -543,6 +543,7 @@ class PrepareVariables(PreparePersons):
         tmp_table_name = self._instrument_tmp_table_name("pheno_common")
         cursor = self.connection.cursor()
 
+        cursor.sql("SET GLOBAL pandas_analyze_sample=100000")
         cursor.sql(
             f"CREATE TABLE {tmp_table_name} AS "
             "SELECT * FROM pheno_common_df",


### PR DESCRIPTION
## Background
When importing new phenotype studies, 2 new issues were discovered. Sometimes when scanning the pheno_common instrument PDF, a column would have its type misidentified, making the study unimportable. A new study when imported had the TIMESTAMP type, which was not handled and broke the import

## Aim
Fix these 2 issues

