### PR TITLE
Fix impala storage pedigree only

### DIFF
--- a/dae/dae/import_tools/import_tools.py
+++ b/dae/dae/import_tools/import_tools.py
@@ -357,8 +357,10 @@ class ImportProject:
         )
 
     def has_variants(self) -> bool:
-        # FIXME: this method should check if the input has variants
-        return True
+        for key in ["vcf", "denovo", "cnv", "dae"]:
+            if key in self.import_config["input"]:
+                return True
+        return False
 
     @property
     def study_id(self) -> str:

--- a/dae/dae/query_variants/sql/schema2/base_variants.py
+++ b/dae/dae/query_variants/sql/schema2/base_variants.py
@@ -47,25 +47,27 @@ class SqlSchema2Variants(QueryVariantsBase):
         self.db = db
         self.family_variant_table = family_variant_table
         self.summary_allele_table = summary_allele_table
+        self.has_variants = self.summary_allele_table is not None
         self.pedigree_table = pedigree_table
         self.meta_table = meta_table
         self.gene_models = gene_models
-
-        self.summary_allele_schema = self._fetch_summary_schema()
-        self.family_variant_schema = self._fetch_family_schema()
-
-        self.combined_columns = {
-            **self.family_variant_schema,
-            **self.summary_allele_schema,
-        }
 
         self.pedigree_schema = self._fetch_schema(self.pedigree_table)
         ped_df = self._fetch_pedigree()
         self.families = FamiliesLoader\
             .build_families_data_from_pedigree(ped_df)
 
-        self.partition_descriptor = PartitionDescriptor.parse_string(
-            self._fetch_tblproperties())
+        if self.has_variants:
+            self.summary_allele_schema = self._fetch_summary_schema()
+            self.family_variant_schema = self._fetch_family_schema()
+
+            self.combined_columns = {
+                **self.family_variant_schema,
+                **self.summary_allele_schema,
+            }
+
+            self.partition_descriptor = PartitionDescriptor.parse_string(
+                self._fetch_tblproperties())
 
     def _fetch_summary_schema(self) -> dict[str, str]:
         assert self.summary_allele_table is not None

--- a/impala2_storage/impala2_storage/schema2/impala2_import_storage.py
+++ b/impala2_storage/impala2_storage/schema2/impala2_import_storage.py
@@ -55,10 +55,14 @@ class Impala2ImportStorage(Schema2ImportStorage):
         # pylint: disable=protected-access
         pedigree_table = genotype_storage\
             ._construct_pedigree_table(project.study_id)
-        summary_table, family_table = genotype_storage\
-            ._construct_variant_tables(project.study_id)
-        meta_table = genotype_storage\
-            ._construct_metadata_table(project.study_id)
+        if project.has_variants():
+            summary_table, family_table = genotype_storage\
+                ._construct_variant_tables(project.study_id)
+            meta_table = genotype_storage\
+                ._construct_metadata_table(project.study_id)
+        else:
+            summary_table, family_table = (None, None)
+            meta_table = None
 
         if project.get_processing_parquet_dataset_dir() is not None:
             meta = cls.load_meta(project)

--- a/impala2_storage/impala2_storage/schema2/impala2_import_storage.py
+++ b/impala2_storage/impala2_storage/schema2/impala2_import_storage.py
@@ -30,7 +30,8 @@ class Impala2ImportStorage(Schema2ImportStorage):
             project.study_id,
             layout.study,
             layout.pedigree,
-            layout.meta)
+            layout.meta,
+            has_variants=project.has_variants())
 
     @classmethod
     def _do_load_in_impala(

--- a/impala_storage/impala_storage/schema1/impala_genotype_storage.py
+++ b/impala_storage/impala_storage/schema1/impala_genotype_storage.py
@@ -281,7 +281,7 @@ class ImpalaGenotypeStorage(GenotypeStorage):
         return local_variants_files, hdfs_variants_dir, hdfs_variants_files
 
     def _native_hdfs_upload_dataset(
-        self, study_id: str, variants_dir: str,
+        self, study_id: str, variants_dir: Optional[str],
         pedigree_file: str, partition_description: PartitionDescriptor,
     ) -> tuple[str, str, str]:
 
@@ -389,7 +389,7 @@ class ImpalaGenotypeStorage(GenotypeStorage):
             self._build_hdfs_pedigree(study_id, pedigree_file))
 
     def hdfs_upload_dataset(
-        self, study_id: str, variants_dir: str,
+        self, study_id: str, variants_dir: Optional[str],
         pedigree_file: str,
         partition_description: PartitionDescriptor,
     ) -> tuple[str, str, str]:

--- a/impala_storage/impala_storage/schema1/impala_schema1.py
+++ b/impala_storage/impala_storage/schema1/impala_schema1.py
@@ -145,7 +145,8 @@ class ImpalaSchema1ImportStorage(ImportStorage):
         partition_description = cls._get_partition_description(project)
 
         pedigree_file = cls._pedigree_filename(project)
-        variants_dir = cls._variants_dir if project.has_variants() else None
+        variants_dir = cls._variants_dir(project) \
+            if project.has_variants() else None
         cast(ImpalaGenotypeStorage, genotype_storage).hdfs_upload_dataset(
             project.study_id,
             variants_dir,


### PR DESCRIPTION
## Background
Impala storage imports were broken with pedigree only studies.

## Aim
Fix importing of pedigree only studies in schema1 and schema2 impala storages.

## Implementation
An old helper method was finished in import projects for detecting whether an import project has variants. This is used to disable the variant import parts of schema1 and schema2 imports and study loading has been adjusted where needed to check whether variants are present.