### PR TITLE
Add pheno import parallelization

### DIFF
--- a/dae/dae/pheno/prepare_data.py
+++ b/dae/dae/pheno/prepare_data.py
@@ -391,9 +391,9 @@ class PreparePhenoBrowserBase:
                 except Exception:
                     logger.exception("Failed to create images")
 
-    def add_measure_task(
-            self, graph: TaskGraph, measure: Measure, dbfile: str
-    ) -> None:
+    def get_regression_measures(
+        self, measure: Measure,
+    ) -> dict[str, tuple[Box, Measure]]:
         regression_measures: dict[str, tuple[Box, pd.DataFrame]] = {}
         for reg_id, reg in self.pheno_regressions.regression.items():
             measure_names = reg.measure_names
@@ -417,7 +417,13 @@ class PreparePhenoBrowserBase:
             ):
                 continue
             regression_measures[reg_id] = (reg, reg_measure)
+        return regression_measures
 
+    def add_measure_task(
+            self, graph: TaskGraph, measure: Measure, dbfile: str
+    ) -> None:
+
+        regression_measures = self.get_regression_measures(measure)
         graph.create_task(
             f"build_{measure.measure_id}",
             PreparePhenoBrowserBase.do_measure_build,

--- a/dae/dae/pheno/prepare_data.py
+++ b/dae/dae/pheno/prepare_data.py
@@ -1,6 +1,9 @@
 import os
 from collections.abc import Iterator
 from typing import Any, Optional, Union
+import logging
+import shutil
+import tempfile
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -20,11 +23,20 @@ from dae.pheno.pheno_data import (
     PhenotypeStudy,
     get_pheno_browser_images_dir,
 )
+from dae.pheno.db import PhenoDb
+
+from dae.task_graph.graph import Task, TaskGraph
+from dae.task_graph.executor import task_graph_run_with_results
+from dae.task_graph.cli_tools import TaskGraphCli, TaskCache
+
 from dae.utils.progress import progress, progress_nl
 from dae.variants.attributes import Role
+from sqlalchemy import text
 
 mpl.use("PS")
 plt.ioff()
+
+logger = logging.getLogger(__name__)
 
 
 class PreparePhenoBrowserBase:
@@ -67,8 +79,10 @@ class PreparePhenoBrowserBase:
         )
         return df
 
+    @staticmethod
     def _augment_measure_values_df(
-        self, augment: Measure, augment_name: str,
+        phenotype_data: PhenotypeStudy,
+        augment: Measure, augment_name: str,
         measure: Measure,
     ) -> Optional[pd.DataFrame]:
         assert augment is not None
@@ -84,10 +98,10 @@ class PreparePhenoBrowserBase:
 
         if augment_id == measure.measure_id:
             return None
-        if not self.phenotype_data.has_measure(augment_id):
+        if not phenotype_data.has_measure(augment_id):
             return None
 
-        df = self.phenotype_data.get_people_measure_values_df(
+        df = phenotype_data.get_people_measure_values_df(
             [augment_id, measure.measure_id],
         )
         df.loc[df.role == Role.mom, "role"] = Role.parent  # type: ignore
@@ -107,14 +121,17 @@ class PreparePhenoBrowserBase:
             "values_domain": measure.values_domain,
         }
 
-    def figure_filepath(self, measure: Measure, suffix: str) -> str:
+    @classmethod
+    def figure_filepath(
+        cls, pheno_id: str, images_dir: str, measure: Measure, suffix: str
+    ) -> str:
         """Construct file path for storing a measure figures."""
         filename = f"{measure.measure_id}.{suffix}.png"
 
         assert measure.instrument_name is not None
         outdir = os.path.join(
-            self.images_dir,
-            self.phenotype_data.pheno_id,
+            images_dir,
+            pheno_id,
             measure.instrument_name,
         )
         if not os.path.exists(outdir):
@@ -123,39 +140,47 @@ class PreparePhenoBrowserBase:
         filepath = os.path.join(outdir, filename)
         return filepath
 
-    def browsable_figure_path(self, measure: Measure, suffix: str) -> str:
+    @classmethod
+    def browsable_figure_path(
+        cls, pheno_id: str, measure: Measure, suffix: str
+    ) -> str:
         """Construct file path for storing a measure figures."""
         filename = f"{measure.measure_id}.{suffix}.png"
         assert measure.instrument_name is not None
         filepath = os.path.join(
-            self.phenotype_data.pheno_id,
+            pheno_id,
             measure.instrument_name,
             filename,
         )
         return filepath
 
+    @classmethod
     def save_fig(
-        self, measure: Measure, suffix: str,
+            cls, pheno_id: str, images_dir: str, measure: Measure, suffix: str,
     ) -> tuple[Optional[str], Optional[str]]:
         """Save measure figures."""
         if "/" in measure.measure_id:
             return (None, None)
 
-        small_filepath = self.figure_filepath(
-            measure, f"{suffix}_small",
+        small_filepath = cls.figure_filepath(
+            pheno_id, images_dir, measure, f"{suffix}_small",
         )
-        plt.savefig(small_filepath, dpi=self.SMALL_DPI)
+        plt.savefig(small_filepath, dpi=cls.SMALL_DPI)
 
-        filepath = self.figure_filepath(measure, suffix)
-        plt.savefig(filepath, dpi=self.LARGE_DPI)
+        filepath = cls.figure_filepath(pheno_id, images_dir, measure, suffix)
+        plt.savefig(filepath, dpi=cls.LARGE_DPI)
         plt.close()
         return (
-            self.browsable_figure_path(measure, f"{suffix}_small"),
-            self.browsable_figure_path(measure, suffix),
+            cls.browsable_figure_path(pheno_id, measure, f"{suffix}_small"),
+            cls.browsable_figure_path(pheno_id, measure, suffix),
         )
 
+    @classmethod
     def build_regression(
-        self, dependent_measure: Measure,
+        cls,
+        phenotype_data: PhenotypeStudy,
+        images_dir: str,
+        dependent_measure: Measure,
         independent_measure: Measure,
         jitter: float,
     ) -> dict[str, Union[str, float]]:
@@ -170,8 +195,9 @@ class PreparePhenoBrowserBase:
 
         aug_col_name = independent_measure.measure_name
 
-        aug_df = self._augment_measure_values_df(
-            independent_measure, aug_col_name, dependent_measure,
+        aug_df = cls._augment_measure_values_df(
+            phenotype_data, independent_measure,
+            aug_col_name, dependent_measure,
         )
 
         if aug_df is None:
@@ -207,14 +233,18 @@ class PreparePhenoBrowserBase:
             (
                 res["figure_regression_small"],
                 res["figure_regression"],
-            ) = self.save_fig(
-                dependent_measure, f"prb_regression_by_{aug_col_name}",
+            ) = cls.save_fig(
+                phenotype_data.pheno_id, images_dir,
+                dependent_measure, f"prb_regression_by_{aug_col_name}"
             )
         return res
 
-    def build_values_violinplot(self, measure: Measure) -> dict[str, Any]:
+    @classmethod
+    def build_values_violinplot(
+        cls, pheno_id: str, images_dir: str,
+        df: pd.DataFrame, measure: Measure,
+    ) -> dict[str, Any]:
         """Build a violin plot figure for the measure."""
-        df = self.load_measure(measure)
         drawn = draw_measure_violinplot(df.dropna(), measure.measure_id)
 
         res = {}
@@ -223,15 +253,16 @@ class PreparePhenoBrowserBase:
             (
                 res["figure_distribution_small"],
                 res["figure_distribution"],
-            ) = self.save_fig(measure, "violinplot")
+            ) = cls.save_fig(pheno_id, images_dir, measure, "violinplot")
 
         return res
 
+    @classmethod
     def build_values_categorical_distribution(
-        self, measure: Measure,
+        cls, pheno_id: str, images_dir: str,
+        df: pd.DataFrame, measure: Measure,
     ) -> dict[str, Any]:
         """Build a categorical value distribution fiugre."""
-        df = self.load_measure(measure)
         drawn = draw_categorical_violin_distribution(
             df.dropna(), measure.measure_id,
         )
@@ -241,7 +272,7 @@ class PreparePhenoBrowserBase:
             (
                 res["figure_distribution_small"],
                 res["figure_distribution"],
-            ) = self.save_fig(measure, "distribution")
+            ) = cls.save_fig(pheno_id, images_dir, measure, "distribution")
 
         return res
 
@@ -263,11 +294,12 @@ class PreparePhenoBrowserBase:
 
         return res
 
+    @classmethod
     def build_values_ordinal_distribution(
-        self, measure: Measure,
+        cls, pheno_id: str, images_dir: str,
+        df: pd.DataFrame, measure: Measure,
     ) -> dict[str, Any]:
         """Build an ordinal value distribution figure."""
-        df = self.load_measure(measure)
         drawn = draw_ordinal_violin_distribution(
             df.dropna(), measure.measure_id,
         )
@@ -277,7 +309,7 @@ class PreparePhenoBrowserBase:
             (
                 res["figure_distribution_small"],
                 res["figure_distribution"],
-            ) = self.save_fig(measure, "distribution")
+            ) = cls.save_fig(pheno_id, images_dir, measure, "distribution")
 
         return res
 
@@ -302,19 +334,6 @@ class PreparePhenoBrowserBase:
                 return self.phenotype_data.get_measure(measure_id)
         return None
 
-    def handle_measure(self, measure: Measure) -> dict[str, Any]:
-        """Build appropriate figures for a measure."""
-        res = PreparePhenoBrowserBase._measure_to_dict(measure)
-
-        if measure.measure_type == MeasureType.continuous:
-            res.update(self.build_values_violinplot(measure))
-        elif measure.measure_type == MeasureType.ordinal:
-            res.update(self.build_values_ordinal_distribution(measure))
-        elif measure.measure_type == MeasureType.categorical:
-            res.update(self.build_values_categorical_distribution(measure))
-
-        return res
-
     def _has_regression_measure(
         self, measure_name: str,
         instrument_name: Optional[str],
@@ -334,22 +353,53 @@ class PreparePhenoBrowserBase:
                 return True
         return False
 
-    def handle_regressions(
-        self, measure: Measure,
-    ) -> Iterator[dict[str, Any]]:
-        """Build appropriate regressions and regression figures."""
-        if measure.measure_type not in [
-            MeasureType.continuous,
-            MeasureType.ordinal,
-        ]:
-            return
-        if self.pheno_regressions is None or \
-                self.pheno_regressions.regression is None:
-            return
+    def run(self, **kwargs) -> None:
+        """Run browser preparations for all measures in a phenotype data."""
+        db = self.phenotype_data.db
+        with db.engine.connect() as conn:
+            conn.execute(text("SET wal_autocheckpoint = '50 KiB'"))
+
+        if self.pheno_regressions:
+            for reg_id, reg_data in self.pheno_regressions.regression.items():
+                db.save_regression(
+                    {
+                        "regression_id": reg_id,
+                        "instrument_name": reg_data.instrument_name,
+                        "measure_name": reg_data.measure_name,
+                        "display_name": reg_data.display_name,
+                    },
+                )
+
+        graph = TaskGraph()
+
+        with tempfile.NamedTemporaryFile() as temp_dbfile:
+            shutil.copyfile(db.dbfile, temp_dbfile.name)
+            import pdb; pdb.set_trace()
+            for instrument in list(self.phenotype_data.instruments.values()):
+                for measure in list(instrument.measures.values()):
+                    self.add_measure_task(graph, measure, temp_dbfile.name)
+            task_cache = TaskCache.create(
+                force=False, cache_dir=kwargs.get("task_status_dir"))
+            with TaskGraphCli.create_executor(task_cache, **kwargs) as xtor:
+                try:
+                    for result in task_graph_run_with_results(graph, xtor):
+                        measure, regressions = result
+                        db.save(measure)
+                        if regressions is None:
+                            continue
+                        for regression in regressions:
+                            db.save_regression_values(regression)
+                except Exception:
+                    logger.exception("Failed to create images")
+
+    def add_measure_task(
+            self, graph: TaskGraph, measure: Measure, dbfile: str
+    ) -> None:
+        regression_measures: dict[str, tuple[Box, pd.DataFrame]] = {}
         for reg_id, reg in self.pheno_regressions.regression.items():
-            res = {"measure_id": measure.measure_id}
             measure_names = reg.measure_names
             if measure_names is None:
+                assert reg.measure_name is not None
                 measure_names = [reg.measure_name]
             for measure_name in measure_names:
                 reg_measure = self._get_measure_by_name(
@@ -367,39 +417,76 @@ class PreparePhenoBrowserBase:
                 measure.measure_name, measure.instrument_name,
             ):
                 continue
+            regression_measures[reg_id] = (reg, reg_measure)
 
-            res["regression_id"] = reg_id
-            regression = self.build_regression(
-                measure, reg_measure, reg.jitter,
+        graph.create_task(
+            f"build_{measure.measure_id}",
+            PreparePhenoBrowserBase.do_measure_build,
+            [
+                self.pheno_id,
+                dbfile,
+                self.phenotype_data.config,
+                measure,
+                self.images_dir,
+                regression_measures
+            ],
+            []
+        )
+
+    @classmethod
+    def do_measure_build(
+        cls,
+        pheno_id: str,
+        dbfile: str,
+        db_config: Optional[Box],
+        measure: Measure,
+        images_dir: str,
+        regression_measures: dict[str, tuple[Box, Measure]]
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        pheno_data = PhenotypeStudy(
+            pheno_id, dbfile, db_config, read_only=True
+        )
+        df = pheno_data.get_people_measure_values_df(
+            [measure.measure_id],
+        )
+        measure_dict = PreparePhenoBrowserBase._measure_to_dict(measure)
+        if measure.measure_type == MeasureType.continuous:
+            measure_dict.update(cls.build_values_violinplot(
+                pheno_id, images_dir, df, measure
+            ))
+        elif measure.measure_type == MeasureType.ordinal:
+            measure_dict.update(cls.build_values_ordinal_distribution(
+                pheno_id, images_dir, df, measure
+            ))
+        elif measure.measure_type == MeasureType.categorical:
+            measure_dict.update(cls.build_values_categorical_distribution(
+                pheno_id, images_dir, df, measure
+            ))
+
+        if len(regression_measures) == 0:
+            return measure_dict, None
+
+        if measure.measure_type not in [
+            MeasureType.continuous,
+            MeasureType.ordinal,
+        ]:
+            return measure_dict, None
+
+        regression_rows = []
+        for reg_id, reg_conf_and_measure in regression_measures.items():
+            reg_conf, reg_measure = reg_conf_and_measure
+            res = {
+                "measure_id": measure.measure_id,
+                "regression_id": reg_id
+            }
+            regression = cls.build_regression(
+                pheno_data, images_dir, measure, reg_measure, reg_conf.jitter,
             )
             res.update(regression)  # type: ignore
             if (
                 res.get("pvalue_regression_male") is not None
                 or res.get("pvalue_regression_female") is not None
             ):
-                yield res
+                regression_rows.append(res)
 
-    def run(self) -> None:
-        """Run browser preparations for all measures in a phenotype data."""
-        db = self.phenotype_data.db
-
-        if self.pheno_regressions:
-            for reg_id, reg_data in self.pheno_regressions.regression.items():
-                db.save_regression(
-                    {
-                        "regression_id": reg_id,
-                        "instrument_name": reg_data.instrument_name,
-                        "measure_name": reg_data.measure_name,
-                        "display_name": reg_data.display_name,
-                    },
-                )
-
-        for instrument in list(self.phenotype_data.instruments.values()):
-            progress_nl()
-            for measure in list(instrument.measures.values()):
-                progress(text=str(measure) + "\n")
-                var = self.handle_measure(measure)
-                db.save(var)
-                if self.pheno_regressions:
-                    for regression in self.handle_regressions(measure):
-                        db.save_regression_values(regression)
+        return measure_dict, regression_rows

--- a/dae/dae/pheno/tests/test_prepare_data.py
+++ b/dae/dae/pheno/tests/test_prepare_data.py
@@ -22,7 +22,7 @@ def test_augment_measure(
     regressand = fake_phenotype_data.get_measure("i1.m1")
     regressor = fake_phenotype_data.get_measure("i1.age")
     df = prep._augment_measure_values_df(
-        regressor, "test regression", regressand,
+        fake_phenotype_data, regressor, "test regression", regressand,
     )
     assert df is not None
 
@@ -49,13 +49,13 @@ def test_augment_measure_regressor_no_instrument_name(
     regressand = fake_phenotype_data.get_measure("i1.m1")
     regressor = fake_phenotype_data.get_measure("i1.age")
     exp_df = prep._augment_measure_values_df(
-        regressor, "test regression", regressand,
+        fake_phenotype_data, regressor, "test regression", regressand,
     )
     assert exp_df is not None
 
     regressor.instrument_name = None
     df = prep._augment_measure_values_df(
-        regressor, "test regression", regressand,
+        fake_phenotype_data, regressor, "test regression", regressand,
     )
     assert df is not None
 
@@ -79,7 +79,7 @@ def test_augment_measure_with_identical_measures(
     regressand = fake_phenotype_data.get_measure("i1.age")
     regressor = fake_phenotype_data.get_measure("i1.age")
     df = prep._augment_measure_values_df(
-        regressor, "test regression", regressand,
+        fake_phenotype_data, regressor, "test regression", regressand,
     )
     assert df is None
 
@@ -92,7 +92,7 @@ def test_augment_measure_with_nonexistent_regressor(
     regressor = fake_phenotype_data.get_measure("i1.age")
     regressor.instrument_name = None
     df = prep._augment_measure_values_df(
-        regressor, "test regression", regressand,
+        fake_phenotype_data, regressor, "test regression", regressand,
     )
     assert df is None
 
@@ -163,7 +163,9 @@ def test_build_regression(
     regressor = fake_phenotype_data.get_measure("i1.age")
     jitter = 0.32403423849
 
-    res = prep.build_regression(regressand, regressor, jitter)
+    res = prep.build_regression(
+        fake_phenotype_data, output_dir, regressand, regressor, jitter
+    )
     assert res is not None
     assert isinstance(res, dict)
 
@@ -202,7 +204,10 @@ def test_build_regression_min_vals(
     regressor = fake_phenotype_data.get_measure("i1.age")
     jitter = 0.32403423849
 
-    assert not prep.build_regression(regressand, regressor, jitter)
+    assert not prep.build_regression(
+        fake_phenotype_data, output_dir,
+        regressand, regressor, jitter,
+    )
 
 
 def test_build_regression_min_unique_vals(
@@ -247,7 +252,9 @@ def test_build_regression_min_unique_vals(
     regressor = fake_phenotype_data.get_measure("i1.age")
     jitter = 0.32403423849
 
-    assert not prep.build_regression(regressand, regressor, jitter)
+    assert not prep.build_regression(
+        fake_phenotype_data, output_dir, regressand, regressor, jitter,
+    )
 
 
 def test_build_regression_identical_measures(
@@ -260,7 +267,9 @@ def test_build_regression_identical_measures(
     regressor = fake_phenotype_data.get_measure("i1.age")
     jitter = 0.32403423849
 
-    assert not prep.build_regression(regressand, regressor, jitter)
+    assert not prep.build_regression(
+        fake_phenotype_data, output_dir, regressand, regressor, jitter
+    )
 
 
 def test_build_regression_aug_df_is_none(
@@ -282,9 +291,13 @@ def test_build_regression_aug_df_is_none(
     regressor = fake_phenotype_data.get_measure("i1.age")
     jitter = 0.32403423849
 
-    assert not prep.build_regression(regressand, regressor, jitter)
+    assert not prep.build_regression(
+        fake_phenotype_data, output_dir,
+        regressand, regressor, jitter,
+    )
 
 
+@pytest.mark.xfail(reason="Deprecated API")
 def test_handle_regressions(
     mocker: pytest_mock.MockerFixture,
     fake_phenotype_data: PhenotypeStudy,
@@ -331,6 +344,7 @@ def test_handle_regressions(
     assert jitter == 0.13
 
 
+@pytest.mark.xfail(reason="Deprecated API")
 def test_handle_regressions_non_continuous_or_ordinal_measure(
     fake_phenotype_data: PhenotypeStudy,
     output_dir: str,
@@ -352,6 +366,7 @@ def test_handle_regressions_non_continuous_or_ordinal_measure(
         next(prep.handle_regressions(regressand_raw))
 
 
+@pytest.mark.xfail(reason="Deprecated API")
 def test_handle_regressions_regressand_is_regressor(
     fake_phenotype_data: PhenotypeStudy,
     output_dir: str,
@@ -369,6 +384,7 @@ def test_handle_regressions_regressand_is_regressor(
         next(prep.handle_regressions(regressand))
 
 
+@pytest.mark.xfail(reason="Deprecated API")
 def test_handle_regressions_default_jitter(
     mocker: pytest_mock.MockerFixture,
     fake_phenotype_data: PhenotypeStudy,

--- a/dae/dae/pheno/tests/test_prepare_data.py
+++ b/dae/dae/pheno/tests/test_prepare_data.py
@@ -320,6 +320,14 @@ def test_handle_regressions(
         side_effect=fake_build_regression,
     )
 
+    def fake_save_fig(*_args: Any) -> tuple[Optional[str], Optional[str]]:
+        return ("test1", "test2")
+    mocker.patch(
+        "dae.pheno.prepare_data."
+        "PreparePhenoBrowserBase.save_fig",
+        side_effect=fake_save_fig,
+    )
+
     reg = GPFConfigParser.load_config(
         fake_phenotype_data_config, pheno_conf_schema,
     )
@@ -359,10 +367,18 @@ def test_handle_regressions(
 
 
 def test_handle_regressions_non_continuous_or_ordinal_measure(
+    mocker: pytest_mock.MockerFixture,
     fake_phenotype_data: PhenotypeStudy,
     output_dir: str,
     fake_phenotype_data_config: str,
 ) -> None:
+    def fake_save_fig(*_args: Any) -> tuple[Optional[str], Optional[str]]:
+        return ("test1", "test2")
+    mocker.patch(
+        "dae.pheno.prepare_data."
+        "PreparePhenoBrowserBase.save_fig",
+        side_effect=fake_save_fig,
+    )
     reg = GPFConfigParser.load_config(
         fake_phenotype_data_config, pheno_conf_schema,
     )
@@ -393,10 +409,18 @@ def test_handle_regressions_non_continuous_or_ordinal_measure(
 
 
 def test_handle_regressions_regressand_is_regressor(
+    mocker: pytest_mock.MockerFixture,
     fake_phenotype_data: PhenotypeStudy,
     output_dir: str,
     fake_phenotype_data_config: str,
 ) -> None:
+    def fake_save_fig(*_args: Any) -> tuple[Optional[str], Optional[str]]:
+        return ("test1", "test2")
+    mocker.patch(
+        "dae.pheno.prepare_data."
+        "PreparePhenoBrowserBase.save_fig",
+        side_effect=fake_save_fig,
+    )
     reg = GPFConfigParser.load_config(
         fake_phenotype_data_config, pheno_conf_schema,
     )
@@ -427,6 +451,14 @@ def test_handle_regressions_default_jitter(
         "dae.pheno.prepare_data."
         "PreparePhenoBrowserBase.build_regression",
         side_effect=fake_build_regression,
+    )
+
+    def fake_save_fig(*_args: Any) -> tuple[Optional[str], Optional[str]]:
+        return ("test1", "test2")
+    mocker.patch(
+        "dae.pheno.prepare_data."
+        "PreparePhenoBrowserBase.save_fig",
+        side_effect=fake_save_fig,
     )
 
     reg = GPFConfigParser.load_config(

--- a/dae/dae/pheno/tests/test_prepare_data.py
+++ b/dae/dae/pheno/tests/test_prepare_data.py
@@ -1,10 +1,9 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines
 import os
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 import matplotlib.pyplot as plt
 import pandas as pd
-import pytest
 import pytest_mock
 
 from dae.configuration.gpf_config_parser import GPFConfigParser
@@ -128,20 +127,20 @@ def test_build_regression(
         },
     )
 
-    def fake_augment_df(*args: Any) -> pd.DataFrame:
+    def fake_augment_df(*_args: Any) -> pd.DataFrame:
         return fake_df
 
-    def fake_linregres(*args: Any) -> Any:
+    def fake_linregres(*_args: Any) -> Any:
 
         class Result:  # pylint: disable=too-few-public-methods
-            pvalues = [0.123456, 0.123456]
+            pvalues: ClassVar = [0.123456, 0.123456]
 
         res_male = Result()
         res_female = Result()
         res_female.pvalues[1] = 0.654321
         return (res_male, res_female)
 
-    def fake_savefig(*args: Any) -> tuple[str, str]:
+    def fake_savefig(*_args: Any) -> tuple[str, str]:
         return ("figsmall", "fig")
 
     mocked_linregres = mocker.patch(
@@ -164,7 +163,7 @@ def test_build_regression(
     jitter = 0.32403423849
 
     res = prep.build_regression(
-        fake_phenotype_data, output_dir, regressand, regressor, jitter
+        fake_phenotype_data, output_dir, regressand, regressor, jitter,
     )
     assert res is not None
     assert isinstance(res, dict)
@@ -190,7 +189,7 @@ def test_build_regression_min_vals(
         },
     )
 
-    def fake_augment_df(*args: Any) -> pd.DataFrame:
+    def fake_augment_df(*_args: Any) -> pd.DataFrame:
         return fake_df
 
     mocker.patch(
@@ -238,7 +237,7 @@ def test_build_regression_min_unique_vals(
         },
     )
 
-    def fake_augment_df(*args: Any) -> pd.DataFrame:
+    def fake_augment_df(*_args: Any) -> pd.DataFrame:
         return fake_df
 
     mocker.patch(
@@ -258,7 +257,6 @@ def test_build_regression_min_unique_vals(
 
 
 def test_build_regression_identical_measures(
-    mocker: pytest_mock.MockerFixture,
     fake_phenotype_data: PhenotypeStudy,
     output_dir: str,
 ) -> None:
@@ -268,7 +266,7 @@ def test_build_regression_identical_measures(
     jitter = 0.32403423849
 
     assert not prep.build_regression(
-        fake_phenotype_data, output_dir, regressand, regressor, jitter
+        fake_phenotype_data, output_dir, regressand, regressor, jitter,
     )
 
 
@@ -277,7 +275,7 @@ def test_build_regression_aug_df_is_none(
     fake_phenotype_data: PhenotypeStudy,
     output_dir: str,
 ) -> None:
-    def fake_augment_df(*args: Any) -> Optional[pd.DataFrame]:
+    def fake_augment_df(*_args: Any) -> Optional[pd.DataFrame]:
         return None
 
     mocker.patch(
@@ -304,13 +302,11 @@ def test_handle_regressions(
     fake_phenotype_data_config: str,
 ) -> None:
     def fake_build_regression(
-        phenotype_data: PhenotypeStudy, images_dir: str,
+        _phenotype_data: PhenotypeStudy, _images_dir: str,
         dependent_measure: str, independent_measure: str,
         jitter: float,
     ) -> dict:
         return {  # This return value is not important to the test
-            "pheno_db": phenotype_data,
-            "images_dir": images_dir,
             "regressand": dependent_measure,
             "regressor": independent_measure,
             "jitter": jitter,
@@ -342,7 +338,7 @@ def test_handle_regressions(
     assert len(res) == 2
     print(res)
     assert sorted(
-        [r["regression_id"] for r in res[1]]) == sorted(["age", "nviq"]
+        [r["regression_id"] for r in res[1]]) == sorted(["age", "nviq"],
     )
 
     mocked.assert_called()
@@ -424,7 +420,7 @@ def test_handle_regressions_default_jitter(
     output_dir: str,
     fake_phenotype_data_config: str,
 ) -> None:
-    def fake_build_regression(*args: Any) -> dict:
+    def fake_build_regression(*_args: Any) -> dict:
         return {"pvalue_regression_male": 0, "pvalue_regression_female": 0}
 
     mocked = mocker.patch(

--- a/dae/dae/tools/pheno2browser.py
+++ b/dae/dae/tools/pheno2browser.py
@@ -10,6 +10,7 @@ from dae.configuration.schemas.phenotype_data import regression_conf_schema
 from dae.pheno import pheno_data
 from dae.pheno.prepare_data import PreparePhenoBrowserBase
 from dae.utils.filehash import sha256sum
+from dae.task_graph.cli_tools import TaskGraphCli
 
 
 class CLIError(Exception):
@@ -49,8 +50,9 @@ def calc_dbfile_hashsum(dbfilename):
 
 
 def build_pheno_browser(
-    dbfile, pheno_name, output_dir, pheno_regressions=None,
+    dbfile, pheno_name, output_dir, pheno_regressions=None, **kwargs
 ):
+
     phenodb = pheno_data.PhenotypeStudy(
         pheno_name, dbfile=dbfile, read_only=False,
     )
@@ -62,17 +64,10 @@ def build_pheno_browser(
 
     prep = PreparePhenoBrowserBase(
         pheno_name, phenodb, output_dir, pheno_regressions, images_dir)
-    prep.run()
-
-    # hash_sum = calc_dbfile_hashsum(dbfile)
-    # hashfile = os.path.join(
-    #     output_dir,
-    #     '{}.hash'.format(pheno_name))
-    # with open(hashfile, 'w') as f:
-    #     f.write(hash_sum)
+    prep.run(**kwargs)
 
 
-def main(argv=None):  # IGNORE:C0111
+def main(argv=None):
     """Command line options."""
     if argv is None:
         argv = sys.argv
@@ -125,6 +120,10 @@ USAGE
             type=str,
         )
 
+        TaskGraphCli.add_arguments(
+            parser, use_commands=False
+        )
+
         # Process arguments
         args = parser.parse_args()
 
@@ -146,6 +145,7 @@ USAGE
 
         build_pheno_browser(
             args.dbfile, args.pheno_name, args.output, regressions,
+            **vars(args)
         )
 
         return 0

--- a/dae/dae/tools/pheno_import.py
+++ b/dae/dae/tools/pheno_import.py
@@ -4,15 +4,15 @@ import argparse
 import os
 import sys
 import traceback
-from typing import Any, Optional
 from copy import copy
+from pathlib import Path
+from typing import Any, Optional
 
 import yaml
 from box import Box
 
 from dae.configuration.gpf_config_parser import GPFConfigParser
 from dae.configuration.schemas.phenotype_data import regression_conf_schema
-from dae.task_graph.graph import TaskGraph
 from dae.pheno.common import (
     check_phenotype_data_config,
     default_config,
@@ -46,7 +46,7 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
         metavar="<instruments dir>",
     )
 
-    parser.add_argument( "--tab-separated",
+    parser.add_argument("--tab-separated",
         dest="tab_separated",
         action="store_true",
         help="Flag for whether the instrument files are tab separated.",
@@ -172,24 +172,21 @@ def build_browser(
     del kwargs["pheno_db_filename"]
     pheno_name = args.pheno_name
     del kwargs["pheno_name"]
-    
 
     build_pheno_browser(
         pheno_db_filename,
         pheno_name,
         output_dir,
         regressions,
-        **kwargs
+        **kwargs,
     )
 
     pheno_conf_path = os.path.join(
         output_dir, f"{pheno_name}.yaml",
     )
 
-    with open(pheno_conf_path, "w") as pheno_conf_file:
-        pheno_conf_file.write(yaml.dump(
-            generate_phenotype_data_config(args, regressions),
-        ))
+    config = yaml.dump(generate_phenotype_data_config(args, regressions))
+    Path(pheno_conf_path).write_text(config)
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -251,8 +248,6 @@ def main(argv: Optional[list[str]] = None) -> int:
 
         if not args.import_only:
             build_browser(args, regressions)
-
-        return 0
     except KeyboardInterrupt:
         return 0
     except Exception as e:
@@ -263,6 +258,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         sys.stderr.write(program_name + ": " + repr(e) + "\n")
         sys.stderr.write(indent + "  for help use --help")
         return 2
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/dae/dae/tools/pheno_import.py
+++ b/dae/dae/tools/pheno_import.py
@@ -5,18 +5,21 @@ import os
 import sys
 import traceback
 from typing import Any, Optional
+from copy import copy
 
 import yaml
 from box import Box
 
 from dae.configuration.gpf_config_parser import GPFConfigParser
 from dae.configuration.schemas.phenotype_data import regression_conf_schema
+from dae.task_graph.graph import TaskGraph
 from dae.pheno.common import (
     check_phenotype_data_config,
     default_config,
     dump_config,
 )
 from dae.pheno.prepare.pheno_prepare import PrepareVariables
+from dae.task_graph.cli_tools import TaskGraphCli
 from dae.tools.pheno2browser import build_pheno_browser
 
 
@@ -43,8 +46,7 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
         metavar="<instruments dir>",
     )
 
-    parser.add_argument(
-        "--tab-separated",
+    parser.add_argument( "--tab-separated",
         dest="tab_separated",
         action="store_true",
         help="Flag for whether the instrument files are tab separated.",
@@ -59,7 +61,6 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "-d",
         "--data-dictionary",
         dest="data_dictionary",
         help="The tab separated file that contains descriptions of measures.",
@@ -88,13 +89,6 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--force",
-        dest="force",
-        help="overwrites already existing pheno db file.",
-        action="store_true",
-    )
-
-    parser.add_argument(
         "--continue",
         dest="browser_only",
         help="Perform the second browser generation step on an existing DB.",
@@ -107,6 +101,8 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
         help="Perform the data import step only.",
         action="store_true",
     )
+
+    TaskGraphCli.add_arguments(parser, use_commands=False)
 
     return parser
 
@@ -171,15 +167,23 @@ def build_browser(
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
+    kwargs = copy(vars(args))
+    pheno_db_filename = args.pheno_db_filename
+    del kwargs["pheno_db_filename"]
+    pheno_name = args.pheno_name
+    del kwargs["pheno_name"]
+    
+
     build_pheno_browser(
-        args.pheno_db_filename,
-        args.pheno_name,
+        pheno_db_filename,
+        pheno_name,
         output_dir,
         regressions,
+        **kwargs
     )
 
     pheno_conf_path = os.path.join(
-        output_dir, f"{args.pheno_name}.yaml",
+        output_dir, f"{pheno_name}.yaml",
     )
 
     with open(pheno_conf_path, "w") as pheno_conf_file:

--- a/integration/local/entrypoint.sh
+++ b/integration/local/entrypoint.sh
@@ -18,8 +18,9 @@ cd /wd/integration/fixtures/pheno/comp-data
 
 /opt/conda/bin/conda run --no-capture-output -n gpf \
     pheno_import --force -p comp_pheno.ped \
-    -o $DAE_DB_DIR/pheno/comp_pheno
-    -i instruments/ -d comp_pheno_data_dictionary.tsv --pheno-id comp_pheno \
+    -o $DAE_DB_DIR/pheno/comp_pheno \
+    --force \
+    -i instruments/ --data-dictionary comp_pheno_data_dictionary.tsv --pheno-id comp_pheno \
     --regression comp_pheno_regressions.conf \
     --person-column personId
 

--- a/integration/remote/entrypoint.sh
+++ b/integration/remote/entrypoint.sh
@@ -24,7 +24,8 @@ cd /wd/integration/fixtures/pheno/comp-data
 /opt/conda/bin/conda run --no-capture-output -n gpf \
     pheno_import --force -p comp_pheno.ped \
     -o $DAE_DB_DIR/pheno/comp_pheno \
-    -i instruments/ -d comp_pheno_data_dictionary.tsv --pheno-id comp_pheno \
+    --force \
+    -i instruments/ --data-dictionary comp_pheno_data_dictionary.tsv --pheno-id comp_pheno \
     --regression comp_pheno_regressions.conf \
     --person-column personId
 


### PR DESCRIPTION
## Background
When updating the pheno browser import scripts, the import was noticeably slow when performing the browser regression and image generation steps. We decided to attempt to parallelize the process using the `TaskGraph`.

## Implementation
For every single measure in every single instrument, a single task is created for calculating and generating regressions and images. The code had to be moved around a bit, due to connections not being serializable and a workaround has been implemented for workers to be able to access the DB due to DuckDB's read/write limitations: when creating workers, a temporary copy for reading is created. A new utility has been added to the task graph toolkit for running a task graph and getting direct results from the tasks.

