### PR TITLE
adjust genotype browser api related types and names

### DIFF
--- a/dae/dae/person_filters.py
+++ b/dae/dae/person_filters.py
@@ -1,5 +1,4 @@
 from collections.abc import Collection
-from typing import List, Set
 
 import numpy as np
 import pandas as pd
@@ -16,8 +15,8 @@ class PersonFilter:
         raise NotImplementedError
 
     def apply(
-        self, families: FamiliesData, roles: List[str] | None = None,
-    ) -> Set[str]:
+        self, families: FamiliesData, roles: list[str] | None = None,
+    ) -> set[str]:
         raise NotImplementedError
 
 
@@ -29,8 +28,8 @@ class CriteriaFilter(PersonFilter):  # pylint: disable=abstract-method
         self.values: Collection = values
 
     def apply(
-        self, families: FamiliesData, roles: List[str] | None = None,
-    ) -> Set[str]:
+        self, families: FamiliesData, roles: list[str] | None = None,
+    ) -> set[str]:
         """Return a set of person ids for individuals matching the filter."""
         ped_df = families.ped_df.copy()
         if roles is not None:
@@ -88,8 +87,8 @@ class PhenoFilter(CriteriaFilter):  # pylint: disable=abstract-method
         )
 
     def apply(
-        self, families: FamiliesData, roles: List[str] | None = None,
-    ) -> Set[str]:
+        self, families: FamiliesData, roles: list[str] | None = None,
+    ) -> set[str]:
         ids = set()
         for person_id in self.measure_df["person_id"]:
             if person_id not in families.persons_by_person_id:
@@ -143,7 +142,7 @@ class FamilyFilter(PersonFilter):
     def apply_to_df(self, df: pd.DataFrame) -> pd.DataFrame:
         return self.person_filter.apply_to_df(df)
 
-    def apply(self, *args, **kwargs) -> Set[str]:
+    def apply(self, *args, **kwargs) -> set[str]:
         families: FamiliesData = args[0]
         return families.families_of_persons(
             self.person_filter.apply(*args, **kwargs),

--- a/wdae/wdae/genotype_browser/views.py
+++ b/wdae/wdae/genotype_browser/views.py
@@ -84,7 +84,7 @@ class GenotypeBrowserQueryView(QueryDatasetView):
             presentInParent (json): Roles object to filter with.
             inheritanceTypeFilter (list): Inheritance filtering.
             geneScores (list): Gene score range filter.
-            gender (list): Gender filter.
+            genders (list): Gender filter.
             variantTypes (list): Filter by variant type.
             effectTypes (list): Filter by effect type.
             studyFilters (list): Filter by study ID (dataset only).

--- a/wdae/wdae/studies/query_transformer.py
+++ b/wdae/wdae/studies/query_transformer.py
@@ -20,7 +20,7 @@ class QueryTransformer:
     FILTER_RENAMES_MAP: ClassVar[dict[str, str]] = {
         "familyIds": "family_ids",
         "personIds": "person_ids",
-        "gender": "sexes",
+        "genders": "sexes",
         "geneSymbols": "genes",
         "variantTypes": "variant_type",
         "effectTypes": "effect_types",
@@ -415,13 +415,13 @@ class QueryTransformer:
                     kwargs["genes"] = []
                 kwargs["genes"] += genes
 
-        if "gender" in kwargs:
-            sexes = set(kwargs["gender"])
+        if "genders" in kwargs:
+            sexes = set(kwargs["genders"])
             if sexes != {"female", "male", "unspecified"}:
                 sexes_query = f"any({','.join(sexes)})"
-                kwargs["gender"] = sexes_query
+                kwargs["genders"] = sexes_query
             else:
-                kwargs["gender"] = None
+                kwargs["genders"] = None
 
         if "variantTypes" in kwargs:
             variant_types = set(kwargs["variantTypes"])

--- a/wdae/wdae/studies/tests/test_study_wrapper_queries.py
+++ b/wdae/wdae/studies/tests/test_study_wrapper_queries.py
@@ -100,7 +100,7 @@ def test_query_sexes_variants(
 ) -> None:
     study_wrapper = t4c8_study_1_wrapper
     query = {
-        "gender": sexes,
+        "genders": sexes,
     }
     variants = list(study_wrapper.query_variants_wdae(
         query, [{"source": "location"}]),
@@ -408,7 +408,7 @@ def test_query_complex_query(
             "frame-shift", "nonsense", "splice-site",
             "no-frame-shift-newStop", "missense", "synonymous",
         ],
-        "gender": [
+        "genders": [
             "female", "male",
         ],
         "inheritanceTypeFilter": [],


### PR DESCRIPTION
## Background
Small changes needed for GPFJS state refactor.

## Aim
- "Gender" list becomes "Genders" list. Renamed to not confuse with single gender.
