### PR TITLE
Improvement and fixes in serialisation of gene models in GTF format

### DIFF
--- a/dae/dae/enrichment_tool/build_coding_length_enrichment_background.py
+++ b/dae/dae/enrichment_tool/build_coding_length_enrichment_background.py
@@ -23,8 +23,10 @@ def cli(argv: list[str] | None = None) -> None:
     """Command line tool to create coding length enrichment background."""
     if argv is None:
         argv = sys.argv[1:]
-    description = "Command line tool to create coding length enrichment " \
+    description = (
+        "Command line tool to create coding length enrichment "
         "background"
+    )
     parser = argparse.ArgumentParser(description=description)
     VerbosityConfiguration.set_arguments(parser)
 

--- a/dae/dae/enrichment_tool/tests/test_build_coding_length_background.py
+++ b/dae/dae/enrichment_tool/tests/test_build_coding_length_background.py
@@ -44,4 +44,4 @@ def test_build_coding_length_background(
     df = pl.read_csv(str(output), separator="\t")
     assert df.shape == (2, 2)
     assert df["gene"].to_list() == ["T4", "C8"]
-    assert df["gene_weight"].to_list() == [41, 43]
+    assert df["gene_weight"].to_list() == [44, 45]

--- a/dae/dae/enrichment_tool/tests/test_t4c8_enrichment.py
+++ b/dae/dae/enrichment_tool/tests/test_t4c8_enrichment.py
@@ -15,7 +15,7 @@ from dae.testing import denovo_study, setup_denovo, setup_pedigree
 
 @pytest.fixture()
 def ped_1(tmp_path: pathlib.Path) -> pathlib.Path:
-    ped_path = setup_pedigree(
+    return setup_pedigree(
         tmp_path / "input" / "ped_1" / "in.ped",
         """
 familyId personId dadId momId sex status role
@@ -26,12 +26,11 @@ f1.3     mom3     0     0     2   1      mom
 f1.3     dad3     0     0     1   1      dad
 f1.3     ch3      dad3  mom3  2   2      prb
         """)
-    return ped_path
 
 
 @pytest.fixture()
 def denovo_1(tmp_path: pathlib.Path) -> pathlib.Path:
-    denovo_path = setup_denovo(
+    return setup_denovo(
         tmp_path / "input" / "denovo_1" / "denovo.tsv",
         """
 familyId  location  variant    bestState
@@ -45,7 +44,6 @@ f1.1      chr1:195  sub(C->T)  2||2||1/0||0||1
 f1.3      chr1:145  sub(C->T)  2||2||1/0||0||1
         """,
     )
-    return denovo_path
 
 
 @pytest.fixture()
@@ -55,7 +53,7 @@ def study_1(
     ped_1: pathlib.Path,
     denovo_1: pathlib.Path,
 ) -> GenotypeData:
-    result = denovo_study(
+    return denovo_study(
         tmp_path, "study_1", ped_1, [denovo_1],
         t4c8_fixture,
         study_config_update={
@@ -90,7 +88,6 @@ def study_1(
                 ],
             },
         })
-    return result
 
 
 def test_t4c8_setup(t4c8_fixture: GPFInstance) -> None:
@@ -108,16 +105,16 @@ def test_t4c8_coding_len_background(t4c8_fixture: GPFInstance) -> None:
     assert background is not None
     background.load()
 
-    assert background.genes_weight(["t4"]) == 41
-    assert background.genes_weight(["c8"]) == 43
+    assert background.genes_weight(["t4"]) == 44
+    assert background.genes_weight(["c8"]) == 45
     assert background.genes_weight(["t1"]) == 0
-    assert background._total == 84
+    assert background._total == 89
 
-    assert background.genes_weight(["T4"]) == 41
-    assert background.genes_weight(["C8"]) == 43
+    assert background.genes_weight(["T4"]) == 44
+    assert background.genes_weight(["C8"]) == 45
 
-    assert background.genes_weight(["T4", "C8"]) == 84
-    assert background.genes_weight(["T4", "C8", "T1"]) == 84
+    assert background.genes_weight(["T4", "C8"]) == 89
+    assert background.genes_weight(["T4", "C8", "T1"]) == 89
 
 
 def test_study_1(study_1: GenotypeData) -> None:
@@ -157,17 +154,17 @@ def test_study_1_enrichment(
     res = affected["LGDs"]
     assert res.all.events == 2
     assert res.all.overlapped == 0
-    assert res.all.expected == pytest.approx(0.976, 0.001)
+    assert res.all.expected == pytest.approx(0.988, 0.001)
 
     res = affected["missense"]
     assert res.all.events == 2
     assert res.all.overlapped == 2
-    assert res.all.expected == pytest.approx(0.976, 0.001)
+    assert res.all.expected == pytest.approx(0.988, 0.001)
 
     res = affected["synonymous"]
     assert res.all.events == 3
     assert res.all.overlapped == 2
-    assert res.all.expected == pytest.approx(1.464, 0.001)
+    assert res.all.expected == pytest.approx(1.483, 0.001)
 
 
 def test_study_1_enrichment_with_caching(
@@ -197,17 +194,17 @@ def test_study_1_enrichment_with_caching(
     res = affected["LGDs"]
     assert res.all.events == 2
     assert res.all.overlapped == 0
-    assert res.all.expected == pytest.approx(0.976, 0.001)
+    assert res.all.expected == pytest.approx(0.988, 0.001)
 
     res = affected["missense"]
     assert res.all.events == 2
     assert res.all.overlapped == 2
-    assert res.all.expected == pytest.approx(0.976, 0.001)
+    assert res.all.expected == pytest.approx(0.988, 0.001)
 
     res = affected["synonymous"]
     assert res.all.events == 3
     assert res.all.overlapped == 2
-    assert res.all.expected == pytest.approx(1.464, 0.001)
+    assert res.all.expected == pytest.approx(1.483, 0.001)
 
 
 def test_build_study_1_enrichment_cache(

--- a/dae/dae/genomic_resources/gene_models.py
+++ b/dae/dae/genomic_resources/gene_models.py
@@ -7,7 +7,6 @@ import logging
 import operator
 from collections import defaultdict
 from datetime import datetime
-from io import StringIO
 from typing import IO, Any, ClassVar, Protocol, cast
 
 import pandas as pd
@@ -401,12 +400,12 @@ class TranscriptModel:
     def update_frames(self) -> None:
         """Update codon frames."""
         frames = self.calc_frames()
-        for exon, frame in zip(self.exons, frames):
+        for exon, frame in zip(self.exons, frames, strict=True):
             exon.frame = frame
 
     def test_frames(self) -> bool:
         frames = self.calc_frames()
-        for exon, frame in zip(self.exons, frames):
+        for exon, frame in zip(self.exons, frames, strict=True):
             if exon.frame != frame:
                 return False
         return True
@@ -682,7 +681,8 @@ class GeneModels(
             assert len(exon_starts) == len(exon_ends) == len(exon_frames)
 
             exons = []
-            for start, end, frame in zip(exon_starts, exon_ends, exon_frames):
+            for start, end, frame in zip(exon_starts, exon_ends, exon_frames,
+                                         strict=True):
                 exons.append(Exon(start=start, stop=end, frame=frame))
             attributes: dict = {}
             atts = line.get("atts")
@@ -761,7 +761,7 @@ class GeneModels(
 
             exons = [
                 Exon(start + 1, end)
-                for start, end in zip(exon_starts, exon_ends)
+                for start, end in zip(exon_starts, exon_ends, strict=True)
             ]
 
             transcript_ids_counter[tr_name] += 1
@@ -837,7 +837,7 @@ class GeneModels(
 
             exons = [
                 Exon(start + 1, end)
-                for start, end in zip(exon_starts, exon_ends)
+                for start, end in zip(exon_starts, exon_ends, strict=True)
             ]
 
             transcript_ids_counter[tr_name] += 1
@@ -971,7 +971,7 @@ class GeneModels(
 
             exons = [
                 Exon(start + 1, end)
-                for start, end in zip(exon_starts, exon_ends)
+                for start, end in zip(exon_starts, exon_ends, strict=True)
             ]
 
             transcript_ids_counter[tr_name] += 1
@@ -1056,7 +1056,7 @@ class GeneModels(
 
             exons = [
                 Exon(start + 1, end)
-                for start, end in zip(exon_starts, exon_ends)
+                for start, end in zip(exon_starts, exon_ends, strict=True)
             ]
 
             transcript_ids_counter[tr_name] += 1
@@ -1179,7 +1179,7 @@ class GeneModels(
 
             exons = [
                 Exon(start + 1, end)
-                for start, end in zip(exon_starts, exon_ends)
+                for start, end in zip(exon_starts, exon_ends, strict=True)
             ]
 
             transcript_ids_counter[tr_name] += 1

--- a/dae/dae/genomic_resources/gene_models.py
+++ b/dae/dae/genomic_resources/gene_models.py
@@ -1491,6 +1491,11 @@ class GeneModels(
             "gene_mapping": {"type": "string"},
         }
 
+    @deprecated("Switch to using 'gene_models_to_gtf' function")
+    def to_gtf(self) -> str:
+        """Output gene models in GTF format."""
+        return gene_models_to_gtf(self)
+
 
 def join_gene_models(*gene_models: GeneModels) -> GeneModels:
     """Join muliple gene models into a single gene models object."""

--- a/dae/dae/genomic_resources/gene_models.py
+++ b/dae/dae/genomic_resources/gene_models.py
@@ -449,35 +449,37 @@ class TranscriptModel:
         for exon in self.exons:
             write_record("exon", exon.start, exon.stop, write_exon_number=True)
 
-        cds_regions = self.cds_regions()
-        if cds_regions:
-            for cds in cds_regions[:-1]:  # all but last CDS region
-                write_record("CDS", cds.start, cds.stop, write_exon_number=True)
-            # handle last separately, because the GTF format
-            # excludes the stop codon from the CDS regions
-            # also check if the adjustment we make leaves
-            # enough bases for it to have one codon at least
-            if ((cds_regions[-1].stop - 2) - cds_regions[-1].start) >= 2:
-                write_record("CDS",
-                    cds_regions[-1].start,
-                    cds_regions[-1].stop - 2,
-                    write_exon_number=True)
+        if self.is_coding():
+            cds_regions = self.cds_regions()
+            if cds_regions:
+                for cds in cds_regions[:-1]:  # all but last CDS region
+                    write_record("CDS", cds.start, cds.stop,
+                                 write_exon_number=True)
+                # handle last separately, because the GTF format
+                # excludes the stop codon from the CDS regions
+                # also check if the adjustment we make leaves
+                # enough bases for it to have one codon at least
+                if ((cds_regions[-1].stop - 2) - cds_regions[-1].start) >= 2:
+                    write_record("CDS",
+                        cds_regions[-1].start,
+                        cds_regions[-1].stop - 2,
+                        write_exon_number=True)
 
-        for utr in self.utr3_regions() + self.utr5_regions():
-            write_record("UTR", utr.start, utr.stop)
+            for utr in self.utr3_regions() + self.utr5_regions():
+                write_record("UTR", utr.start, utr.stop)
 
-        left = Region(self.chrom, self.cds[0], self.cds[0] + 2)
-        right = Region(self.chrom, self.cds[1] - 2, self.cds[1])
+            left = Region(self.chrom, self.cds[0], self.cds[0] + 2)
+            right = Region(self.chrom, self.cds[1] - 2, self.cds[1])
 
-        start_codon = left if self.strand == "+" else right
-        stop_codon = right if self.strand == "+" else left
+            start_codon = left if self.strand == "+" else right
+            stop_codon = right if self.strand == "+" else left
 
-        write_record("start_codon",
-                     start_codon.start, start_codon.stop,  # type: ignore
-                     write_exon_number=True)
-        write_record("stop_codon",
-                      stop_codon.start, stop_codon.stop,  # type: ignore
-                      write_exon_number=True)
+            write_record("start_codon",
+                        start_codon.start, start_codon.stop,  # type: ignore
+                        write_exon_number=True)
+            write_record("stop_codon",
+                        stop_codon.start, stop_codon.stop,  # type: ignore
+                        write_exon_number=True)
 
         return record_buffer
 

--- a/dae/dae/genomic_resources/tests/test_gene_models.py
+++ b/dae/dae/genomic_resources/tests/test_gene_models.py
@@ -3,7 +3,7 @@ import gzip
 import os
 import pathlib
 import textwrap
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 
@@ -34,112 +34,6 @@ def fixture_dirname() -> Callable:
 @pytest.fixture()
 def t4c8_gene_models(tmp_path: pathlib.Path) -> GeneModels:
     return t4c8_genes(tmp_path / "gene_models")
-
-
-@pytest.fixture()
-def ensembl_gtf_example() -> GeneModels:
-    # Example from: https://ftp.ensembl.org/pub/current/gtf/homo_sapiens/README
-    res = build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
-#!genome-build GRCh38
-11  ensembl_havana  gene        5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";
-11  ensembl_havana  transcript  5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
-11  ensembl_havana  exon        5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";exon_id||"ENSE00001276439";exon_version||"4";
-11  ensembl_havana  CDS         5422201  5423151  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";protein_id||"ENSP00000300778";protein_version||"4";
-11  ensembl_havana  start_codon 5422201  5422203  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
-11  ensembl_havana  stop_codon  5423152  5423154  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
-11  ensembl_havana  UTR         5422111  5422200  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
-11  ensembl_havana  UTR         5423155  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";tag||"a||b||c";
-""")),  # noqa: E501
-        })
-    return build_gene_models_from_resource(res)
-
-
-@pytest.fixture()
-def ensembl_gtf_example_shh() -> GeneModels:
-    # SHH = Sonic hedgehog gene
-    res = build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
-chr7    HAVANA  gene    155799980       155812463       .       -       .       gene_id||"ENSG00000164690.8";||gene_type||"protein_coding";||gene_name||"SHH";||level||2;||hgnc_id||"HGNC:10848";||havana_gene||"OTTHUMG00000151349.3";
-chr7    HAVANA  transcript      155799980       155812463       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  exon    155811823       155812463       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  CDS     155811823       155812122       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  start_codon     155812120       155812122       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  exon    155806296       155806557       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||2;||exon_id||"ENSE00001086617.1";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  CDS     155806296       155806557       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||2;||exon_id||"ENSE00001086617.1";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  exon    155799980       155803726       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  CDS     155802903       155803726       .       -       2       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  stop_codon      155802900       155802902       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  UTR     155812123       155812463       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-chr7    HAVANA  UTR     155799980       155802902       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
-"""))})  # noqa: E501
-    return build_gene_models_from_resource(res)
-
-
-@pytest.fixture()
-def gencode_46_calml_example() -> GeneModels:
-    # CALML6
-    res = build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
-chr1        HAVANA      gene        1915108     1917296     .           +           .           gene_id||"ENSG00000169885.10";||gene_type||"protein_coding";||gene_name||"CALML6";||level||1;||hgnc_id||"HGNC:24193";||havana_gene||"OTTHUMG00000000943.3";
-chr1        HAVANA      transcript  1915260     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      exon        1915260     1915307     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      CDS         1915281     1915307     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      start_codon 1915281     1915283     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      exon        1915685     1915735     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      CDS         1915685     1915735     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      exon        1916441     1916615     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      CDS         1916441     1916615     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      exon        1916752     1916896     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      CDS         1916752     1916896     .           +           2           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      exon        1916974     1917074     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      CDS         1916974     1917074     .           +           1           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      exon        1917147     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      CDS         1917147     1917190     .           +           2           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      stop_codon  1917191     1917193     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      UTR         1915260     1915280     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-chr1        HAVANA      UTR         1917191     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
-"""))})  # noqa: E501
-    return build_gene_models_from_resource(res)
-
-
-@pytest.fixture()
-def ensembl_gtf_example_noncoding() -> GeneModels:
-    res = build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
-chr1    HAVANA    gene    89295    133566    .    -    .    gene_id||"ENSG00000238009.7";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||level||2;||tag||"overlapping_locus";||havana_gene||"OTTHUMG00000001096.2";
-chr1    HAVANA    transcript    89295    120932    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
-chr1    HAVANA    exon    120775    120932    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||1;||exon_id||"ENSE00001606755.2";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
-chr1    HAVANA    exon    112700    112804    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||2;||exon_id||"ENSE00001957285.1";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
-chr1    HAVANA    exon    92091    92240    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||3;||exon_id||"ENSE00001944529.1";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
-chr1    HAVANA    exon    89295    91629    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||4;||exon_id||"ENSE00001846804.1";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
-"""))})  # noqa: E501
-    return build_gene_models_from_resource(res)
-
-
-@pytest.fixture()
-def gtf_example_no_exons() -> GeneModels:
-    res = build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
-chr1    HAVANA    gene    89295    133566    .    -    .    gene_id||"ENSG00000238009.7";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||level||2;||tag||"overlapping_locus";||havana_gene||"OTTHUMG00000001096.2";
-chr1    HAVANA    transcript    89295    120932    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
-"""))})  # noqa: E501
-    return build_gene_models_from_resource(res)
 
 
 def test_gene_models_from_gtf(fixture_dirname: Callable) -> None:
@@ -439,7 +333,7 @@ def test_save_load_gene_models_from_file(
 
         assert len(transcript_model.exons) == len(transcript_model1.exons)
         for index, (exon, exon1) in enumerate(zip(
-                transcript_model.exons, transcript_model1.exons)):
+                transcript_model.exons, transcript_model1.exons, strict=True)):
             assert exon.start == exon1.start, (
                 transcript_model.exons[: index + 2],
                 transcript_model1.exons[: index + 2],
@@ -515,8 +409,24 @@ chr19  HAVANA  UTR          408362  408401  .  -  .  gene_id||"ENSG00000183186.7
     assert tm.strand == "-"
 
 
-def test_ensembl_example(ensembl_gtf_example: GeneModels) -> None:
-    gene_models = ensembl_gtf_example
+def test_ensembl_example() -> None:
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+#!genome-build GRCh38
+11  ensembl_havana  gene        5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";
+11  ensembl_havana  transcript  5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  exon        5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";exon_id||"ENSE00001276439";exon_version||"4";
+11  ensembl_havana  CDS         5422201  5423151  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";protein_id||"ENSP00000300778";protein_version||"4";
+11  ensembl_havana  start_codon 5422201  5422203  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  stop_codon  5423152  5423154  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  UTR         5422111  5422200  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  UTR         5423155  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";tag||"a||b||c";
+""")),  # noqa: E501
+        })
+    gene_models = build_gene_models_from_resource(res)
     gene_models.load()
 
     assert len(gene_models.gene_models) == 1
@@ -554,125 +464,3 @@ def test_create_regions_from_genes(
     assert len(result) == 1
     reg = result[0]
     assert str(reg) == expected
-
-
-def test_save_as_gtf_simple(ensembl_gtf_example: GeneModels) -> None:
-    reference = ensembl_gtf_example
-    reference.load()
-    serialized = reference.to_gtf()
-
-    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": serialized,
-    }))
-    gene_models.load()
-
-    assert len(gene_models.gene_models) == 1
-    assert len(gene_models.transcript_models) == 1
-    assert "OR51Q1" in gene_models.gene_models
-
-    assert "ENST00000300778" in gene_models.transcript_models
-    tm = gene_models.transcript_models["ENST00000300778"]
-
-    assert tm.tr_id == "ENST00000300778"
-    assert tm.cds == (5422201, 5423154)
-    assert tm.tx == (5422111, 5423206)
-    assert len(tm.exons) == 1
-    assert tm.strand == "+"
-
-
-def test_save_as_gtf_complex(ensembl_gtf_example_shh: GeneModels) -> None:
-    example_models = ensembl_gtf_example_shh
-    example_models.load()
-    serialized = example_models.to_gtf()
-
-    assert "start_codon\t155812120\t155812122" in serialized
-    assert "stop_codon\t155802900\t155802902" in serialized
-
-    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": serialized,
-    }))
-    gene_models.load()
-
-    assert len(gene_models.gene_models) == 1
-    assert len(gene_models.transcript_models) == 1
-    assert "SHH" in gene_models.gene_models
-
-    assert "ENST00000297261.7" in gene_models.transcript_models
-    tm = gene_models.transcript_models["ENST00000297261.7"]
-
-    assert tm.tr_id == "ENST00000297261.7"
-    assert tm.cds == (155802900, 155812122)
-    assert tm.tx == (155799980, 155812463)
-    assert len(tm.exons) == 3
-    assert tm.strand == "-"
-
-
-def test_calml6(gencode_46_calml_example: GeneModels) -> None:
-    example_models = gencode_46_calml_example
-    example_models.load()
-    serialized = example_models.to_gtf()
-
-    tx = example_models.transcript_models["ENST00000307786.8"]
-    exonframes = [(exon, exon.frame) for exon in tx.exons]
-
-
-def test_save_as_gtf_noncoding(
-    ensembl_gtf_example_noncoding: GeneModels,
-) -> None:
-    example_models = ensembl_gtf_example_noncoding
-    example_models.load()
-    serialized = example_models.to_gtf()
-
-    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": serialized,
-    }))
-    gene_models.load()
-    assert len(gene_models.gene_models) == 1
-    assert len(gene_models.transcript_models) == 1
-    assert "ENSG00000238009" in gene_models.gene_models
-    assert "ENST00000466430.5" in gene_models.transcript_models
-    tm = gene_models.transcript_models["ENST00000466430.5"]
-
-    assert tm.tr_id == "ENST00000466430.5"
-    assert tm.cds == (120932, 89295)
-    assert tm.tx == (89295, 120932)
-    assert tm.is_coding() is False
-    assert len(tm.exons) == 4
-    assert tm.strand == "-"
-
-
-def test_save_as_gtf_no_exons(
-    gtf_example_no_exons: GeneModels,
-) -> None:
-    example_models = gtf_example_no_exons
-    example_models.load()
-    serialized = example_models.to_gtf()
-
-    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
-        content={
-            "genomic_resource.yaml":
-                "{type: gene_models, filename: gencode.txt, format: gtf}",
-            "gencode.txt": serialized,
-    }))
-    gene_models.load()
-    assert len(gene_models.gene_models) == 1
-    assert len(gene_models.transcript_models) == 1
-    assert "ENSG00000238009" in gene_models.gene_models
-    assert "ENST00000466430.5" in gene_models.transcript_models
-    tm = gene_models.transcript_models["ENST00000466430.5"]
-
-    assert tm.tr_id == "ENST00000466430.5"
-    assert tm.cds == (120932, 89295)
-    assert tm.tx == (89295, 120932)
-    assert tm.is_coding() is False
-    assert len(tm.exons) == 0
-    assert tm.strand == "-"

--- a/dae/dae/genomic_resources/tests/test_gene_models.py
+++ b/dae/dae/genomic_resources/tests/test_gene_models.py
@@ -82,6 +82,36 @@ chr7    HAVANA  UTR     155799980       155802902       .       -       .       
     return build_gene_models_from_resource(res)
 
 
+@pytest.fixture()
+def gencode_46_calml_example() -> GeneModels:
+    # CALML6
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+chr1        HAVANA      gene        1915108     1917296     .           +           .           gene_id||"ENSG00000169885.10";||gene_type||"protein_coding";||gene_name||"CALML6";||level||1;||hgnc_id||"HGNC:24193";||havana_gene||"OTTHUMG00000000943.3";
+chr1        HAVANA      transcript  1915260     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1915260     1915307     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1915281     1915307     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      start_codon 1915281     1915283     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1915685     1915735     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1915685     1915735     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1916441     1916615     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1916441     1916615     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1916752     1916896     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1916752     1916896     .           +           2           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1916974     1917074     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1916974     1917074     .           +           1           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1917147     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1917147     1917190     .           +           2           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      stop_codon  1917191     1917193     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      UTR         1915260     1915280     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      UTR         1917191     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+"""))})  # noqa: E501
+    return build_gene_models_from_resource(res)
+
+
 def test_gene_models_from_gtf(fixture_dirname: Callable) -> None:
     gtf_filename = fixture_dirname("gene_models/test_ref_gene.gtf")
     print(gtf_filename)
@@ -551,3 +581,13 @@ def test_save_as_gtf_complex(ensembl_gtf_example_shh: GeneModels) -> None:
     assert tm.tx == (155799980, 155812463)
     assert len(tm.exons) == 3
     assert tm.strand == "-"
+
+
+def test_calml6(gencode_46_calml_example: GeneModels) -> None:
+    example_models = gencode_46_calml_example
+    example_models.load()
+    serialized = example_models.to_gtf()
+
+    tx = example_models.transcript_models["ENST00000307786.8"]
+    exonframes = [(exon, exon.frame) for exon in tx.exons]
+    import pdb; pdb.set_trace()

--- a/dae/dae/genomic_resources/tests/test_gene_models_gtf_serialization.py
+++ b/dae/dae/genomic_resources/tests/test_gene_models_gtf_serialization.py
@@ -61,7 +61,7 @@ chr7    HAVANA  UTR     155799980       155802902       .       -       .       
 
 
 @pytest.fixture()
-def gencode_46_calml_example() -> GeneModels:
+def gencode_46_calml6_example() -> GeneModels:
     # CALML6
     res = build_inmemory_test_resource(
         content={

--- a/dae/dae/genomic_resources/tests/test_gene_models_gtf_serialization.py
+++ b/dae/dae/genomic_resources/tests/test_gene_models_gtf_serialization.py
@@ -1,0 +1,233 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import textwrap
+
+import pytest
+
+from dae.genomic_resources.gene_models import (
+    GeneModels,
+    build_gene_models_from_resource,
+    models_to_gtf,
+)
+from dae.genomic_resources.testing import (
+    build_inmemory_test_resource,
+    convert_to_tab_separated,
+)
+
+
+@pytest.fixture()
+def ensembl_gtf_example() -> GeneModels:
+    # Example from: https://ftp.ensembl.org/pub/current/gtf/homo_sapiens/README
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+#!genome-build GRCh38
+11  ensembl_havana  gene        5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";
+11  ensembl_havana  transcript  5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  exon        5422111  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";exon_id||"ENSE00001276439";exon_version||"4";
+11  ensembl_havana  CDS         5422201  5423151  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";protein_id||"ENSP00000300778";protein_version||"4";
+11  ensembl_havana  start_codon 5422201  5422203  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  stop_codon  5423152  5423154  .  +  0  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";exon_number||"1";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  UTR         5422111  5422200  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";
+11  ensembl_havana  UTR         5423155  5423206  .  +  .  gene_id||"ENSG00000167360";gene_version||"4";transcript_id||"ENST00000300778";transcript_version||"4";gene_name||"OR51Q1";gene_source||"ensembl_havana";gene_biotype||"protein_coding";transcript_name||"OR51Q1-001";transcript_source||"ensembl_havana";transcript_biotype||"protein_coding";tag||"CCDS";ccds_id||"CCDS31381";tag||"a||b||c";
+""")),  # noqa: E501
+        })
+    return build_gene_models_from_resource(res)
+
+
+@pytest.fixture()
+def ensembl_gtf_example_shh() -> GeneModels:
+    # SHH = Sonic hedgehog gene
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+chr7    HAVANA  gene    155799980       155812463       .       -       .       gene_id||"ENSG00000164690.8";||gene_type||"protein_coding";||gene_name||"SHH";||level||2;||hgnc_id||"HGNC:10848";||havana_gene||"OTTHUMG00000151349.3";
+chr7    HAVANA  transcript      155799980       155812463       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  exon    155811823       155812463       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  CDS     155811823       155812122       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  start_codon     155812120       155812122       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  exon    155806296       155806557       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||2;||exon_id||"ENSE00001086617.1";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  CDS     155806296       155806557       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||2;||exon_id||"ENSE00001086617.1";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  exon    155799980       155803726       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  CDS     155802903       155803726       .       -       2       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  stop_codon      155802900       155802902       .       -       0       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  UTR     155812123       155812463       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||1;||exon_id||"ENSE00001086614.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+chr7    HAVANA  UTR     155799980       155802902       .       -       .       gene_id||"ENSG00000164690.8";||transcript_id||"ENST00000297261.7";||gene_type||"protein_coding";||gene_name||"SHH";||transcript_type||"protein_coding";||transcript_name||"SHH-201";||exon_number||3;||exon_id||"ENSE00001149618.3";||level||2;||protein_id||"ENSP00000297261.2";||transcript_support_level||"1";||hgnc_id||"HGNC:10848";||tag||"basic";||tag||"Ensembl_canonical";||tag||"GENCODE_Primary";||tag||"MANE_Select";||tag||"appris_principal_1";||tag||"CCDS";||ccdsid||"CCDS5942.1";||havana_gene||"OTTHUMG00000151349.3";||havana_transcript||"OTTHUMT00000322327.2";
+"""))})  # noqa: E501
+    return build_gene_models_from_resource(res)
+
+
+@pytest.fixture()
+def gencode_46_calml_example() -> GeneModels:
+    # CALML6
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+chr1        HAVANA      gene        1915108     1917296     .           +           .           gene_id||"ENSG00000169885.10";||gene_type||"protein_coding";||gene_name||"CALML6";||level||1;||hgnc_id||"HGNC:24193";||havana_gene||"OTTHUMG00000000943.3";
+chr1        HAVANA      transcript  1915260     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1915260     1915307     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1915281     1915307     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      start_codon 1915281     1915283     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1915685     1915735     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1915685     1915735     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1916441     1916615     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1916441     1916615     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1916752     1916896     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1916752     1916896     .           +           2           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1916974     1917074     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1916974     1917074     .           +           1           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      exon        1917147     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      CDS         1917147     1917190     .           +           2           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      stop_codon  1917191     1917193     .           +           0           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      UTR         1915260     1915280     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+chr1        HAVANA      UTR         1917191     1917296     .           +           .           gene_id||"ENSG00000169885.10";||transcript_id||"ENST00000307786.8";||gene_type||"protein_coding";||gene_name||"CALML6";||transcript_type||"protein_coding";
+"""))})  # noqa: E501
+    return build_gene_models_from_resource(res)
+
+
+@pytest.fixture()
+def ensembl_gtf_example_noncoding() -> GeneModels:
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+chr1    HAVANA    gene    89295    133566    .    -    .    gene_id||"ENSG00000238009.7";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||level||2;||tag||"overlapping_locus";||havana_gene||"OTTHUMG00000001096.2";
+chr1    HAVANA    transcript    89295    120932    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
+chr1    HAVANA    exon    120775    120932    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||1;||exon_id||"ENSE00001606755.2";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
+chr1    HAVANA    exon    112700    112804    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||2;||exon_id||"ENSE00001957285.1";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
+chr1    HAVANA    exon    92091    92240    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||3;||exon_id||"ENSE00001944529.1";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
+chr1    HAVANA    exon    89295    91629    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||exon_number||4;||exon_id||"ENSE00001846804.1";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
+"""))})  # noqa: E501
+    return build_gene_models_from_resource(res)
+
+
+@pytest.fixture()
+def gtf_example_no_exons() -> GeneModels:
+    res = build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": convert_to_tab_separated(textwrap.dedent("""
+chr1    HAVANA    gene    89295    133566    .    -    .    gene_id||"ENSG00000238009.7";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||level||2;||tag||"overlapping_locus";||havana_gene||"OTTHUMG00000001096.2";
+chr1    HAVANA    transcript    89295    120932    .    -    .    gene_id||"ENSG00000238009.7";||transcript_id||"ENST00000466430.5";||gene_type||"lncRNA";||gene_name||"ENSG00000238009";||transcript_type||"lncRNA";||transcript_name||"ENST00000466430";||level||2;||transcript_support_level||"5";||tag||"not_best_in_genome_evidence";||tag||"basic";||havana_gene||"OTTHUMG00000001096.2";||havana_transcript||"OTTHUMT00000003225.1";
+"""))})  # noqa: E501
+    return build_gene_models_from_resource(res)
+
+
+def test_save_as_gtf_simple(ensembl_gtf_example: GeneModels) -> None:
+    reference = ensembl_gtf_example
+    reference.load()
+    serialized = models_to_gtf(reference)
+
+    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": serialized,
+    }))
+    gene_models.load()
+
+    assert len(gene_models.gene_models) == 1
+    assert len(gene_models.transcript_models) == 1
+    assert "OR51Q1" in gene_models.gene_models
+
+    assert "ENST00000300778" in gene_models.transcript_models
+    tm = gene_models.transcript_models["ENST00000300778"]
+
+    assert tm.tr_id == "ENST00000300778"
+    assert tm.cds == (5422201, 5423154)
+    assert tm.tx == (5422111, 5423206)
+    assert len(tm.exons) == 1
+    assert tm.strand == "+"
+
+
+def test_save_as_gtf_complex(ensembl_gtf_example_shh: GeneModels) -> None:
+    example_models = ensembl_gtf_example_shh
+    example_models.load()
+    serialized = models_to_gtf(example_models)
+
+    assert "start_codon\t155812120\t155812122" in serialized
+    assert "stop_codon\t155802900\t155802902" in serialized
+
+    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": serialized,
+    }))
+    gene_models.load()
+
+    assert len(gene_models.gene_models) == 1
+    assert len(gene_models.transcript_models) == 1
+    assert "SHH" in gene_models.gene_models
+
+    assert "ENST00000297261.7" in gene_models.transcript_models
+    tm = gene_models.transcript_models["ENST00000297261.7"]
+
+    assert tm.tr_id == "ENST00000297261.7"
+    assert tm.cds == (155802900, 155812122)
+    assert tm.tx == (155799980, 155812463)
+    assert len(tm.exons) == 3
+    assert tm.strand == "-"
+
+
+def test_save_as_gtf_noncoding(
+    ensembl_gtf_example_noncoding: GeneModels,
+) -> None:
+    example_models = ensembl_gtf_example_noncoding
+    example_models.load()
+    serialized = models_to_gtf(example_models)
+
+    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": serialized,
+    }))
+    gene_models.load()
+    assert len(gene_models.gene_models) == 1
+    assert len(gene_models.transcript_models) == 1
+    assert "ENSG00000238009" in gene_models.gene_models
+    assert "ENST00000466430.5" in gene_models.transcript_models
+    tm = gene_models.transcript_models["ENST00000466430.5"]
+
+    assert tm.tr_id == "ENST00000466430.5"
+    assert tm.cds == (120932, 89295)
+    assert tm.tx == (89295, 120932)
+    assert tm.is_coding() is False
+    assert len(tm.exons) == 4
+    assert tm.strand == "-"
+
+
+def test_save_as_gtf_no_exons(
+    gtf_example_no_exons: GeneModels,
+) -> None:
+    example_models = gtf_example_no_exons
+    example_models.load()
+    serialized = models_to_gtf(example_models)
+
+    gene_models = build_gene_models_from_resource(build_inmemory_test_resource(
+        content={
+            "genomic_resource.yaml":
+                "{type: gene_models, filename: gencode.txt, format: gtf}",
+            "gencode.txt": serialized,
+    }))
+    gene_models.load()
+    assert len(gene_models.gene_models) == 1
+    assert len(gene_models.transcript_models) == 1
+    assert "ENSG00000238009" in gene_models.gene_models
+    assert "ENST00000466430.5" in gene_models.transcript_models
+    tm = gene_models.transcript_models["ENST00000466430.5"]
+
+    assert tm.tr_id == "ENST00000466430.5"
+    assert tm.cds == (120932, 89295)
+    assert tm.tx == (89295, 120932)
+    assert tm.is_coding() is False
+    assert len(tm.exons) == 0
+    assert tm.strand == "-"


### PR DESCRIPTION
## Background

When serializing gene models into GTF format, we need to produce a `phase` field for
all coding sequence features - CDS, start_codon and stop_codon.

## Aim

Fully support serialization of GeneModels in GTF format.

## Implementation

Multiple functions for processing GTF coding sequence features were added.
Some functions in `dae.utils.regions` package were fixed. 

Detailed testing of GTF coding sequence features supported.