### PR TITLE
Refactor dataset description

### DIFF
--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -1,6 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
-from pprint import pprint
 
 import pytest
 from django.test.client import Client
@@ -224,7 +223,6 @@ def test_datasets_hierarchy(
 
     data = response.data  # type: ignore
     assert data
-    pprint(data)
     assert len(data["data"]) == 22
     dataset1 = next(filter(
         lambda x: x["dataset"] == "Dataset1", data["data"],

--- a/wdae/wdae/datasets_api/tests/test_datasets_api.py
+++ b/wdae/wdae/datasets_api/tests/test_datasets_api.py
@@ -62,20 +62,6 @@ def test_datasets_api_get_404(admin_client: Client) -> None:
     assert data["error"] == "Dataset alabala not found"
 
 
-def test_datasets_api_get_dataset_with_hierarchy_description(
-    admin_client: Client
-) -> None:
-    response = admin_client.get("/api/v3/datasets/Dataset1")
-
-    assert response
-    data = response.data  # type: ignore
-    assert data["data"]["children_description"] == (
-        "\nThis dataset includes:\n"
-        "- **[Study1](datasets/Study1)** some new description\n\n"
-        "- **[Study3](datasets/Study3)** \n"
-    )
-
-
 def test_datasets_api_get_forbidden(user_client: Client) -> None:
     response = user_client.get("/api/v3/datasets/quads_in_parent")
 

--- a/wdae/wdae/datasets_api/urls.py
+++ b/wdae/wdae/datasets_api/urls.py
@@ -34,14 +34,14 @@ urlpatterns = [
         name="dataset_description",
     ),
     re_path(
-        r"^/hierarchy/?$",
-        views.FullDatasetHierarchyView.as_view(),
-        name="full_dataset_hierarchy",
-    ),
-    re_path(
-        r"^/dataset-hierarchy/(?P<dataset_id>.+)",
+        r"^/hierarchy/(?P<dataset_id>.+)",
         views.DatasetHierarchyView.as_view(),
         name="dataset_hierarchy",
+    ),
+    re_path(
+        r"^/hierarchy/?$",
+        views.DatasetHierarchyView.as_view(),
+        name="full_dataset_hierarchy",
     ),
     re_path(
         r"^/permissions/?$",

--- a/wdae/wdae/datasets_api/urls.py
+++ b/wdae/wdae/datasets_api/urls.py
@@ -14,27 +14,27 @@ urlpatterns = [
         name="denied_prompt",
     ),
     re_path(
-        r"^/details/(?P<dataset_id>.+)$",
+        r"^/details/(?P<dataset_id>[^/]+)/?$",
         views.DatasetDetailsView.as_view(),
         name="dataset_details",
     ),
     re_path(
-        r"^/pedigree/(?P<dataset_id>.+)/(?P<column>.+)$",
+        r"^/pedigree/(?P<dataset_id>.+)/(?P<column>[^/]+)/?$",
         views.DatasetPedigreeView.as_view(),
         name="pedigree",
     ),
     re_path(
-        r"^/config/(?P<dataset_id>.+)$",
+        r"^/config/(?P<dataset_id>[^/]+)/?$",
         views.DatasetConfigView.as_view(),
         name="dataset_config",
     ),
     re_path(
-        r"^/description/(?P<dataset_id>.+)$",
+        r"^/description/(?P<dataset_id>[^/]+)/?$",
         views.DatasetDescriptionView.as_view(),
         name="dataset_description",
     ),
     re_path(
-        r"^/hierarchy/(?P<dataset_id>.+)",
+        r"^/hierarchy/(?P<dataset_id>[^/]+)/?$",
         views.DatasetHierarchyView.as_view(),
         name="dataset_hierarchy",
     ),
@@ -59,7 +59,7 @@ urlpatterns = [
         name="list_studies",
     ),
     re_path(
-        r"^/(?P<dataset_id>.+)$",
+        r"^/(?P<dataset_id>[^/]+)/?$",
         views.DatasetView.as_view(),
         name="dataset",
     ),

--- a/wdae/wdae/datasets_api/urls.py
+++ b/wdae/wdae/datasets_api/urls.py
@@ -35,6 +35,11 @@ urlpatterns = [
     ),
     re_path(
         r"^/hierarchy/?$",
+        views.FullDatasetHierarchyView.as_view(),
+        name="full_dataset_hierarchy",
+    ),
+    re_path(
+        r"^/dataset-hierarchy/(?P<dataset_id>.+)",
         views.DatasetHierarchyView.as_view(),
         name="dataset_hierarchy",
     ),

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -66,8 +66,12 @@ def augment_with_parents(
 def get_description_etag(
     request: Request, **_kwargs: dict[str, Any],
 ) -> str:
+    """Get description etag."""
     dataset_id = request.parser_context["kwargs"]["dataset_id"]
-    return get_cacheable_hash(f"{dataset_id}_description")
+    cache_hash = get_cacheable_hash(f"{dataset_id}_description")
+    if cache_hash is None:
+        cache_hash = "0"
+    return cache_hash
 
 
 class DatasetView(QueryBaseView):

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -14,7 +14,7 @@ from query_base.query_base import QueryBaseView
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
-from studies.study_wrapper import StudyWrapper, StudyWrapperBase
+from studies.study_wrapper import StudyWrapperBase
 
 from dae.studies.study import GenotypeData
 from datasets_api.permissions import (

--- a/wdae/wdae/gpf_instance/gpf_instance.py
+++ b/wdae/wdae/gpf_instance/gpf_instance.py
@@ -71,12 +71,18 @@ def get_cacheable_hash(hashable_id: str) -> str | None:
     return _GPF_HASH_STORE.get(hashable_id)
 
 
-def set_cacheable_hash(hashable_id: str, content: str | None) -> None:
+def calc_and_set_cacheable_hash(hashable_id: str, content: str | None) -> None:
+    _GPF_HASH_STORE[hashable_id] = calc_cacheable_hash(content)
+
+
+def set_cacheable_hash(hashable_id: str, hashsum: str) -> None:
+    _GPF_HASH_STORE[hashable_id] = hashsum
+
+
+def calc_cacheable_hash(content: str | None) -> str:
     if content is None:
         content = ""
-    _GPF_HASH_STORE[hashable_id] = \
-        hashlib.md5(content.encode("utf-8")).hexdigest()  # noqa: S324
-
+    return hashlib.md5(content.encode("utf-8")).hexdigest()  # noqa: S324
 
 class WGPFInstance(GPFInstance):
     """GPF instance class for use in wdae."""

--- a/wdae/wdae/gpf_instance/views.py
+++ b/wdae/wdae/gpf_instance/views.py
@@ -10,7 +10,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from dae import __version__ as VERSION  # type: ignore
-from gpf_instance.gpf_instance import get_cacheable_hash, set_cacheable_hash
+from gpf_instance.gpf_instance import (
+    calc_and_set_cacheable_hash,
+    get_cacheable_hash,
+)
 
 
 @api_view(["GET"])
@@ -68,7 +71,7 @@ class MarkdownFileView(QueryBaseView):
             )
 
         if get_cacheable_hash(self.CONTENT_ID) is None:
-            set_cacheable_hash(self.CONTENT_ID, content)
+            calc_and_set_cacheable_hash(self.CONTENT_ID, content)
 
         return Response(
             {"content": content},
@@ -97,7 +100,10 @@ class MarkdownFileView(QueryBaseView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-        set_cacheable_hash(self.CONTENT_ID, request.data.get("content"))
+        calc_and_set_cacheable_hash(
+            self.CONTENT_ID,
+            request.data.get("content"),
+        )
         return Response(status=status.HTTP_200_OK)
 
 

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -93,7 +93,6 @@ class StudyWrapperBase:
     def build_genotype_data_description(
         gpf_instance: Any,
         config: Box,
-        description: str | None,
         person_set_collection_configs: dict[str, Any] | None,
     ) -> dict[str, Any]:
         """Build and return genotype data group description."""
@@ -111,13 +110,10 @@ class StudyWrapperBase:
             "genome",
             "chr_prefix",
             "gene_browser",
-            "description_editable",
         ]
         result = {
             key: config.get(key, None) for key in keys
         }
-
-        result["description"] = description
 
         result["genotype_browser"] = config.genotype_browser.enabled
         result["genotype_browser_config"] = {

--- a/wdae/wdae/studies/study_wrapper.py
+++ b/wdae/wdae/studies/study_wrapper.py
@@ -110,6 +110,7 @@ class StudyWrapperBase:
             "genome",
             "chr_prefix",
             "gene_browser",
+            "description_editable",
         ]
         result = {
             key: config.get(key, None) for key in keys


### PR DESCRIPTION
## Background

- The dataset description that comes with a dataset is problematic for dataset cashing because it can be frequently updated.

- The same goes for children dataset descriptions that also come with the dataset api. 

## Aim

- Remove dataset descriptions from the dataset api, so that only the description api is used for getting descriptions.

- Remove logic that creates markdown shortened dataset children descriptions. The frontend should handle this now.

- Create a helpful version of the dataset hierarchy api (tree-like information, used in the dataset dropdown) that can provide a hierarchy for one specific dataset and his children. Useful when creating in the frontend a children description tree.
