### PR TITLE
Replace families data to_dict with manual iteration

### DIFF
--- a/dae/dae/pedigrees/families_data.py
+++ b/dae/dae/pedigrees/families_data.py
@@ -227,8 +227,11 @@ class FamiliesData(Mapping[str, Family]):
     def from_pedigree_df(ped_df: pd.DataFrame) -> FamiliesData:
         """Build a families data object from a pedigree data frame."""
         persons = defaultdict(list)
-        for rec in ped_df.to_dict(orient="records"):
-            person = Person(**rec)  # type: ignore
+        columns = ped_df.columns.tolist()
+        for rec in [
+            dict(zip(columns, data)) for data in ped_df.to_numpy()
+        ]:
+            person = Person(**rec)
             persons[person.family_id].append(person)
 
         fams = FamiliesData.from_family_persons(persons)


### PR DESCRIPTION
## Background
When analyzing the performance of study loading, 1/3 of the time was determined to be spent in pandas' to_dict method. This was due to many type checking calls being performed on each value.

## Aim
Optimize loading families data with pandas.

## Implementation
Due to the poor performance of the method, it was decided to be replaced by manual iteration. This took the loading time of a pedigree only study with phenotype data from 60-70 seconds to 40-50 seconds

