### PR TITLE
fix child description links

### DIFF
--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -71,8 +71,8 @@ def test_datasets_api_get_dataset_with_hierarchy_description(
     data = response.data  # type: ignore
     assert data["data"]["children_description"] == (
         "\nThis dataset includes:\n"
-        "- **[Study1](Study1)** some new description\n\n"
-        "- **[Study3](Study3)** \n"
+        "- **[Study1](datasets/Study1)** some new description\n\n"
+        "- **[Study3](datasets/Study3)** \n"
     )
 
 

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -71,7 +71,7 @@ def produce_description_hierarchy(
                     indent_level + 1
                 )
                 res.append(
-                    f"{indent}- **[{child.name}]({child.study_id})** "
+                    f"{indent}- **[{child.name}](datasets/{child.study_id})** "
                     f"{get_first_paragraph(child.description)}\n"
                     f"{child_descriptions}"
                 )


### PR DESCRIPTION
## Background

#648

## Aim

To fix it.

## Implementation

Add `'datasets/'` to the url of children description.
