### PR TITLE
remove score histogram small and large values description

### DIFF
--- a/dae/dae/genomic_scores/scores.py
+++ b/dae/dae/genomic_scores/scores.py
@@ -82,26 +82,6 @@ SCORE_HISTOGRAM = """
 
 </div>
 
-{%- if score_def.small_values_desc and score_def.large_values_desc %}
-
-<div class="values-desc">
-
-<span class="small-values">
-
-{{ score_def.small_values_desc}}
-
-</span>
-
-<span class="large-values">
-
-{{ score_def.large_values_desc}}
-
-</span>
-
-</div>
-
-{%- endif %}
-
 </div>
 """
 


### PR DESCRIPTION
## Background

Small and large values descriptions were added in the histogram image, so a duplication of the descriptions in helper modal occurs.

![image](https://github.com/user-attachments/assets/6be70e18-4558-438f-a83e-b68963efbbb9)

## Aim

To remove the duplication.

## Implementation

Remove the code which adds the descriptions below the image.