### PR TITLE
Move STATICFILES_DIRS to dev settings

### DIFF
--- a/wdae/wdae/wdae/default_settings.py
+++ b/wdae/wdae/wdae/default_settings.py
@@ -4,8 +4,6 @@
 import logging
 import os
 
-from dae.pheno.pheno_data import get_pheno_browser_images_dir
-
 DEBUG = os.environ.get("WDAE_DEBUG", "False") == "True"
 
 
@@ -135,18 +133,6 @@ STATIC_ROOT = ""
 STATIC_URL = "static/"
 
 APPEND_SLASH = False
-
-
-PHENO_BROWSER_CACHE = get_pheno_browser_images_dir()
-
-# Additional locations of static files
-STATICFILES_DIRS = (
-    # Put strings here, like "/home/html/static" or "C:/www/django/static".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    ("images", PHENO_BROWSER_CACHE),
-)
-
 
 # List of finder classes that know how to find static files in
 # various locations.

--- a/wdae/wdae/wdae/settings.py
+++ b/wdae/wdae/wdae/settings.py
@@ -7,6 +7,8 @@ import os
 from gpf_instance.gpf_instance import get_wgpf_instance_path
 from .default_settings import *
 
+from dae.pheno.pheno_data import get_pheno_browser_images_dir
+
 DEBUG = True
 
 ALLOWED_HOSTS += ["localhost"]
@@ -23,6 +25,16 @@ CORS_ORIGIN_WHITELIST = [
     "http://localhost:8000",
     "http://127.0.0.1:8000",
 ]
+
+PHENO_BROWSER_CACHE = get_pheno_browser_images_dir()
+
+# Additional locations of static files
+STATICFILES_DIRS = (
+    # Put strings here, like "/home/html/static" or "C:/www/django/static".
+    # Always use forward slashes, even on Windows.
+    # Don't forget to use absolute paths, not relative paths.
+    ("images", PHENO_BROWSER_CACHE),
+)
 
 CORS_ALLOW_CREDENTIALS = True
 


### PR DESCRIPTION
## Background
After fixing pheno browser images, `STATICFILES_DIRS` being placed in the default_settings and going into production is now causing issues and unintended behavior.

## Aim
Move `STATICFILES_DIRS` to the development `settings.py`