### PR TITLE
update annotate doc template

### DIFF
--- a/dae/dae/annotation/effect_annotator.py
+++ b/dae/dae/annotation/effect_annotator.py
@@ -63,9 +63,9 @@ class EffectAnnotatorAdapter(AnnotatorBase):
 
         info.documentation += textwrap.dedent("""
 
-* Annotator to identify the effect of the variant on protein coding.
+Annotator to identify the effect of the variant on protein coding.
 
-* <a href="https://iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#effect-annotator" target="_blank">More info</a>
+<a href="https://iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#effect-annotator" target="_blank">More info</a>
 
 """)  # noqa
         info.resources += [genome.resource, gene_models.resource]

--- a/dae/dae/annotation/liftover_annotator.py
+++ b/dae/dae/annotation/liftover_annotator.py
@@ -88,9 +88,9 @@ class AbstractLiftoverAnnotator(AnnotatorBase):
 
         info.documentation += textwrap.dedent("""
 
-* Annotator to lift over a variant from one reference genome to another.
+Annotator to lift over a variant from one reference genome to another.
 
-* <a href="https://iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#lift-over-annotator" target="_blank">More info</a>
+<a href="https://iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#lift-over-annotator" target="_blank">More info</a>
 
 """)  # noqa
         info.resources += [

--- a/dae/dae/annotation/score_annotator.py
+++ b/dae/dae/annotation/score_annotator.py
@@ -104,7 +104,7 @@ class GenomicScoreAnnotatorBase(Annotator):
 
 ![HISTOGRAM]({hist_url})
 
-small values: {score_def.small_values_desc},
+small values: {score_def.small_values_desc}\n
 large_values {score_def.large_values_desc}
         """
 
@@ -241,10 +241,10 @@ class PositionScoreAnnotator(PositionScoreAnnotatorBase):
         self.position_score_queries = []
         info.documentation += textwrap.dedent("""
 
-* Annotator to use with genomic scores depending on genomic position like
-  phastCons, phyloP, FitCons2, etc.
+Annotator to use with genomic scores depending on genomic position like
+phastCons, phyloP, FitCons2, etc.
 
-* <a href="https://www.iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#position-score" target="_blank">More info</a>
+<a href="https://www.iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#position-score" target="_blank">More info</a>
 
 """)  # noqa
 
@@ -298,10 +298,10 @@ class NPScoreAnnotator(PositionScoreAnnotatorBase):
         self.np_score_queries = []
         info.documentation += textwrap.dedent("""
 
-* Annotator to use with genomic scores depending on genomic position and
-  nucleotide change like CADD, MPC, etc.
+Annotator to use with genomic scores depending on genomic position and
+nucleotide change like CADD, MPC, etc.
 
-* <a href="https://www.iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#np-score" target="_blank">More info</a>
+<a href="https://www.iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#np-score" target="_blank">More info</a>
 
 """)  # noqa
 
@@ -362,10 +362,10 @@ class AlleleScoreAnnotator(GenomicScoreAnnotatorBase):
         self.allele_score_queries = []
         info.documentation += textwrap.dedent("""
 
-* Annotator to use with scores that depend on allele like
-  variant frequencies, etc.
+Annotator to use with scores that depend on allele like
+variant frequencies, etc.
 
-* <a href="https://www.iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#allele-score" target="_blank">More info</a>
+<a href="https://www.iossifovlab.com/gpfuserdocs/administration/annotation_tools.html#allele-score" target="_blank">More info</a>
 
 """)  # noqa
 

--- a/dae/dae/annotation/templates/annotate_doc_pipeline_template.jinja
+++ b/dae/dae/annotation/templates/annotate_doc_pipeline_template.jinja
@@ -155,11 +155,12 @@
         padding: 10px 8px;
       }
 
-      .markdown {
-        padding: 8px;
+      .resource-info {
+        font-style: italic;
+        padding: 10px 0 0 0;
       }
 
-      .resource, .annotator-description {
+      .resource {
         padding: 10px 8px;
       }
 
@@ -240,9 +241,9 @@
             <div class="attribute">
               <div class="attribute-info {{'attribute-internal' if attribute_info.internal }}">
                 <div class="attribute-name">
-                  {{attribute_info.name + ' (Internal)' if attribute_info.internal else attribute_info.name}}
+                  {{ attribute_info.name }}
                 </div>
-                <div class="attribute-type">Type: {{attribute_info.type}}</div>
+                <div class="attribute-type">Type: {{attribute_info.type + ' (Internal)' if attribute_info.internal else attribute_info.name}}</div>
               </div>
               <div class="attribute-description">
                 {{markdown(attribute_info.documentation)}}
@@ -258,7 +259,6 @@
           </div>
     
           {% if annotator_info.documentation %}
-            <summary>Summary:</summary>
             <div class="annotator-description">
               {{ markdown(annotator_info.documentation) }}
             </div>
@@ -271,13 +271,13 @@
           {% for genomic_resource in annotator_info.resources %}
             <div class="resource">
               <div><b>Resource</b></div>
-              <div>id: <a href="{{genomic_resource.get_url()}}/index.html">
+              <div class="resource-info">Id: <a href="{{genomic_resource.get_url()}}/index.html">
                       {{genomic_resource.get_id()}}</a></div>                            
-              <div>type: {{genomic_resource.get_type()}}</div>
+              <div class="resource-info">Type: {{genomic_resource.get_type()}}</div>
               {% if genomic_resource.get_summary() %}
-                <summary>Summary:</summary>
-                <div class="markdown">
-                  {{ markdown(genomic_resource.get_summary()) }}
+                <div class="resource-info">Summary:</div>
+                <div>
+                  {{ genomic_resource.get_summary() }}
                 </div>
               {% endif %}
             </div>


### PR DESCRIPTION
## Background
More annotate doc ui improvements

## Aim
Remove the bullets from the Annotator Type "Summary".
Also, remove the "Summary" label.
Don't interpret the resource summaries as MD. Assume text.
In a short term, pub small values and large values labels for genomic scores on a separate lines. 
The "(Internal)" should be smaller, and possibly on the right.

## Related issues
Move the small values and large values to the png.
