### PR TITLE
Fix access rights query on MySQL

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -138,7 +138,7 @@ class IsDatasetAllowed(permissions.BasePermission):
             WHERE
                 1 = 1
                 AND h.ancestor_id <> h.descendant_id
-                AND h.direct == TRUE
+                AND h.direct = TRUE
                 AND h.id IS NOT NULL
         ),
         to_root (
@@ -172,7 +172,7 @@ class IsDatasetAllowed(permissions.BasePermission):
             WHERE
                 1 = 1
                 AND h.ancestor_id <> h.descendant_id
-                AND h.direct == TRUE
+                AND h.direct = TRUE
                 AND h.id IS NOT NULL
         ),
         dataset_branch(


### PR DESCRIPTION
## Background
The new dataset access rights query would break on MySQL used on deployed instance

## Aim
Update the query so it validates with MySQL.

## Implementation
The issue was the usage of the `==` operator which is not supported on MySQL (only `=`)