### PR TITLE
Fix pheno classification

### DIFF
--- a/dae/dae/pheno/common.py
+++ b/dae/dae/pheno/common.py
@@ -4,7 +4,7 @@ import enum
 from pprint import pprint
 
 from box import Box
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class RankRange(BaseModel):
@@ -14,6 +14,8 @@ class RankRange(BaseModel):
 
 class InferenceConfig(BaseModel):
     """Classification inference configuration class."""
+    model_config = ConfigDict(extra="forbid")
+
     min_individuals: int = 1
     non_numeric_cutoff: float = 0.06
     value_max_len: int = 32
@@ -25,6 +27,9 @@ class InferenceConfig(BaseModel):
 
 
 class ImportConfig(BaseModel):
+    """Pheno import tool configuration."""
+    model_config = ConfigDict(extra="forbid")
+
     report_only: bool = False
     instruments_tab_separated: bool = False
     person_column: str = "personId"
@@ -34,8 +39,6 @@ class ImportConfig(BaseModel):
     verbose: int = 0
     instruments_dir: str = ""
     pedigree: str = ""
-
-
 
 
 class MeasureType(enum.Enum):
@@ -100,15 +103,15 @@ def default_config() -> Box:
 def check_phenotype_data_config(config: InferenceConfig) -> bool:
     """Check phenotype database preparation config for consistency."""
     categorical = config.categorical.min_rank
-    if categorical < 1:
+    if categorical and categorical < 1:
         print("categorical min rank expected to be > 0")
         return False
     ordinal = config.ordinal.min_rank
-    if ordinal < categorical:
+    if ordinal and categorical and ordinal < categorical:
         print("ordinal min rank expected to be >= categorical min rank")
         return False
     continuous = config.continuous.min_rank
-    if continuous < ordinal:
+    if continuous and ordinal and continuous < ordinal:
         print("continuous min rank expected to be >= ordinal min rank")
         return False
 

--- a/dae/dae/pheno/prepare/measure_classifier.py
+++ b/dae/dae/pheno/prepare/measure_classifier.py
@@ -438,8 +438,11 @@ class MeasureClassifier:
         """Classify a measure based on classification report."""
         conf = self.config
 
-        if conf.min_individuals and rep.count_with_values and \
-                rep.count_with_values < conf.min_individuals:
+        if (
+            conf.min_individuals is not None and
+            rep.count_with_values is not None and 
+            rep.count_with_values < conf.min_individuals
+        ):
             return MeasureType.raw
 
         non_numeric = (
@@ -448,14 +451,14 @@ class MeasureClassifier:
 
         if non_numeric <= conf.non_numeric_cutoff:
             if (
-                rep.count_unique_numeric_values and
-                conf.continuous.min_rank and
+                rep.count_unique_numeric_values is not None and
+                conf.continuous.min_rank is not None and
                 rep.count_unique_numeric_values >= conf.continuous.min_rank
             ):
                 return MeasureType.continuous
             if (
-                rep.count_unique_numeric_values and
-                conf.ordinal.min_rank and
+                rep.count_unique_numeric_values is not None and
+                conf.ordinal.min_rank is not None and
                 rep.count_unique_numeric_values >= conf.ordinal.min_rank
             ):
                 return MeasureType.ordinal
@@ -463,9 +466,9 @@ class MeasureClassifier:
             return MeasureType.raw
 
         if (
-            rep.count_unique_values
-            and conf.categorical.min_rank
-            and conf.categorical.max_rank
+            rep.count_unique_values is not None
+            and conf.categorical.min_rank is not None
+            and conf.categorical.max_rank is not None
             and rep.count_unique_values >= conf.categorical.min_rank
             and rep.count_unique_values <= conf.categorical.max_rank
             # and rep.value_max_len <= conf.value_max_len

--- a/dae/dae/pheno/prepare/measure_classifier.py
+++ b/dae/dae/pheno/prepare/measure_classifier.py
@@ -60,7 +60,7 @@ class ClassifierReport:
     def __repr__(self) -> str:
         return self.log_line(short=True)
 
-    def log_line(self, short: bool = False) -> str:
+    def log_line(self, *, short: bool = False) -> str:
         """Construct a log line in clissifier report."""
         attributes = self.short_attributes()
         values = [str(getattr(self, attr)).strip() for attr in attributes]
@@ -78,7 +78,7 @@ class ClassifierReport:
         return "\t".join(attributes)
 
     @staticmethod
-    def header_line(short: bool = False) -> str:
+    def header_line(*, short: bool = False) -> str:
         """Construct clissifier report header line."""
         attributes = ClassifierReport.short_attributes()
         if not short:
@@ -438,7 +438,8 @@ class MeasureClassifier:
         """Classify a measure based on classification report."""
         conf = self.config
 
-        if rep.count_with_values < conf.min_individuals:
+        if conf.min_individuals and rep.count_with_values and \
+                rep.count_with_values < conf.min_individuals:
             return MeasureType.raw
 
         non_numeric = (
@@ -446,15 +447,26 @@ class MeasureClassifier:
         ) / cast(int, rep.count_with_values)
 
         if non_numeric <= conf.non_numeric_cutoff:
-            if rep.count_unique_numeric_values >= conf.continuous.min_rank:
+            if (
+                rep.count_unique_numeric_values and
+                conf.continuous.min_rank and
+                rep.count_unique_numeric_values >= conf.continuous.min_rank
+            ):
                 return MeasureType.continuous
-            if rep.count_unique_numeric_values >= conf.ordinal.min_rank:
+            if (
+                rep.count_unique_numeric_values and
+                conf.ordinal.min_rank and
+                rep.count_unique_numeric_values >= conf.ordinal.min_rank
+            ):
                 return MeasureType.ordinal
 
             return MeasureType.raw
 
         if (
-            rep.count_unique_values >= conf.categorical.min_rank
+            rep.count_unique_values
+            and conf.categorical.min_rank
+            and conf.categorical.max_rank
+            and rep.count_unique_values >= conf.categorical.min_rank
             and rep.count_unique_values <= conf.categorical.max_rank
             # and rep.value_max_len <= conf.value_max_len
         ):

--- a/dae/dae/pheno/tests/test_type_inference.py
+++ b/dae/dae/pheno/tests/test_type_inference.py
@@ -1,0 +1,134 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import textwrap
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from dae.pheno.common import InferenceConfig
+from dae.pheno.prepare.pheno_prepare import PrepareVariables
+
+
+def test_valid_config_loads() -> None:
+
+    config = yaml.safe_load(textwrap.dedent(
+        """
+        categorical:
+          max_rank: 14
+          min_rank: 1
+        continuous:
+          max_rank: null
+          min_rank: 10
+        measure_type: null
+        min_individuals: 1
+        non_numeric_cutoff: 0.06
+        ordinal:
+          max_rank: null
+          min_rank: 1
+        skip: false
+        value_max_len: 32
+        measure_type: ordinal
+        """,
+    ))
+
+    assert InferenceConfig.parse_obj(config) is not None
+
+
+def test_config_with_unknown_keys_errors() -> None:
+    config = yaml.safe_load(textwrap.dedent(
+        """
+        categorical:
+          max_rank: 14
+          min_rank: 1
+        continuous:
+          max_rank: null
+          min_rank: 10
+        measure_type: null
+        min_individuals: 1
+        non_numeric_cutoff: 0.06
+        ordinal:
+          max_rank: null
+          min_rank: 1
+        skip: false
+        value_max_len: 32
+        measure_type: ordinal
+        some_key: asdf
+        another_key: dkfhjldfjh
+        """,
+    ))
+    with pytest.raises(ValidationError):
+        InferenceConfig.parse_obj(config)
+
+
+def test_merge() -> None:
+    configs = yaml.safe_load(textwrap.dedent(
+        """
+        "*.*":
+          categorical:
+            max_rank: 14
+            min_rank: 1
+          continuous:
+            max_rank: null
+            min_rank: 10
+          measure_type: null
+          min_individuals: 1
+          non_numeric_cutoff: 0.06
+          skip: false
+          value_max_len: 32
+
+        "some_instrument.*":
+          categorical:
+            max_rank: 16
+            min_rank: 2
+
+        "*.some_measure":
+          measure_type: ordinal
+
+        "another_instrument.some_measure":
+          skip: true
+        """,
+    ))
+
+    config = PrepareVariables.merge_inference_configs(
+        configs,
+        "some_instrument",
+        "another_measure",
+    )
+
+    assert config.categorical.max_rank == 16
+    assert config.categorical.min_rank == 2
+    assert config.measure_type is None
+    assert config.skip is False
+
+    config = PrepareVariables.merge_inference_configs(
+        configs,
+        "some_instrument",
+        "some_measure",
+    )
+
+    assert config.categorical.max_rank == 16
+    assert config.categorical.min_rank == 2
+    assert config.measure_type == "ordinal"
+    assert config.skip is False
+
+    config = PrepareVariables.merge_inference_configs(
+        configs,
+        "asdf",
+        "ghjk",
+    )
+
+    assert config.categorical.max_rank == 14
+    assert config.categorical.min_rank == 1
+    assert config.measure_type is None
+    assert config.skip is False
+
+    config = PrepareVariables.merge_inference_configs(
+        configs,
+        "another_instrument",
+        "some_measure",
+    )
+
+    assert config.categorical.max_rank == 14
+    assert config.categorical.min_rank == 1
+    assert config.measure_type == "ordinal"
+    assert config.skip is True


### PR DESCRIPTION
## Background
Pheno classification was mistakenly merged and not reverted while it was a WIP.

## Aim
Finish up whatever work was left.

## Implementation
A new option has been added to the pheno import tool. `--inference-config` points to a yaml file containing a dict of wildcards to inference configurations. The inference configurations have been given a pydantic class for verification.
When performing classification for a measure, the multiple wildcard configurations get merged, with measure name specifications taking priority over instrument. The skip option has been reimplemented this way into the inference configurations. Inference configurations can also directly specify a measure's type as a string to skip most of the classification work.

