### PR TITLE
order alphabetically pheno db search results

### DIFF
--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -491,7 +491,10 @@ class PhenoDb:  # pylint: disable=too-many-instance-attributes
             query = query.where(
                 self.variable_browser.c.instrument_name == instrument_name,
             )
-        return query.order_by(self.variable_browser.c.instrument_name)
+        return query.order_by(
+            self.variable_browser.c.instrument_name,
+            self.variable_browser.c.measure_id,
+        )
 
     def search_measures(
         self, instrument_name: str | None = None,


### PR DESCRIPTION
## Background
Ordering pheno db search results only on instrument name is not enough.

## Aim
Order on both instrument name and measure id.

## Implementation
Use a combined `order by` on both columns.