### PR TITLE
fix grr index page issues

### DIFF
--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -529,14 +529,14 @@ def _collect_impl_stats_tasks(  # pylint: disable=too-many-arguments
 
     # This is the hack to update stats_hash without recreaing the histograms.
     graph.create_task(
-        f"{impl.resource.resource_id}_store_stats_hash",
+        f"{impl.resource.get_full_id()}_store_stats_hash",
         _store_stats_hash,
         [proto, impl.resource],
         tasks,
     )
 
     graph.create_task(
-        f"{impl.resource.resource_id}_manifest_rebuild",
+        f"{impl.resource.get_full_id()}_manifest_rebuild",
         _do_resource_manifest_command,
         [proto, impl.resource, dry_run, force, use_dvc],
         tasks,
@@ -553,19 +553,19 @@ def _stats_need_rebuild(
     if stored_hash is None:
         logger.info(
             "No hash stored for <%s>, need update",
-            impl.resource.resource_id,
+            impl.resource.get_full_id(),
         )
         return True
 
     if stored_hash != current_hash:
         logger.info(
             "Stored hash for <%s> is outdated, need update",
-            impl.resource.resource_id,
+            impl.resource.get_full_id(),
         )
         return True
 
     logger.info(
-        "<%s> statistics hash is up to date", impl.resource.resource_id,
+        "<%s> statistics hash is up to date", impl.resource.get_full_id(),
     )
     return False
 

--- a/dae/dae/genomic_resources/fsspec_protocol.py
+++ b/dae/dae/genomic_resources/fsspec_protocol.py
@@ -631,7 +631,7 @@ class FsspecReadWriteProtocol(
                 sum(f for _, f in res.get_manifest().get_files()),
             )
             assert res.config is not None
-            result[res.resource_id] = {
+            result[res.get_full_id()] = {
                 **res.config,
                 "res_version": res.get_version_str(),
                 "res_files": len(list(res.get_manifest().get_files())),

--- a/dae/dae/genomic_resources/implementations/genomic_scores_impl.py
+++ b/dae/dae/genomic_resources/implementations/genomic_scores_impl.py
@@ -292,13 +292,13 @@ class GenomicScoreImplementation(
             start = region.start
             end = region.stop
             min_max_tasks.append(graph.create_task(
-                f"{self.resource_id}_calculate_min_max_{chrom}_{start}_{end}",
+                f"{self.resource.get_full_id()}_calculate_min_max_{chrom}_{start}_{end}",
                 GenomicScoreImplementation._do_min_max,
                 [self.resource, score_ids, chrom, start, end],
                 [],
             ))
         merge_task = graph.create_task(
-            f"{self.resource_id}_merge_min_max",
+            f"{self.resource.get_full_id()}_merge_min_max",
             GenomicScoreImplementation._merge_min_max,
             [score_ids, *min_max_tasks],
             min_max_tasks,
@@ -378,7 +378,7 @@ class GenomicScoreImplementation(
         else:
             update_hist_confs_deps = [minmax_task]
         update_hist_confs = graph.create_task(
-            f"{self.resource_id}_update_hist_confs",
+            f"{self.resource.get_full_id()}_update_hist_confs",
             GenomicScoreImplementation._update_hist_confs,
             [all_hist_confs, minmax_task],
             update_hist_confs_deps,
@@ -390,20 +390,20 @@ class GenomicScoreImplementation(
             start = region.start
             end = region.stop
             histogram_tasks.append(graph.create_task(
-                f"{self.resource_id}_calculate_histogram_"
+                f"{self.resource.get_full_id()}_calculate_histogram_"
                 f"{chrom}_{start}_{end}",
                 GenomicScoreImplementation._do_histogram,
                 [self.resource, update_hist_confs, chrom, start, end],
                 [update_hist_confs],
             ))
         merge_task = graph.create_task(
-            f"{self.resource_id}_merge_histograms",
+            f"{self.resource.get_full_id()}_merge_histograms",
             GenomicScoreImplementation._merge_histograms,
             [self.resource, update_hist_confs, *histogram_tasks],
             histogram_tasks,
         )
         save_task = graph.create_task(
-            f"{self.resource_id}_save_histograms",
+            f"{self.resource.get_full_id()}_save_histograms",
             GenomicScoreImplementation._save_histograms,
             [self.resource, merge_task],
             [merge_task],

--- a/dae/dae/genomic_resources/repository.py
+++ b/dae/dae/genomic_resources/repository.py
@@ -293,6 +293,13 @@ class GenomicResource:
         """Return genomic resource ID."""
         return self.resource_id
 
+    def get_full_id(self) -> str:
+        """Return genomic resource ID with version."""
+        version = ""
+        if self.get_version_str() != "0":
+            version = f"({self.get_version_str()})"
+        return f"{self.resource_id}{version}"
+
     def get_config(self) -> dict[str, Any]:
         """Return the resouce configuration."""
         if self.config is None:
@@ -323,7 +330,7 @@ class GenomicResource:
         return self.get_description()
 
     def get_url(self) -> str:
-        return f"{self.proto.get_url()}/{self.get_id()}"
+        return f"{self.proto.get_url()}/{self.get_full_id()}"
 
     def get_labels(self) -> dict[str, Any]:
         """Return resource labels."""

--- a/dae/dae/genomic_resources/resource_implementation.py
+++ b/dae/dae/genomic_resources/resource_implementation.py
@@ -193,7 +193,18 @@ h3,h4 {
     margin-top:0.5em;
     margin-bottom:0.5em;
 }
-
+table {
+    border-collapse: collapse;
+}
+th, td {
+    padding: 10px;
+}
+th {
+    font-size: 20px;
+}
+td {
+    font-size: 18px;
+}
 {% block extra_styles %}{% endblock %}
 
 </style>
@@ -205,12 +216,13 @@ h3,h4 {
 <table border="1">
 <tr><td><b>Id:</b></td><td>{{ resource.resource_id }}</td></tr>
 <tr><td><b>Type:</b></td><td>{{ resource.get_type() }}</td></tr>
+<tr><td><b>Version:</b></td><td>{{ resource.get_version_str() }}</td></tr>
 <tr>
 <td><b>Summary:</b></td>
 <td>
 {%- set summary = resource.get_summary() -%}
 {{
-    summary if summary else "N/A"
+    markdown(summary, extras=["tables"]) if summary else "N/A"
 }}</td>
 </tr>
 <tr>
@@ -218,7 +230,7 @@ h3,h4 {
 <td>
 {%- set description = resource.get_description() -%}
 {{
-    markdown(description) if description else "N/A"
+    markdown(description, extras=["tables"]) if description else "N/A"
 }}</td>
 </tr>
 <tr>

--- a/dae/dae/genomic_resources/tests/test_repository_factory.py
+++ b/dae/dae/genomic_resources/tests/test_repository_factory.py
@@ -76,7 +76,7 @@ def test_build_a_complex_but_realistic_scenario_yaml(tmp_path):
         type: group
         children:
         - type: group
-          cache_dir: "{tmp_path!s}/tmp/remotes12Cache"
+          cache_dir: "{tmp_path!s}/tmp/remotes12Cache(1.3)"
           children:
           - id: r1
             type: http
@@ -105,7 +105,7 @@ def test_build_a_complex_but_realistic_scenario_yaml(tmp_path):
     #   * only directory repository has a 'directory'             attribute;
     #   * only embedded   repository has a 'content'               attribute.
     assert str(repo.children[0].cache_url) == \
-        f"file://{tmp_path}/tmp/remotes12Cache"
+        f"file://{tmp_path}/tmp/remotes12Cache(1.3)"
     assert repo.children[0].child.children[0].proto.url == \
         "http://r1.org/repo"
     assert repo.children[0].child.children[1].proto.url == \


### PR DESCRIPTION
## Background
Resource index page needs to show version number.
All version of a resource needs to show in the main index page.
All main index page resource versions show incorrect link to the first version of the resource.
Resource index pages do not render markdown tables in description and summary block. 

## Aim
Add version to resource index page.
Provide support of markdown tables when rendering description and summary.
Implement usage of resource id and version instead of only resource id to fix version problems.

## Implementation
Use resource id and version in multiple places.
