### PR TITLE
Pedigree only import support

### DIFF
--- a/dae/dae/duckdb_storage/duckdb_import_storage.py
+++ b/dae/dae/duckdb_storage/duckdb_import_storage.py
@@ -47,7 +47,10 @@ class DuckDbImportStorage(Schema2ImportStorage):
         study_config.update({
             "genotype_storage": {
                 "id": genotype_storage.storage_id,
-                "tables": {"pedigree": study_tables.pedigree},
+                "tables": {
+                    "pedigree": study_tables.pedigree,
+                    "meta": study_tables.meta
+                },
             },
             "genotype_browser": {"enabled": False},
         })

--- a/dae/dae/duckdb_storage/duckdb_import_storage.py
+++ b/dae/dae/duckdb_storage/duckdb_import_storage.py
@@ -21,7 +21,9 @@ class DuckDbImportStorage(Schema2ImportStorage):
             cls, project: ImportProject) -> Schema2DatasetLayout:
         genotype_storage = project.get_genotype_storage()
         assert isinstance(genotype_storage, DuckDbGenotypeStorage)
-        layout = schema2_dataset_layout(project.get_parquet_dataset_dir())
+        layout = schema2_dataset_layout(
+            project.get_parquet_dataset_dir(), existing=True
+        )
         return genotype_storage.import_dataset(
             project.study_id, layout, project.get_partition_descriptor())
 

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -35,11 +35,13 @@ class Schema2DatasetLayout:
 
 
 def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
+    summary = fs_utils.join(study_dir, "summary")
+    family = fs_utils.join(study_dir, "family")
     return Schema2DatasetLayout(
         study_dir,
         fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),
-        fs_utils.join(study_dir, "summary"),
-        fs_utils.join(study_dir, "family"),
+        summary if fs_utils.exists(summary) else None,
+        family if fs_utils.exists(family) else None,
         fs_utils.join(study_dir, "meta", "meta.parquet"))
 
 

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -34,14 +34,25 @@ class Schema2DatasetLayout:
     base_dir: Optional[str] = None
 
 
-def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
+def schema2_dataset_layout(
+    study_dir: str, existing: bool = False
+) -> Schema2DatasetLayout:
+    """
+    Create dataset layout for a given directory.
+
+    Existing flag should be used depending on whether this directory is
+    already created and being read or being created at the moment.
+    """
     summary = fs_utils.join(study_dir, "summary")
     family = fs_utils.join(study_dir, "family")
+    if existing:
+        summary = summary if fs_utils.exists(summary) else None
+        family = family if fs_utils.exists(family) else None
     return Schema2DatasetLayout(
         study_dir,
         fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),
-        summary if fs_utils.exists(summary) else None,
-        family if fs_utils.exists(family) else None,
+        summary,
+        family,
         fs_utils.join(study_dir, "meta", "meta.parquet"))
 
 

--- a/dae/dae/testing/import_helpers.py
+++ b/dae/dae/testing/import_helpers.py
@@ -128,6 +128,24 @@ def setup_import_project(
     return project
 
 
+def pedigree_import(
+    root_path: pathlib.Path,
+    study_id: str,
+    ped_path: pathlib.Path,
+    gpf_instance: GPFInstance,
+    project_config_update: Optional[dict[str, Any]] = None,
+    project_config_overwrite: Optional[dict[str, Any]] = None,
+    project_config_replace: Optional[dict[str, Any]] = None,
+) -> ImportProject:
+    """Import a VCF study and return the import project."""
+    study = StudyInputLayout(study_id, ped_path, [], [], [], [])
+    return setup_import_project(
+        root_path, study, gpf_instance,
+        project_config_update=project_config_update,
+        project_config_overwrite=project_config_overwrite,
+        project_config_replace=project_config_replace)
+
+
 def vcf_import(
     root_path: pathlib.Path,
     study_id: str,

--- a/dae/tests/integration/import_tools/test_pedigree_only_import.py
+++ b/dae/tests/integration/import_tools/test_pedigree_only_import.py
@@ -1,0 +1,64 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import pathlib
+
+import pytest
+from dae.testing.import_helpers import StudyInputLayout, pedigree_import
+from dae.testing import alla_gpf, setup_pedigree
+from dae.genotype_storage.genotype_storage import GenotypeStorage
+from dae.gpf_instance.gpf_instance import GPFInstance
+from dae.import_tools.cli import run_with_project
+from dae.import_tools.import_tools import ImportProject
+
+@pytest.fixture(scope="module")
+def pedigree_only_import_data(
+    tmp_path_factory: pytest.TempPathFactory,
+    genotype_storage: GenotypeStorage,
+) -> tuple[pathlib.Path, GPFInstance, StudyInputLayout]:
+    root_path = tmp_path_factory.mktemp(
+        f"pedigree_dataset_{genotype_storage.storage_id}")
+
+    gpf_instance = alla_gpf(root_path)
+
+    if genotype_storage:
+        gpf_instance\
+            .genotype_storages\
+            .register_default_storage(genotype_storage)
+
+    ped_path = setup_pedigree(
+        root_path / "vcf_data" / "in.ped",
+        """
+        familyId personId dadId	 momId	sex status role
+        f1       m1       0      0      2   1      mom
+        f1       d1       0      0      1   1      dad
+        f1       p1       d1     m1     1   2      prb
+        """)
+
+    return root_path, gpf_instance, StudyInputLayout(
+        "pedigree_dataset", ped_path, [], [], [], [])
+
+@pytest.fixture(scope="module")
+def pedigree_only_project(
+    tmp_path_factory: pytest.TempPathFactory,
+    pedigree_only_import_data: tuple[pathlib.Path, GPFInstance, StudyInputLayout],
+    genotype_storage: GenotypeStorage,
+) -> ImportProject:
+    root_path, gpf_instance, layout = pedigree_only_import_data
+
+    project = pedigree_import(
+        root_path,
+        "pedigree_dataset", layout.pedigree,
+        gpf_instance,
+    )
+    return project
+
+def test_pedigree_only_import(
+    pedigree_only_project: ImportProject,
+    genotype_storage: GenotypeStorage,
+) -> None:
+
+    run_with_project(pedigree_only_project)
+
+    gpf_instance = pedigree_only_project.get_gpf_instance()
+    gpf_instance.reload()
+    study = gpf_instance.get_genotype_data("pedigree_dataset")
+    assert study is not None


### PR DESCRIPTION
## Background
When using import projects, importing studies with only pedigree data was erroneous. We want to support this to import studies from phenotype data for previewing pheno data only.

## Aim
Fix and add tests for pedigree only imports

## Implementation
Duckdb imports were missing a table in one case and always assumed variants tables would be present, despite actually being programmed to handle cases without variants tables.