### PR TITLE
Pheno experiments

### DIFF
--- a/dae/dae/pheno/prepare_data.py
+++ b/dae/dae/pheno/prepare_data.py
@@ -2,7 +2,6 @@ import logging
 import os
 import pathlib
 import shutil
-import tempfile
 from typing import Any
 
 import matplotlib as mpl

--- a/dae/dae/pheno/prepare_data.py
+++ b/dae/dae/pheno/prepare_data.py
@@ -370,8 +370,10 @@ class PreparePhenoBrowserBase:
         for instrument in list(self.phenotype_data.instruments.values()):
             for measure in list(instrument.measures.values()):
                 self.add_measure_task(graph, measure, temp_dbfile_name)
-        task_cache = TaskCache.create(
-            force=False, cache_dir=kwargs.get("task_status_dir"))
+            task_cache = TaskCache.create(
+                force=kwargs.get("force"),
+                cache_dir=kwargs.get("task_status_dir"),
+            )
         with TaskGraphCli.create_executor(task_cache, **kwargs) as xtor:
             try:
                 for result in task_graph_run_with_results(graph, xtor):

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -175,7 +175,7 @@ class WGPFInstance(GPFInstance):
         return RemoteGeneSetsDb(self._clients, gene_sets_db)
 
     @cached_property
-    def denovo_gene_sets_db(self) -> RemoteDenovoGeneSetsDb:
+    def denovo_gene_sets_db(self) -> RemoteDenovoGeneSetsDb:  # type: ignore
         self.load_remotes()
         denovo_gene_sets_db = super().denovo_gene_sets_db
         return RemoteDenovoGeneSetsDb(self._clients, denovo_gene_sets_db)

--- a/wdae/wdae/gpf_instance/views.py
+++ b/wdae/wdae/gpf_instance/views.py
@@ -26,13 +26,17 @@ def version(_request: Request) -> Response:
 def get_description_etag(
     _request: Request, **_kwargs: dict[str, Any],
 ) -> str:
-    return get_cacheable_hash("instance_description")
+    cache_hash = get_cacheable_hash("instance_description")
+    assert cache_hash is not None
+    return cache_hash
 
 
 def get_about_etag(
     _request: Request, **_kwargs: dict[str, Any],
 ) -> str:
-    return get_cacheable_hash("instance_about")
+    cache_hash = get_cacheable_hash("instance_about")
+    assert cache_hash is not None
+    return cache_hash
 
 
 class MarkdownFileView(QueryBaseView):

--- a/wdae/wdae/gpf_instance/views.py
+++ b/wdae/wdae/gpf_instance/views.py
@@ -27,7 +27,8 @@ def get_description_etag(
     _request: Request, **_kwargs: dict[str, Any],
 ) -> str:
     cache_hash = get_cacheable_hash("instance_description")
-    assert cache_hash is not None
+    if cache_hash is None:
+        cache_hash = "0"
     return cache_hash
 
 
@@ -35,7 +36,8 @@ def get_about_etag(
     _request: Request, **_kwargs: dict[str, Any],
 ) -> str:
     cache_hash = get_cacheable_hash("instance_about")
-    assert cache_hash is not None
+    if cache_hash is None:
+        cache_hash = "0"
     return cache_hash
 
 


### PR DESCRIPTION
## Background
When attempting to import phenotype data using workers on multiple nodes, the import was broken and a few adjustments had to be made

## Implementation
The temporary DB file copy is now made in the output directory instead of a tempfile location. This allows workers on different nodes to be able to find the file when properly shared. Also a fix has been added for the `--force` flag which didn't propagate to the DASK executor.