### PR TITLE
Fix permissions any user

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -198,6 +198,7 @@ class IsDatasetAllowed(permissions.BasePermission):
         SELECT DISTINCT db.branch_dataset_id, db.branch_dataset_wdae_id
         FROM user_to_group AS ug
         LEFT OUTER JOIN dataset_to_group AS dg ON ug.gid = dg.gid
+            OR dg.gname == 'any_user'
         LEFT OUTER JOIN dataset_branch AS db ON db.dataset_id = dg.did
         WHERE
             1=1


### PR DESCRIPTION
## Background
Updating the access rights requests to use a single hierarchy query introduced 2 new bugs with anonymous users and the special "any_user" group.

## Aim
Restore previous functionality.

## Implementation
The special `any_user` group is now taken into account in the SQL query and anonymous users have special handling where instead of going through the user based hierarchy query, it will search all datasets for the `any_user` group.