### PR TITLE
Grr info page fixes

### DIFF
--- a/dae/dae/gene_scores/implementations/gene_scores_impl.py
+++ b/dae/dae/gene_scores/implementations/gene_scores_impl.py
@@ -141,6 +141,50 @@ GENE_SCORES_TEMPLATE = """
 {% extends base %}
 {% block content %}
 
+<style>
+    .modal {
+        display: none;
+        position: fixed;
+        z-index: 1;
+        padding-top: 100px;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0,0,0,0.5);
+        justify-content: center;
+    }
+    .modal-content {
+        margin: auto;
+        display: block;
+        width: 80%;
+        max-width: 700px;
+    }
+    .close {
+        float: right;
+        font-size: 40px;
+        font-weight: bold;
+    }
+    .close:hover,
+    .close:focus {
+         color: #bbb;
+         text-decoration: none;
+         cursor: pointer;
+    }
+</style>
+{% block javascript %}
+    <script type="text/javascript">
+        function openModal(scoreId) {
+            var modal = document.getElementById("modal-" + scoreId);
+            modal.style.display = "flex";
+        }
+        function closeModal(scoreId) {
+            var modal = document.getElementById("modal-" + scoreId);
+            modal.style.display = "none";
+        }
+    </script>
+{% endblock %}
+
 {% set score = data.gene_score %}
 
 <h1>Scores</h1>
@@ -178,9 +222,11 @@ GENE_SCORES_TEMPLATE = """
                 {% if hist %}
                     <div class="histogram">
                         <img src="{{score.get_histogram_image_filename(score_id)}}"
-                        width="200px"
-                        alt={{ score_id }}
-                        title={{ score_id }}>
+                            width="200px"
+                            alt={{ score_id }}
+                            title={{ score_id | replace(" ", "_")}}
+                            style="cursor: pointer"
+                            onclick="openModal(title)">>
                     </div>
                 {% endif %}
                 </td>
@@ -194,6 +240,18 @@ GENE_SCORES_TEMPLATE = """
                 </td>
             </tr>
         {% endfor %}
+        {%- for score_id in score.score_definitions.keys() -%}
+            <div id="modal-{{score_id | replace(" ", "_")}}" class="modal">
+                <div style="padding: 10px 20px; background-color: #fff; height: fit-content; width: fit-content;">
+                    <span title={{score_id | replace(" ", "_")}} class="close" onclick="closeModal(title)">&times;</span>
+                    <img class="modal-content" id="histogram-{{score_id}}"
+                        src="{{ score.get_histogram_image_filename(score_id) }}"
+                        alt="{{ "HISTOGRAM FOR " + score_id }}"
+                        title={{ score_id | replace(" ", "_")}}
+                        width="200">
+                </div>
+            </div>
+        {%- endfor %}
     </table>
 {% endblock %}
 """  # noqa: E501

--- a/dae/dae/genomic_resources/implementations/gene_models_impl.py
+++ b/dae/dae/genomic_resources/implementations/gene_models_impl.py
@@ -107,7 +107,25 @@ class GeneModelsImpl(
 
                 <p>Format: {{ data.config.format }}</p>
             <h1>Statistics</h1>
+                <div style="width: fit-content">
+                    <h2>Global statistics</h2>
+                    <table border="1">
+                        <tr>
+                            <th>Transcript number</th>
+                            <th>Protein coding transcript number</th>
+                            <th>Gene number</th>
+                            <th>Protein coding gene number</th>
+                        </tr>
+                        <tr>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.transcript_number)}}</td>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_transcript_number)}}</td>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.gene_number)}}</td>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_gene_number)}}</td>
+                        </tr>
+                    </table>
+                </div>
                 <div style="max-height: 50%; overflow-y: auto; width: fit-content">
+                    <h2>Per chromosome statistics</h2>
                     <table border="1">
                         <tr>
                             <th></th>
@@ -115,13 +133,6 @@ class GeneModelsImpl(
                             <th>Protein coding transcript number</th>
                             <th>Gene number</th>
                             <th>Protein coding gene number</th>
-                        </tr>
-                        <tr>
-                            <th>Global</th>
-                            <td>{{ '{:,}'.format(data.stats.global_statistic.transcript_number)}}</td>
-                            <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_transcript_number)}}</td>
-                            <td>{{ '{:,}'.format(data.stats.global_statistic.gene_number)}}</td>
-                            <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_gene_number)}}</td>
                         </tr>
                         {% for chrom, stat in data.stats.chrom_statistics.items() %}
                             <tr>

--- a/dae/dae/genomic_resources/implementations/gene_models_impl.py
+++ b/dae/dae/genomic_resources/implementations/gene_models_impl.py
@@ -107,31 +107,33 @@ class GeneModelsImpl(
 
                 <p>Format: {{ data.config.format }}</p>
             <h1>Statistics</h1>
-                <table border="1">
-                    <tr>
-                        <th></th>
-                        <th>Transcript number</th>
-                        <th>Protein coding transcript number</th>
-                        <th>Gene number</th>
-                        <th>Protein coding gene number</th>
-                    </tr>
-                    <tr>
-                        <th>Global</th>
-                        <td>{{ '{:,}'.format(data.stats.global_statistic.transcript_number)}}</td>
-                        <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_transcript_number)}}</td>
-                        <td>{{ '{:,}'.format(data.stats.global_statistic.gene_number)}}</td>
-                        <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_gene_number)}}</td>
-                    </tr>
-                    {% for chrom, stat in data.stats.chrom_statistics.items() %}
+                <div style="max-height: 50%; overflow-y: auto; width: fit-content">
+                    <table border="1">
                         <tr>
-                            <th>{{"Chromosome number: " + chrom}}</th>
-                            <td>{{ '{:,}'.format(stat.transcript_number)}}</td>
-                            <td>{{ '{:,}'.format(stat.protein_coding_transcript_number)}}</td>
-                            <td>{{ '{:,}'.format(stat.gene_number)}}</td>
-                            <td>{{ '{:,}'.format(stat.protein_coding_gene_number)}}</td>
+                            <th></th>
+                            <th>Transcript number</th>
+                            <th>Protein coding transcript number</th>
+                            <th>Gene number</th>
+                            <th>Protein coding gene number</th>
                         </tr>
-                    {% endfor %}
-                </table>
+                        <tr>
+                            <th>Global</th>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.transcript_number)}}</td>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_transcript_number)}}</td>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.gene_number)}}</td>
+                            <td>{{ '{:,}'.format(data.stats.global_statistic.protein_coding_gene_number)}}</td>
+                        </tr>
+                        {% for chrom, stat in data.stats.chrom_statistics.items() %}
+                            <tr>
+                                <th>{{ chrom }}</th>
+                                <td>{{ '{:,}'.format(stat.transcript_number)}}</td>
+                                <td>{{ '{:,}'.format(stat.protein_coding_transcript_number)}}</td>
+                                <td>{{ '{:,}'.format(stat.gene_number)}}</td>
+                                <td>{{ '{:,}'.format(stat.protein_coding_gene_number)}}</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
             {% endblock %}
         """))
 

--- a/dae/dae/genomic_resources/implementations/genomic_scores_impl.py
+++ b/dae/dae/genomic_resources/implementations/genomic_scores_impl.py
@@ -493,6 +493,55 @@ GENOMIC_SCORES_TEMPLATE = """
 {% extends base %}
 {% block content %}
 
+<style>
+    .modal {
+        display: none;
+        position: fixed;
+        z-index: 1;
+        padding-top: 100px;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0,0,0,0.5);
+        justify-content: center;
+    }
+
+    .modal-content {
+        margin: auto;
+        display: block;
+        width: 80%;
+        max-width: 700px;
+    }
+
+    .close {
+        float: right;
+        font-size: 40px;
+        font-weight: bold;
+    }
+
+    .close:hover,
+    .close:focus {
+         color: #bbb;
+         text-decoration: none;
+         cursor: pointer;
+    }
+</style>
+
+{% block javascript %}
+    <script type="text/javascript">
+        function openModal(scoreId) {
+            var modal = document.getElementById("modal-" + scoreId);
+            modal.style.display = "flex";
+        }
+
+        function closeModal(scoreId) {
+            var modal = document.getElementById("modal-" + scoreId);
+            modal.style.display = "none";
+        }
+    </script>
+{% endblock %}
+
 {% set impl = data.genomic_scores %}
 {% set scores = impl.score %}
 
@@ -541,8 +590,10 @@ GENOMIC_SCORES_TEMPLATE = """
                     impl.score.get_histogram_image_filename(score_id) %}
                 <img src="{{ hist_image_file }}"
                     alt="{{ "HISTOGRAM FOR " + score_id }}"
-                    title={{ score_id }}
-                    width="200">
+                    title={{ score_id | replace(" ", "_") }}
+                    width="200"
+                    style="cursor: pointer"
+                    onclick="openModal(title)">
                 {%- else -%}
                 NO HISTOGRAM
                 {%- endif -%}
@@ -557,6 +608,18 @@ GENOMIC_SCORES_TEMPLATE = """
             </td>
 
         </tr>
+    {%- endfor %}
+    {%- for score_id in scores.score_definitions.keys() -%}
+        <div id="modal-{{score_id | replace(" ", "_")}}" class="modal">
+            <div style="padding: 10px 20px; background-color: #fff; height: fit-content; width: fit-content;">
+                <span title={{score_id | replace(" ", "_")}} class="close" onclick="closeModal(title)">&times;</span>
+                <img class="modal-content" id="histogram-{{score_id}}"
+                    src="{{ impl.score.get_histogram_image_filename(score_id) }}"
+                    alt="{{ "HISTOGRAM FOR " + score_id }}"
+                    title={{ score_id | replace(" ", "_")}}
+                    width="200">
+            </div>
+        </div>
     {%- endfor %}
 </table>
 

--- a/dae/dae/genomic_resources/implementations/reference_genome_impl.py
+++ b/dae/dae/genomic_resources/implementations/reference_genome_impl.py
@@ -387,7 +387,7 @@ class ReferenceGenomeImplementation(
                         <th>Chrom</th>
                         <th>Length</th>
                         {% for nucleotide in
-                            data["global_statistic"]["nuc_distribution"].keys() %}
+                            data["global_statistic"]["nuc_distribution"].keys()|sort %}
                             <th>{{ nucleotide }}</th>
                         {% endfor %}
                     </tr>
@@ -396,7 +396,7 @@ class ReferenceGenomeImplementation(
                             <td>{{ chrom }}</td>
                             <td>{{ '{:,}'.format(length) }}</td>
                             {% for nucleotide in
-                                data["global_statistic"]["nuc_distribution"].keys() %}
+                                data["global_statistic"]["nuc_distribution"].keys()|sort %}
                                 {% if data["chrom_statistics"].get(chrom) %}
                                     <td>{{ "%0.2f%%" % data["chrom_statistics"].get(chrom).nucleotide_distribution.get(nucleotide) }}</td>
                                 {% else %}


### PR DESCRIPTION
## Background
Further adjustments to the info pages.
Histograms are too small to look at.

## Aim
Some fixes and adjustments to the info pages.
Make histograms easier to look at by adding a histogram modal view.

## Implementation
Clicking on histograms should open a modal view.


