### PR TITLE
Fix impala2 import

### DIFF
--- a/dae/dae/annotation/annotate_schema2_parquet.py
+++ b/dae/dae/annotation/annotate_schema2_parquet.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import pathlib
 import sys
 from glob import glob
 from typing import Optional
@@ -18,7 +17,9 @@ from dae.parquet.parquet_writer import (
 )
 from dae.parquet.partition_descriptor import PartitionDescriptor
 from dae.parquet.schema2.parquet_io import VariantsParquetWriter
-from dae.schema2_storage.schema2_import_storage import schema2_dataset_layout
+from dae.schema2_storage.schema2_import_storage import (
+    create_schema2_dataset_layout,
+)
 from dae.task_graph.cli_tools import TaskGraphCli
 from dae.variants_loaders.parquet.loader import ParquetLoader
 
@@ -123,7 +124,7 @@ class AnnotateSchema2ParquetTool(AnnotationTool):
 
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
-        layout = schema2_dataset_layout(output_dir)
+        layout = create_schema2_dataset_layout(output_dir)
 
         if loader.layout.summary is None:
             raise ValueError("Invalid summary dir in input layout!")

--- a/dae/dae/duckdb_storage/duckdb_import_storage.py
+++ b/dae/dae/duckdb_storage/duckdb_import_storage.py
@@ -8,7 +8,7 @@ from dae.import_tools.import_tools import ImportProject, save_study_config
 from dae.schema2_storage.schema2_import_storage import (
     Schema2DatasetLayout,
     Schema2ImportStorage,
-    schema2_dataset_layout,
+    load_schema2_dataset_layout,
 )
 from dae.task_graph.graph import TaskGraph
 
@@ -21,8 +21,8 @@ class DuckDbImportStorage(Schema2ImportStorage):
             cls, project: ImportProject) -> Schema2DatasetLayout:
         genotype_storage = project.get_genotype_storage()
         assert isinstance(genotype_storage, DuckDbGenotypeStorage)
-        layout = schema2_dataset_layout(
-            project.get_parquet_dataset_dir(), existing=True
+        layout = load_schema2_dataset_layout(
+            project.get_parquet_dataset_dir()
         )
         return genotype_storage.import_dataset(
             project.study_id, layout, project.get_partition_descriptor())

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -21,7 +21,7 @@ from dae.parquet.schema2.serializers import AlleleParquetSerializer
 from dae.task_graph.graph import Task, TaskGraph
 from dae.utils import fs_utils
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -41,11 +41,11 @@ def load_schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
     Assumes that the dataset already exists, therefore it should check whether
     summary and family tables exist.
     """
-    summary = fs_utils.join(study_dir, "summary")
-    summary = summary if fs_utils.exists(summary) else None
+    summary_path = fs_utils.join(study_dir, "summary")
+    summary = summary_path if fs_utils.exists(summary_path) else None
 
-    family = fs_utils.join(study_dir, "family")
-    family = family if fs_utils.exists(family) else None
+    family_path = fs_utils.join(study_dir, "family")
+    family = family_path if fs_utils.exists(family_path) else None
 
     return Schema2DatasetLayout(
         study_dir,
@@ -54,9 +54,8 @@ def load_schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
         family,
         fs_utils.join(study_dir, "meta", "meta.parquet"))
 
-def schema2_dataset_layout(
-    study_dir: str
-) -> Schema2DatasetLayout:
+
+def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
     """
     Create dataset layout for a given directory.
 

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -55,12 +55,11 @@ def load_schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
         fs_utils.join(study_dir, "meta", "meta.parquet"))
 
 
-def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
+def create_schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
     """
     Create dataset layout for a given directory.
 
-    Existing flag should be used depending on whether this directory is
-    already created and being read or being created at the moment.
+    Used for creating new datasets, where all tables should exist.
     """
     summary = fs_utils.join(study_dir, "summary")
     family = fs_utils.join(study_dir, "family")
@@ -75,7 +74,7 @@ def schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
 def schema2_project_dataset_layout(
         project: ImportProject) -> Schema2DatasetLayout:
     study_dir = fs_utils.join(project.work_dir, project.study_id)
-    return schema2_dataset_layout(study_dir)
+    return create_schema2_dataset_layout(study_dir)
 
 
 class Schema2ImportStorage(ImportStorage):
@@ -310,7 +309,7 @@ class Schema2ImportStorage(ImportStorage):
         parquet_dir = project.get_parquet_dataset_dir()
         if parquet_dir is None:
             raise ValueError("parquet dataset not stored: {project.study_id}")
-        layout = schema2_dataset_layout(parquet_dir)
+        layout = create_schema2_dataset_layout(parquet_dir)
 
         table = pq.read_table(layout.meta)
         result = {}

--- a/dae/dae/schema2_storage/schema2_import_storage.py
+++ b/dae/dae/schema2_storage/schema2_import_storage.py
@@ -34,8 +34,28 @@ class Schema2DatasetLayout:
     base_dir: Optional[str] = None
 
 
+def load_schema2_dataset_layout(study_dir: str) -> Schema2DatasetLayout:
+    """
+    Create dataset layout for a given directory.
+
+    Assumes that the dataset already exists, therefore it should check whether
+    summary and family tables exist.
+    """
+    summary = fs_utils.join(study_dir, "summary")
+    summary = summary if fs_utils.exists(summary) else None
+
+    family = fs_utils.join(study_dir, "family")
+    family = family if fs_utils.exists(family) else None
+
+    return Schema2DatasetLayout(
+        study_dir,
+        fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),
+        summary,
+        family,
+        fs_utils.join(study_dir, "meta", "meta.parquet"))
+
 def schema2_dataset_layout(
-    study_dir: str, existing: bool = False
+    study_dir: str
 ) -> Schema2DatasetLayout:
     """
     Create dataset layout for a given directory.
@@ -45,9 +65,6 @@ def schema2_dataset_layout(
     """
     summary = fs_utils.join(study_dir, "summary")
     family = fs_utils.join(study_dir, "family")
-    if existing:
-        summary = summary if fs_utils.exists(summary) else None
-        family = family if fs_utils.exists(family) else None
     return Schema2DatasetLayout(
         study_dir,
         fs_utils.join(study_dir, "pedigree", "pedigree.parquet"),

--- a/dae/dae/schema2_storage/tests/test_schema2_import_storage.py
+++ b/dae/dae/schema2_storage/tests/test_schema2_import_storage.py
@@ -4,7 +4,7 @@ import pytest
 
 from dae.schema2_storage.schema2_import_storage import (
     Schema2DatasetLayout,
-    schema2_dataset_layout,
+    create_schema2_dataset_layout,
 )
 from dae.testing import acgt_gpf, setup_pedigree, setup_vcf
 from dae.testing.import_helpers import vcf_study
@@ -12,7 +12,7 @@ from dae.testing.import_helpers import vcf_study
 
 @pytest.fixture(scope="module")
 def import_data(
-    tmp_path_factory: pytest.TempPathFactory
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> Schema2DatasetLayout:
     root_path = tmp_path_factory.mktemp("import_data")
     gpf_instance = acgt_gpf(root_path)
@@ -43,7 +43,7 @@ chr3   1    .  A   G,TA .    .      .    GT     0/1  0/1  0/0
         gpf_instance,
         project_config_overwrite={"destination": {"storage_type": "schema2"}},
     )
-    return schema2_dataset_layout(f"{root_path}/work_dir/study")
+    return create_schema2_dataset_layout(f"{root_path}/work_dir/study")
 
 
 def test_schema2_import_metadata(import_data: Schema2DatasetLayout) -> None:

--- a/dae/dae/variants_loaders/parquet/loader.py
+++ b/dae/dae/variants_loaders/parquet/loader.py
@@ -15,7 +15,7 @@ from dae.pedigrees.families_data import FamiliesData
 from dae.pedigrees.loader import FamiliesLoader
 from dae.schema2_storage.schema2_import_storage import (
     Schema2DatasetLayout,
-    schema2_dataset_layout,
+    create_schema2_dataset_layout,
 )
 from dae.utils.regions import Region
 from dae.variants.attributes import Inheritance, Role, Sex, Status
@@ -139,7 +139,8 @@ class ParquetLoader:
 
     def __init__(self, data_dir: str):
         self.data_dir: str = data_dir
-        self.layout: Schema2DatasetLayout = schema2_dataset_layout(data_dir)
+        self.layout: Schema2DatasetLayout = \
+            create_schema2_dataset_layout(data_dir)
 
         if not os.path.exists(self.layout.pedigree):
             raise ParquetLoaderException(

--- a/gcp_storage/gcp_storage/gcp_import_storage.py
+++ b/gcp_storage/gcp_storage/gcp_import_storage.py
@@ -7,7 +7,7 @@ from dae.configuration.study_config_builder import StudyConfigBuilder
 from dae.import_tools.import_tools import ImportProject, save_study_config
 from dae.schema2_storage.schema2_import_storage import (
     Schema2ImportStorage,
-    schema2_dataset_layout,
+    create_schema2_dataset_layout,
 )
 from dae.task_graph.graph import TaskGraph
 from gcp_storage.gcp_genotype_storage import GcpGenotypeStorage
@@ -20,7 +20,9 @@ class GcpImportStorage(Schema2ImportStorage):
 
     @classmethod
     def _do_import_dataset(cls, project: ImportProject) -> None:
-        layout = schema2_dataset_layout(project.get_parquet_dataset_dir())
+        layout = create_schema2_dataset_layout(
+            project.get_parquet_dataset_dir(),
+        )
         genotype_storage = cast(
             GcpGenotypeStorage, project.get_genotype_storage())
         assert isinstance(genotype_storage, GcpGenotypeStorage)


### PR DESCRIPTION
## Background
Impala2 import had a bug when using has_variants helper method, due to the check being faulty in specific cases.

## Implementation
Schema2 import is more dependent on the study layout being provided. Now there are 2 schema2 helpers for creating a study layout, one that uses the old behavior and creates all tables, and another intended for loading/reading, which checks for variants tables before adding them to the layout

