### PR TITLE
Optimize dataset hierarchy search

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - pytest-doctestplus=1.2
   - pylint=3.2
   - pandas-stubs=2.1
-  - django-stubs=4.2
+  - django-stubs=5.0.2
   - types-pyyaml=6.0
   - types-setuptools=67
   - types-toml=0.10

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -208,6 +208,15 @@ class IsDatasetAllowed(permissions.BasePermission):
         wgpf_instance = get_wgpf_instance()
         dataset_ids = set(wgpf_instance.get_genotype_data_ids())
 
+        user_groups = get_user_groups(user)
+        if (
+            settings.DISABLE_PERMISSIONS or
+            user.is_superuser or
+            user.is_staff or
+            "admin" in user_groups
+        ):
+            return dataset_ids
+
         query = IsDatasetAllowed.get_allowed_datasets_query()
 
         with connection.cursor() as cursor:

--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -15,6 +15,7 @@ from gpf_instance.gpf_instance import (
     get_wgpf_instance,
 )
 from rest_framework import permissions
+from rest_framework.request import Request
 from utils.datasets import find_dataset_id_in_request
 
 from .models import Dataset, DatasetHierarchy
@@ -22,12 +23,17 @@ from .models import Dataset, DatasetHierarchy
 logger = logging.getLogger(__name__)
 
 
-def get_instance_timestamp_etag(_request, **_kwargs) -> str:
+def get_instance_timestamp_etag(
+    _request: Request, **_kwargs: dict[str, Any],
+) -> str:
     etag = f"{get_instance_timestamp()}"
     return hashlib.md5(etag.encode()).hexdigest()
 
 
-def get_permissions_etag(request, **_kwargs) -> str:
+def get_permissions_etag(
+    request: Request, **_kwargs: dict[str, Any],
+) -> str:
+    """Return E-Tag for queries dependant on user access permissions."""
     etag = (
         f"{get_instance_timestamp()}"
         f"{get_permission_timestamp()}"
@@ -220,7 +226,7 @@ class IsDatasetAllowed(permissions.BasePermission):
         query = IsDatasetAllowed.get_allowed_datasets_query()
 
         with connection.cursor() as cursor:
-            cursor.execute(query, [user.id, instance_id])
+            cursor.execute(query, [user.id, instance_id])  # type: ignore
 
             allowed_datasets_ids = {row[1] for row in cursor.fetchall()}
 

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from collections.abc import Iterable
 from typing import Any, cast
 
@@ -17,7 +18,6 @@ from studies.study_wrapper import StudyWrapper, StudyWrapperBase
 
 from dae.studies.study import GenotypeData
 from datasets_api.permissions import (
-    IsDatasetAllowed,
     get_instance_timestamp_etag,
     get_permissions_etag,
     get_wdae_parents,
@@ -61,6 +61,7 @@ def augment_with_parents(
         )
     ]
     return dataset
+
 
 def produce_description_hierarchy(
     dataset: GenotypeData,

--- a/wdae/wdae/enrichment_api/views.py
+++ b/wdae/wdae/enrichment_api/views.py
@@ -145,7 +145,7 @@ class EnrichmentTestView(QueryDatasetView):
     # @silk_profile(name="Enrichment Test")
     def post(self, request: Request) -> Response:
         """Run the enrichment test and return the result."""
-        query = expand_gene_set(request.data, request.user)
+        query = expand_gene_set(request.data, request.user, self.instance_id)
         dataset_id = query.get("datasetId", None)
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/wdae/wdae/gene_sets/views.py
+++ b/wdae/wdae/gene_sets/views.py
@@ -6,7 +6,7 @@ import json
 import logging
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Any
+from typing import Any, cast
 
 from datasets_api.permissions import get_instance_timestamp_etag
 from django.http.response import StreamingHttpResponse
@@ -80,7 +80,7 @@ class GeneSetsView(QueryBaseView):
                 return Response(status=status.HTTP_404_NOT_FOUND)
             gene_sets = self.gpf_instance.get_all_denovo_gene_sets(
                 gene_sets_types,
-                self.get_permitted_datasets(request.user),
+                cast(list, self.get_permitted_datasets(request.user)),
                 gene_sets_collection_id,
             )
         else:
@@ -158,7 +158,7 @@ class GeneSetDownloadView(QueryBaseView):
             if not self.gpf_instance.has_denovo_gene_sets():
                 return Response(status=status.HTTP_404_NOT_FOUND)
             gene_set = self.gpf_instance.get_denovo_gene_set(
-                gene_set_id, gene_sets_types, permitted_datasets,
+                gene_set_id, gene_sets_types, cast(list, permitted_datasets),
                 gene_sets_collection_id,
             )
         else:

--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -48,7 +48,8 @@ class QueryVariantsView(QueryDatasetView):
 
     @request_logging(LOGGER)
     @method_decorator(etag(get_permissions_etag))
-    def post(self, request):
+    def post(self, request: Request) -> Response:
+        """Query gene view summary variants."""
         data = expand_gene_set(request.data, request.user, self.instance_id)
         dataset_id = data.pop("datasetId", None)
         if dataset_id is None:
@@ -93,7 +94,10 @@ class DownloadSummaryVariantsView(QueryDatasetView):
         handle_partial_permissions(self.instance_id, user, dataset_id, data)
 
         download_limit = None
-        if not (user.is_authenticated and user.has_unlimited_download):
+        if not (
+            user.is_authenticated and
+            user.has_unlimited_download  # type: ignore
+        ):
             download_limit = self.DOWNLOAD_LIMIT
         data.update({"limit": download_limit})
 
@@ -103,8 +107,7 @@ class DownloadSummaryVariantsView(QueryDatasetView):
         variants = dataset.get_gene_view_summary_variants_download(
             freq_col, **data)
 
-        for variant in variants:
-            yield variant
+        yield from variants
 
     @request_logging(LOGGER)
     def post(self, request: Request) -> Response:

--- a/wdae/wdae/gene_view/views.py
+++ b/wdae/wdae/gene_view/views.py
@@ -27,7 +27,8 @@ class ConfigView(QueryDatasetView):
     @request_logging(LOGGER)
     @method_decorator(etag(get_permissions_etag))
     def get(self, request):
-        data = expand_gene_set(request.query_params, request.user)
+        data = expand_gene_set(
+            request.query_params, request.user, self.instance_id)
         dataset_id = data["datasetId"]
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -48,7 +49,7 @@ class QueryVariantsView(QueryDatasetView):
     @request_logging(LOGGER)
     @method_decorator(etag(get_permissions_etag))
     def post(self, request):
-        data = expand_gene_set(request.data, request.user)
+        data = expand_gene_set(request.data, request.user, self.instance_id)
         dataset_id = data.pop("datasetId", None)
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -108,7 +109,8 @@ class DownloadSummaryVariantsView(QueryDatasetView):
     @request_logging(LOGGER)
     def post(self, request: Request) -> Response:
         """Summary variants download."""
-        data = expand_gene_set(parse_query_params(request.data), request.user)
+        data = expand_gene_set(
+            parse_query_params(request.data), request.user, self.instance_id)
         dataset_id = data.pop("datasetId", None)
         if dataset_id is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/wdae/wdae/genotype_browser/views.py
+++ b/wdae/wdae/genotype_browser/views.py
@@ -141,9 +141,9 @@ class GenotypeBrowserQueryView(QueryDatasetView):
         if dataset is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         if not dataset.is_remote:
-            data = expand_gene_set(data, user)
+            data = expand_gene_set(data, user, self.instance_id)
         elif "geneSet" in data:
-            gene_set = expand_gene_syms(data, user)
+            gene_set = expand_gene_syms(data, user, self.instance_id)
             data["geneSymbols"] = list(gene_set["syms"])
             del data["geneSet"]
 

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -122,7 +122,7 @@ class PhenoToolView(QueryDatasetView):
 
     def post(self, request: Request) -> Response:
         """Return pheno tool results based on POST request."""
-        data = expand_gene_set(request.data, request.user)
+        data = expand_gene_set(request.data, request.user, self.instance_id)
         adapter = self.prepare_pheno_tool_adapter(data)
 
         if not adapter:
@@ -189,7 +189,8 @@ class PhenoToolDownload(PhenoToolView):
 
     def post(self, request: Request) -> Response:
         """Pheno tool download."""
-        data = expand_gene_set(parse_query_params(request.data), request.user)
+        data = expand_gene_set(
+            parse_query_params(request.data), request.user, self.instance_id)
 
         if not user_has_permission(
             self.instance_id, request.user, data["datasetId"],

--- a/wdae/wdae/query_base/query_base.py
+++ b/wdae/wdae/query_base/query_base.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from datasets_api.permissions import IsDatasetAllowed
 from django.contrib.auth.models import User
 from gpf_instance.gpf_instance import get_wgpf_instance, recreated_dataset_perm
-from rest_framework import views  # type: ignore
+from rest_framework import views
 from utils.authentication import GPFOAuth2Authentication
 
 

--- a/wdae/wdae/query_base/query_base.py
+++ b/wdae/wdae/query_base/query_base.py
@@ -1,4 +1,6 @@
 """Module containing the base view for data-related views."""
+from collections.abc import Iterable
+
 from datasets_api.permissions import IsDatasetAllowed
 from django.contrib.auth.models import User
 from gpf_instance.gpf_instance import get_wgpf_instance, recreated_dataset_perm
@@ -24,9 +26,8 @@ class QueryBaseView(views.APIView):
         self.variants_db = self.gpf_instance._variants_db
         self.pheno_registry = self.gpf_instance._pheno_registry
 
-    @staticmethod
-    def get_permitted_datasets(user: User) -> list[str]:
-        return IsDatasetAllowed.permitted_datasets(user)
+    def get_permitted_datasets(self, user: User) -> Iterable[str]:
+        return IsDatasetAllowed.permitted_datasets(user, self.instance_id)
 
 
 class QueryDatasetView(QueryBaseView):

--- a/wdae/wdae/utils/expand_gene_set.py
+++ b/wdae/wdae/utils/expand_gene_set.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from gpf_instance.gpf_instance import get_wgpf_instance
 
 
-def expand_gene_set(data: dict, user: User) -> dict:
+def expand_gene_set(data: dict, user: User, instance_id: str) -> dict:
     """Expand gene set to list of gene symbols."""
     if "geneSet" in data:
         gene_sets_collection_id = None
@@ -21,14 +21,14 @@ def expand_gene_set(data: dict, user: User) -> dict:
 
         assert gene_sets_collection_id is not None
         gene_set = expand_gene_syms(
-            data, user,
+            data, user, instance_id,
         )
         data["geneSymbols"] = list(gene_set["syms"])
         data["geneSet"] = gene_set["desc"]
     return data
 
 
-def expand_gene_syms(data: dict, user: User) -> dict:
+def expand_gene_syms(data: dict, user: User, instance_id: str) -> dict:
     """Expand gene set symbols."""
     gene_set = None
     query = data.get("geneSet")
@@ -44,7 +44,9 @@ def expand_gene_syms(data: dict, user: User) -> dict:
         gene_set = denovo_gene_sets_db.get_gene_set(
             gene_set,
             denovo_gene_set_spec,
-            permitted_datasets=IsDatasetAllowed.permitted_datasets(user),
+            permitted_datasets=IsDatasetAllowed.permitted_datasets(
+                user, instance_id,
+            ),
             collection_id=gene_sets_collection,
         )
     else:


### PR DESCRIPTION
## Background
When collecting all datasets, for every single dataset we ran a query to determine whether the user has access to it via hierarchy. The overhead from running many SQL queries became large enough on the production instance to be the second slowest part of loading datasets.

## Aim
Optimize dataset accessibility collection.

## Implementation
A new query was written, which using CTEs would collect all of the user's datasets from the user's groups and join this set with the branches of the hierarchy, This query was implemented into the django permission class `IsDatasetAllowed` and into it's `permitted_datasets` static method. The clients of IsDatasetAllowed were also updated to use this new query.
