### PR TITLE
fix grr gene scores info page missing description

### DIFF
--- a/dae/dae/gene_scores/implementations/gene_scores_impl.py
+++ b/dae/dae/gene_scores/implementations/gene_scores_impl.py
@@ -160,7 +160,7 @@ GENE_SCORES_TEMPLATE = """
                 <td>{{ score.value_type }}</td>
 
                 <td>
-                    <div>{{ score_def.description }}</div>
+                    <div>{{ score_def.desc }}</div>
                     {% if score_def.small_values_desc %}
                         <div style="color: rgb(145,145,145)">
                             {{ "Small values desc: " + score_def.small_values_desc }}


### PR DESCRIPTION
## Background
Missing gene scores grr info page description to scores table

## Aim
Add gene scores grr info page description to scores table

## Implementation
Change description to desc
