### PR TITLE
change dataset permissions api search to use name

### DIFF
--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -427,7 +427,7 @@ class DatasetPermissionsView(BaseDatasetPermissionsView):
         query = Dataset.objects
         if dataset_search is not None and dataset_search != "":
             query = query.filter(  # type: ignore
-                dataset_id__icontains=dataset_search)
+                dataset_name__icontains=dataset_search)
 
         if page is None:
             return Response(status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Background
User management dataset permissions api search is using dataset id to match search terms.

## Aim
Change dataset table to search by name and not by id (which is hidden).