### PR TITLE
fix unauthorized access to permissions api

### DIFF
--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -415,6 +415,13 @@ class DatasetPermissionsView(BaseDatasetPermissionsView):
     @method_decorator(etag(get_permissions_etag))
     def get(self, request: Request) -> Response:
         """Return dataset permissions details."""
+
+        if not request.user.is_staff:
+            return Response(
+                {"error": "You have no permission to edit the description."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         dataset_search = request.GET.get("search")
         page = request.GET.get("page", 1)
         query = Dataset.objects


### PR DESCRIPTION
## Background
Permissions api in user management is not protected and can be freely accessed.

## Aim
Require staff access when api request is made. 

## Implementation
Check user permission.