### PR TITLE
Batch annotation for annotate_columns

### DIFF
--- a/dae/dae/annotation/annotate_utils.py
+++ b/dae/dae/annotation/annotate_utils.py
@@ -130,6 +130,11 @@ class AnnotationTool:
         return pipeline
 
     def _get_pipeline_config(self) -> str:
+        if self.args.pipeline == "context":
+            return pathlib.Path(
+                self.gpf_instance.dae_dir,
+                self.gpf_instance.dae_config.annotation.conf_file,
+            ).read_text()
         if (pipeline_path := pathlib.Path(self.args.pipeline)).exists():
             return pipeline_path.read_text()
         if (pipeline_res := self.grr.find_resource(self.args.pipeline)):

--- a/dae/dae/annotation/tests/test_annotate_columns.py
+++ b/dae/dae/annotation/tests/test_annotate_columns.py
@@ -264,3 +264,38 @@ def test_cli_columns_basic_setup(
     out_file_content = get_file_content_as_string(str(out_file))
     print(out_file_content)
     assert out_file_content == out_expected_content
+
+def test_cli_batch_mode(
+        annotate_directory_fixture: pathlib.Path) -> None:
+    in_content = textwrap.dedent("""
+        chrom   pos
+        chr1    23
+        chr1    24
+    """)
+    out_expected_content = (
+        "chrom\tpos\tscore\n"
+        "chr1\t23\t0.1\n"
+        "chr1\t24\t0.2\n"
+    )
+
+    root_path = annotate_directory_fixture
+    in_file = root_path / "in.txt"
+    out_file = root_path / "out.txt"
+    annotation_file = root_path / "annotation.yaml"
+    grr_file = root_path / "grr.yaml"
+    work_dir = root_path / "work"
+
+    setup_denovo(in_file, in_content)
+
+    cli_columns([
+        str(a) for a in [
+            in_file, annotation_file, "-o", out_file,
+            "-w", work_dir,
+            "--grr", grr_file,
+            "--batch-mode",
+            "-j", 1,
+        ]
+    ])
+    out_file_content = get_file_content_as_string(str(out_file))
+    print(out_file_content)
+    assert out_file_content == out_expected_content


### PR DESCRIPTION
## Background

We decided to add batch mode annotation to provide better support for third party tools in our annotation pipeline

## Aim

This PR adds a batch mode to `annotate_columns` and basic pipeline support for batch mode

## Implementation

The annotator base class has received a new method for batch annotation, which calls `annotate` on a list of `Annotatable`. `annotate_columns` has a new optional argument to use the new batch annotation mode. Batch annotation currently stores a list of every record in memory and can be optimized further.
