### PR TITLE
add gp gene symbols api

### DIFF
--- a/dae/dae/gene_profile/tests/test_gpdb.py
+++ b/dae/dae/gene_profile/tests/test_gpdb.py
@@ -120,3 +120,26 @@ def test_gpdb_sort(
     stats_sorted = gp_gpf_instance.query_gp_statistics(
         1, sort_by="main_CHD8 target genes", order="desc",
     )
+
+
+def test_gpdb_symbol_search(
+        gp_gpf_instance: GPFInstance,
+        sample_gp: GPStatistic) -> None:
+    sample_gp.gene_symbol = "CHD7"
+    gp_gpf_instance._gene_profile_db.insert_gp(sample_gp)
+    sample_gp.gene_symbol = "TESTCHD"
+    gp_gpf_instance._gene_profile_db.insert_gp(sample_gp)
+
+    all_symbols = gp_gpf_instance._gene_profile_db.list_symbols(1)
+    assert len(all_symbols) == 3
+    assert all_symbols[0] == "CHD7"
+    assert all_symbols[-1] == "TESTCHD"
+
+    all_symbols = gp_gpf_instance._gene_profile_db.list_symbols(1, "CHD")
+    assert len(all_symbols) == 2
+    assert all_symbols[0] == "CHD7"
+    assert all_symbols[-1] == "CHD8"
+
+    all_symbols = gp_gpf_instance._gene_profile_db.list_symbols(1, "TEST")
+    assert len(all_symbols) == 1
+    assert all_symbols[0] == "TESTCHD"

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -507,6 +507,16 @@ class GPFInstance:
         ))
         return cast(list[GPStatistic], statistics)
 
+    def list_gp_gene_symbols(
+        self,
+        page: int,
+        symbol_like: Optional[str] = None,
+    ) -> list[str]:
+        """Query AGR statistics and return results."""
+        return self._gene_profile_db.list_symbols(
+            page, symbol_like,
+        )
+
     def _construct_import_effect_annotator_config(
         self,
     ) -> dict[str, Any]:

--- a/wdae/wdae/gene_profiles_api/table_views.py
+++ b/wdae/wdae/gene_profiles_api/table_views.py
@@ -4,6 +4,7 @@ from datasets_api.permissions import get_instance_timestamp_etag
 from query_base.query_base import QueryBaseView
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.request import Request
 
 from django.views.decorators.http import etag
 from django.utils.decorators import method_decorator
@@ -32,6 +33,23 @@ class TableRowsView(QueryBaseView):
         order = data.get("order", None)
         gps = self.gpf_instance.query_gp_statistics(
             page, symbol_like, sort_by, order)
+        if gps is None:
+            return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return Response(gps)
+
+
+class GeneSymbolsView(QueryBaseView):
+    """View for providing gene symbols."""
+    @method_decorator(etag(get_instance_timestamp_etag))
+    def get(self, request: Request) -> Response:
+        """Get gene symbols from the gp table."""
+        data = request.query_params
+        page = int(data.get("page", 1))
+        if page < 1:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+        symbol_like = data.get("symbol", None)
+        gps = self.gpf_instance.list_gp_gene_symbols(
+            page, symbol_like)
         if gps is None:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(gps)

--- a/wdae/wdae/gene_profiles_api/tests/test_agp_api.py
+++ b/wdae/wdae/gene_profiles_api/tests/test_agp_api.py
@@ -131,3 +131,17 @@ def test_get_statistics(admin_client: Client) -> None:
     response = admin_client.get(f"{ROUTE_PREFIX}/table/rows")
     assert response.status_code == 200
     print(response.data)  # type: ignore
+
+
+def test_get_gene_symbols(admin_client: Client) -> None:
+    response = admin_client.get(f"{ROUTE_PREFIX}/table/gene_symbols")
+    assert response.status_code == 200
+    assert response.data == ["CHD8"]  # type: ignore
+
+
+def test_get_nonexisting_gene_symbols(admin_client: Client) -> None:
+    response = admin_client.get(
+        f"{ROUTE_PREFIX}/table/gene_symbols?symbol=DIABLO",
+    )
+    assert response.status_code == 200
+    assert response.data == []  # type: ignore

--- a/wdae/wdae/gene_profiles_api/urls.py
+++ b/wdae/wdae/gene_profiles_api/urls.py
@@ -6,21 +6,26 @@ urlpatterns = [
     re_path(
         r"^/table/configuration/?$",
         table_views.TableConfigurationView.as_view(),
-        name="agp_table_configuration",
+        name="gp_table_configuration",
     ),
     re_path(
         r"^/table/rows/?$",
         table_views.TableRowsView.as_view(),
-        name="agp_table_rows",
+        name="gp_table_rows",
     ),
     re_path(
         r"^/single-view/configuration/?$",
         views.ConfigurationView.as_view(),
-        name="agp_single_view_configuration",
+        name="gp_single_view_configuration",
     ),
     re_path(
         r"^/single-view/gene/(?P<gene_symbol>.+)/?$",
         views.ProfileView.as_view(),
-        name="agp_single_view_profile",
+        name="gp_single_view_profile",
+    ),
+    re_path(
+        r"^/table/gene_symbols/?$",
+        table_views.GeneSymbolsView.as_view(),
+        name="gp_gene_symbols",
     ),
 ]


### PR DESCRIPTION
## Background
Home page search is inaccurate.

## Aim
Make shorter gene symbols appear when searching for them by creating new gp gene symbols api for this specific search.

## Implementation
New api providing only gp gene symbols, sorted.

