### PR TITLE
Multiple measure regressions

### DIFF
--- a/dae/dae/configuration/schemas/phenotype_data.py
+++ b/dae/dae/configuration/schemas/phenotype_data.py
@@ -2,6 +2,7 @@ from dae.configuration.utils import validate_existing_path
 
 regression_schema = {
     "instrument_name": {"type": "string"},
+    "measure_names": {"type": "list", "schema": {"type": "string"}},
     "measure_name": {"type": "string"},
     "jitter": {"type": "float", "default": 0.1},
     "display_name": {"type": "string"},

--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -451,7 +451,7 @@ class PhenoDb:  # pylint: disable=too-many-instance-attributes
                 connection.commit()
 
     def get_browser_measure(self, measure_id: str) -> Optional[dict]:
-        """Get measrue description from phenotype browser database."""
+        """Get measure description from phenotype browser database."""
         sel = select(self.variable_browser)
         sel = sel.where(self.variable_browser.c.measure_id == measure_id)
         with self.engine.connect() as connection:
@@ -464,7 +464,7 @@ class PhenoDb:  # pylint: disable=too-many-instance-attributes
         self, instrument_name: Optional[str] = None,
         keyword: Optional[str] = None,
     ) -> Iterator[dict[str, Any]]:
-        """Find measert by keyword search."""
+        """Find measures by keyword search."""
         query_params = []
 
         if keyword:

--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -9,6 +9,7 @@ from box import Box
 from sqlalchemy import (
     Column,
     Float,
+    Double,
     Integer,
     MetaData,
     String,
@@ -351,8 +352,8 @@ class PhenoDb:  # pylint: disable=too-many-instance-attributes
             Column("measure_id", String(128), nullable=False, index=True),
             Column("figure_regression", String(256)),
             Column("figure_regression_small", String(256)),
-            Column("pvalue_regression_male", Float()),
-            Column("pvalue_regression_female", Float()),
+            Column("pvalue_regression_male", Double()),
+            Column("pvalue_regression_female", Double()),
             PrimaryKeyConstraint(
                 "regression_id", "measure_id", name="regression_pkey",
             ),

--- a/dae/dae/pheno/graphs.py
+++ b/dae/dae/pheno/graphs.py
@@ -96,7 +96,7 @@ def male_female_legend(color_male, color_female, ax=None):
 
     male_patch = mpatches.Patch(color=color_male, label="M")
     female_patch = mpatches.Patch(color=color_female, label="F")
-    ax.legend(handles=[male_patch, female_patch], title="Sex")
+    ax.legend(handles=[male_patch, female_patch], title="Sex", loc="upper right")
 
 
 def draw_linregres(df, col1, col2, jitter: Optional[int] = None, ax=None):
@@ -298,8 +298,8 @@ def draw_measure_violinplot(
         hue_order=[Sex.male, Sex.female],
         linewidth=1,
         split=True,
-        scale="count",
-        scale_hue=False,
+        density_norm="count",
+        common_norm=True,
         palette=palette,
         saturation=1,
     )

--- a/dae/dae/pheno/pheno_data.py
+++ b/dae/dae/pheno/pheno_data.py
@@ -47,6 +47,10 @@ def get_pheno_browser_images_dir(dae_config: Optional[Box] = None) -> str:
         get_pheno_db_dir(dae_config),
     )
     browser_images_path = os.path.join(pheno_db_dir, "images")
+    if not os.path.exists(browser_images_path):
+        logger.error(
+            "Pheno images path %s does not exist!", browser_images_path
+        )
     return browser_images_path
 
 

--- a/dae/dae/pheno/prepare_data.py
+++ b/dae/dae/pheno/prepare_data.py
@@ -56,6 +56,9 @@ class PreparePhenoBrowserBase:
 
         self.phenotype_data = phenotype_data
         self.pheno_regressions = pheno_regressions
+        for reg_data in self.pheno_regressions.regression.values():
+            if "measure_names" in reg_data:
+                reg_data["measure_name"] = reg_data["measure_names"][0]
 
     def load_measure(self, measure: Measure) -> pd.DataFrame:
         df = self.phenotype_data.get_people_measure_values_df(
@@ -344,10 +347,16 @@ class PreparePhenoBrowserBase:
             return
         for reg_id, reg in self.pheno_regressions.regression.items():
             res = {"measure_id": measure.measure_id}
-            reg_measure = self._get_measure_by_name(
-                reg.measure_name,
-                reg.instrument_name or measure.instrument_name,  # type: ignore
-            )
+            for measure_name in reg.measure_names:
+                reg_measure = self._get_measure_by_name(
+                    measure_name,
+                    reg.instrument_name
+                    or measure.instrument_name,  # type: ignore
+                )
+                if not reg_measure:
+                    continue
+                else:
+                    break
             if not reg_measure:
                 continue
             if self._has_regression_measure(

--- a/dae/dae/pheno/prepare_data.py
+++ b/dae/dae/pheno/prepare_data.py
@@ -1,6 +1,6 @@
 import os
 from collections.abc import Iterator
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -56,9 +56,10 @@ class PreparePhenoBrowserBase:
 
         self.phenotype_data = phenotype_data
         self.pheno_regressions = pheno_regressions
-        for reg_data in self.pheno_regressions.regression.values():
-            if "measure_names" in reg_data:
-                reg_data["measure_name"] = reg_data["measure_names"][0]
+        if self.pheno_regressions is not None:
+            for reg_data in self.pheno_regressions.regression.values():
+                if "measure_names" in reg_data:
+                    reg_data["measure_name"] = reg_data["measure_names"][0]
 
     def load_measure(self, measure: Measure) -> pd.DataFrame:
         df = self.phenotype_data.get_people_measure_values_df(
@@ -162,7 +163,7 @@ class PreparePhenoBrowserBase:
         min_number_of_values = 5
         min_number_of_unique_values = 2
 
-        res: Dict[str, Any] = {}
+        res: dict[str, Any] = {}
 
         if dependent_measure.measure_id == independent_measure.measure_id:
             return res
@@ -347,7 +348,10 @@ class PreparePhenoBrowserBase:
             return
         for reg_id, reg in self.pheno_regressions.regression.items():
             res = {"measure_id": measure.measure_id}
-            for measure_name in reg.measure_names:
+            measure_names = reg.measure_names
+            if measure_names is None:
+                measure_names = [reg.measure_name]
+            for measure_name in measure_names:
                 reg_measure = self._get_measure_by_name(
                     measure_name,
                     reg.instrument_name

--- a/dae/dae/pheno/tests/fixtures/regressions.conf
+++ b/dae/dae/pheno/tests/fixtures/regressions.conf
@@ -17,3 +17,8 @@ jitter = 0.3
 instrument_name = "i2"
 measure_name = "regressor1"
 jitter = 0.4
+
+[regression.reg5]
+instrument_name = ""
+measure_names = ["regressor2", "common_regressor"]
+jitter = 0.1

--- a/dae/dae/pheno/tests/test_pheno_regression.py
+++ b/dae/dae/pheno/tests/test_pheno_regression.py
@@ -30,6 +30,11 @@ def test_pheno_regressions_from_conf_path(regressions_conf: str) -> None:
             "measure_name": "regressor1",
             "jitter": 0.4,
         },
+        "reg5": {
+            "instrument_name": "",
+            "measure_names": ["regressor2", "common_regressor"],
+            "jitter": 0.1,
+        },
     }
 
     assert len(regs.regression) == len(expected_regs)
@@ -52,6 +57,7 @@ def test_has_regression_measure(
         ("common_regressor", "i1"),
         ("common_regressor", "i2"),
         ("regressor1", "i2"),
+        ("common_regressor", "i3"),
     ]
 
     for expected in expected_reg_measures:

--- a/dae/dae/tools/pheno_import.py
+++ b/dae/dae/tools/pheno_import.py
@@ -135,6 +135,11 @@ def generate_phenotype_data_config(
     }
     if regressions:
         regressions_dict = regressions.to_dict()
+        for reg in regressions_dict["regression"].values():
+            if reg["measure_name"] is None:
+                del reg["measure_name"]
+            if reg["measure_names"] is None:
+                del reg["measure_names"]
         config["regression"] = regressions_dict["regression"]
     return config
 

--- a/integration/local/entrypoint.sh
+++ b/integration/local/entrypoint.sh
@@ -24,7 +24,7 @@ cd /wd/integration/fixtures/pheno/comp-data
     --person-column personId
 
 mkdir -p $DAE_DB_DIR/pheno/images
-cp -r $DAE_DB_DIR/pheno/comp_pheno/browser/images/comp_pheno \
+cp -r $DAE_DB_DIR/pheno/comp_pheno/images/comp_pheno \
     $DAE_DB_DIR/pheno/
 
 

--- a/integration/remote/entrypoint.sh
+++ b/integration/remote/entrypoint.sh
@@ -28,10 +28,8 @@ cd /wd/integration/fixtures/pheno/comp-data
     --regression comp_pheno_regressions.conf \
     --person-column personId
 
-mv 
-
 mkdir -p $DAE_DB_DIR/pheno/images
-cp -r $DAE_DB_DIR/pheno/comp_pheno/browser/images/comp_pheno \
+cp -r $DAE_DB_DIR/pheno/comp_pheno/images/comp_pheno \
     $DAE_DB_DIR/pheno/
 
 cd /wd


### PR DESCRIPTION
## Background
When importing new phenotype studies, we encountered a case where multiple instrument files had a differently named column intended for use with regressions.

## Aim
Implement support to build regressions for this case.

## Implementation
Regression configurations now have a new field - `measure_names`, which is a list. For every measure in `measure_names`, an attempt to build a regression will be made, the first successfully built regression for each measure will be the final one.