### PR TITLE
Remove families from phenotype studies

### DIFF
--- a/dae/dae/pheno/tests/test_pheno_db.py
+++ b/dae/dae/pheno/tests/test_pheno_db.py
@@ -222,12 +222,6 @@ def test_default_get_measure_df(fake_phenotype_data: PhenotypeStudy) -> None:
     assert len(df) == 17
 
 
-def test_get_persons_df(fake_phenotype_data: PhenotypeStudy) -> None:
-    prbs = fake_phenotype_data.get_persons_df(roles=[Role.prb])
-    assert len(prbs.columns) == 5
-    df_check(prbs, 39, ["person_id", "family_id", "role", "sex", "status"])
-
-
 @pytest.mark.parametrize(
     "families,expected_count", [(["f20"], 5), (["f20", "f21"], 10)],
 )
@@ -268,32 +262,3 @@ def test_min_max_measure_values(fake_phenotype_data: PhenotypeStudy) -> None:
 
         error = np.abs(mmax - df[measure.measure_id].max())
         assert error < 1e-5, measure.measure_id
-
-
-def test_get_persons_df_person_ids(
-    fake_phenotype_data: PhenotypeStudy,
-) -> None:
-    res = fake_phenotype_data.get_persons_df(
-        person_ids=[], family_ids=["f1", "f2", "f3"], roles=[Role.prb],
-    )
-    assert res.empty
-
-
-def test_get_persons_df_family_ids(
-    fake_phenotype_data: PhenotypeStudy,
-) -> None:
-    res = fake_phenotype_data.get_persons_df(
-        person_ids=["f1.p1", "f2.p1", "f3.p1"], family_ids=[], roles=[Role.prb],
-    )
-    assert res.empty
-
-
-def test_get_persons_df_roles(
-    fake_phenotype_data: PhenotypeStudy,
-) -> None:
-    res = fake_phenotype_data.get_persons_df(
-        person_ids=["f1.p1", "f2.p1", "f3.p1"],
-        family_ids=["f1", "f2", "f3"],
-        roles=[],
-    )
-    assert res.empty

--- a/dae/dae/pheno/tests/test_pheno_factory.py
+++ b/dae/dae/pheno/tests/test_pheno_factory.py
@@ -9,7 +9,6 @@ def test_check_pheno_db(fake_pheno_db: PhenoRegistry) -> None:
 def test_get_pheno_db(fake_pheno_db: PhenoRegistry) -> None:
     pheno_data = fake_pheno_db.get_phenotype_data("fake")
     assert pheno_data is not None
-    assert pheno_data.families is not None
     assert pheno_data.instruments is not None
 
 

--- a/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
+++ b/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
@@ -26,13 +26,6 @@ QUERY = {
     (TOOL_URL, "post", QUERY),
     (TOOL_DOWNLOAD_URL, "post", QUERY),
     (
-        "/api/v3/pheno_tool/persons",
-        "post",
-        {
-            "datasetId": "f1_trio",
-        },
-    ),
-    (
         "/api/v3/pheno_tool/people_values",
         "post",
         {

--- a/wdae/wdae/pheno_tool_api/urls.py
+++ b/wdae/wdae/pheno_tool_api/urls.py
@@ -10,11 +10,6 @@ urlpatterns = [
         name="pheno_tool_download",
     ),
     re_path(
-        r"^/persons/?$",
-        views.PhenoToolPersons.as_view(),
-        name="pheno_tool_persons",
-    ),
-    re_path(
         r"^/people_values/?$",
         views.PhenoToolPeopleValues.as_view(),
         name="pheno_tool_people_values",

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -208,35 +208,6 @@ class PhenoToolDownload(PhenoToolView):
         return response
 
 
-class PhenoToolPersons(QueryDatasetView):
-
-    def post(self, request: Request) -> Response:
-        data = request.data
-        dataset_id = data["datasetId"]
-        dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
-        if not dataset or dataset.phenotype_data is None:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
-        result = dataset.phenotype_data.get_persons(
-            data.get("roles", None),
-            data.get("personIds", None),
-            data.get("familyIds", None),
-        )
-
-        response: dict[str, Any] = {}
-        for key in result.keys():
-            person = result[key]
-            response[key] = {
-                "person_id": person.person_id,
-                "family_id": person.family_id,
-                "role": str(person.role),
-                "sex": str(person.sex),
-                "status": str(person.status),
-            }
-
-        return Response(response)
-
-
 class PhenoToolPeopleValues(QueryDatasetView):
     """View for returning person phenotype data."""
 

--- a/wdae/wdae/remote/remote_phenotype_data.py
+++ b/wdae/wdae/remote/remote_phenotype_data.py
@@ -33,22 +33,6 @@ class RemotePhenotypeData(PhenotypeData):
             self._measures = self.get_measures()
         return self._measures
 
-    def get_persons_df(
-        self,
-        roles: Union[Iterable[Role], Iterable[str], None] = None,
-        person_ids: Optional[Iterable[str]] = None,
-        family_ids: Optional[Iterable[str]] = None,
-    ) -> pd.DataFrame:
-
-        persons = self.rest_client.post_pheno_persons(
-            self.remote_dataset_id,
-            cast(Iterable[str], roles),
-            person_ids,
-            family_ids,
-        )
-
-        return pd.DataFrame.from_records(persons.values())
-
     def get_persons_values_df(
         self,
         measure_ids: Iterable[str],
@@ -69,23 +53,6 @@ class RemotePhenotypeData(PhenotypeData):
             roles=roles_los,
         )
         return pd.DataFrame.from_records(persons.values())
-
-    def get_persons(
-        self,
-        roles: Union[Iterable[Role], Iterable[str], None] = None,
-        person_ids: Optional[Iterable[str]] = None,
-        family_ids: Optional[Iterable[str]] = None,
-    ) -> dict[str, Person]:
-        persons = self.rest_client.post_pheno_persons(
-            self.remote_dataset_id,
-            cast(Optional[Iterable[str]], roles),
-            person_ids,
-            family_ids,
-        )
-        for k, v in persons.items():
-            persons[k] = Person(**v)
-
-        return cast(dict[str, Person], persons)
 
     def has_measure(self, measure_id: str) -> bool:
         measure = self.rest_client.get_measure(

--- a/wdae/wdae/remote/rest_api_client.py
+++ b/wdae/wdae/remote/rest_api_client.py
@@ -374,46 +374,10 @@ class RESTClient:
         )
         return response.iter_content()
 
-    # def post_measures_values(
-    #         self, dataset_id: str,
-    #         measure_ids: Optional[Iterable[str]] = None,
-    #         instrument: Optional[str] = None
-    # ) -> Any:
-    #     """Post download request for pheno measures."""
-    #     response = self._post(
-    #         "pheno_browser/measure_values",
-    #         data={
-    #             "dataset_id": dataset_id,
-    #             "measure_ids": measure_ids,
-    #             "instrument": instrument,
-    #         },
-    #         stream=True
-    #     )
-    #     return self._read_json_list_stream(response)
-
     def post_enrichment_test(self, query: dict) -> Any:
         response = self._post(
             "enrichment/test",
             data=query,
-        )
-        return response.json()
-
-    def post_pheno_persons(
-        self, dataset_id: str,
-        roles: Optional[Iterable[str]],
-        person_ids: Optional[Iterable[str]],
-        family_ids: Optional[Iterable[str]],
-    ) -> Any:
-        """Post a pheno measures person query request."""
-        data = {
-            "datasetId": dataset_id,
-            "roles": roles,
-            "personIds": person_ids,
-            "familyIds": family_ids,
-        }
-        response = self._post(
-            "pheno_tool/persons",
-            data=data,
         )
         return response.json()
 

--- a/wdae/wdae/remote/tests/test_rest_api_client.py
+++ b/wdae/wdae/remote/tests/test_rest_api_client.py
@@ -80,18 +80,6 @@ def test_post_enrichment_test(rest_client: RESTClient) -> None:
     assert isinstance(response, dict)
 
 
-def test_post_pheno_persons(rest_client: RESTClient) -> None:
-    pheno_persons = rest_client.post_pheno_persons(
-        "iossifov_2014",
-        None,
-        None,
-        None,
-    )
-
-    assert pheno_persons is not None
-    assert isinstance(pheno_persons, dict)
-
-
 def test_get_instruments_details(rest_client: RESTClient) -> None:
     instrument_details = rest_client.get_instruments_details("iossifov_2014")
 


### PR DESCRIPTION
## Background
Loading phenotype studies was slow, due to loading families data from a pedigree file. Upon further examination, this families data object was largely unused and was only passed on to remote phenotype studies.

## Aim
Remove the `FamiliesData` instance.

## Implementation
Removing the families data object meant removing an API route used only for remote phenotype data creation and from the REST API client too. Any tests related to this object were also removed.