### PR TITLE
Fix handling of measure names with dot

### DIFF
--- a/dae/dae/pheno/db.py
+++ b/dae/dae/pheno/db.py
@@ -542,7 +542,7 @@ class PhenoDb:  # pylint: disable=too-many-instance-attributes
         instrument_tables = {}
 
         for measure_id in measure_ids:
-            instrument, _ = measure_id.split(".")
+            instrument, _ = measure_id.split(".", maxsplit=1)
             instrument_table = table(generate_instrument_table_name(instrument))
             instrument_tables[instrument] = instrument_table
 
@@ -574,7 +574,7 @@ class PhenoDb:  # pylint: disable=too-many-instance-attributes
         query = select(*output_cols).from_(instrument_people)
         joined = set()
         for measure_id in measure_ids:
-            instrument, measure = measure_id.split(".")
+            instrument, measure = measure_id.split(".", maxsplit=1)
             instrument_table = instrument_tables[instrument]
             if instrument not in joined:
                 left_col = person_id_col.sql()

--- a/dae/dae/pheno/tests/test_pheno_db.py
+++ b/dae/dae/pheno/tests/test_pheno_db.py
@@ -222,6 +222,15 @@ def test_default_get_measure_df(fake_phenotype_data: PhenotypeStudy) -> None:
     assert len(df) == 17
 
 
+def test_get_query_with_dot_measure(
+    fake_phenotype_data: PhenotypeStudy,
+) -> None:
+    result = fake_phenotype_data.db._get_measure_values_query(
+        ["instr.some.measure.1"],
+    )
+    assert result is not None
+
+
 @pytest.mark.parametrize(
     "families,expected_count", [(["f20"], 5), (["f20", "f21"], 10)],
 )


### PR DESCRIPTION
## Background
Running the pheno import on a new study revealed an issue with the handling of measure names containing dots.
By design, it's not intended to have measure names with dots in them, but we decided it should be changed as it will most likely not introduce a new bug.

## Aim
Update measure name handling.

## Implementation

When getting the measure and instrument name from the measure id, `.split` was used and the output was being unpacked into 2 variables. These cases now have a `maxsplit` of 1 and should handle measure names with dots.