### PR TITLE
Federation restoration

### DIFF
--- a/dae/dae/pheno/pheno_data.py
+++ b/dae/dae/pheno/pheno_data.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import logging
 import math
+import mimetypes
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable, Sequence
 from itertools import chain, islice
+from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
@@ -245,6 +247,24 @@ class PhenotypeData(ABC):
         """Return a measure by measure_id."""
         assert measure_id in self._measures, measure_id
         return self._measures[measure_id]
+
+    def get_image(self, image_path: str) -> tuple[bytes, str]:
+        """Return binary image data with mimetype."""
+
+        base_image_dir = Path(get_pheno_browser_images_dir())
+
+        full_image_path = base_image_dir / image_path
+
+        image_data = full_image_path.read_bytes()
+
+        mimetype = mimetypes.guess_type(full_image_path)[0]
+
+        if mimetype is None:
+            raise ValueError(
+                f"Cannot guess image mimetype of {full_image_path}",
+            )
+
+        return image_data, mimetype
 
     def get_measures(
         self,

--- a/federation/Dockerfile
+++ b/federation/Dockerfile
@@ -1,0 +1,20 @@
+FROM --platform=linux/amd64 condaforge/mambaforge:latest
+
+
+ADD ./environment.yml /
+ADD ./dev-environment.yml /
+
+RUN /opt/conda/bin/mamba env create --name gpf --file /environment.yml
+# RUN /opt/conda/bin/mamba env update --name gpf --file /dev-environment.yml
+
+
+# GPF ENV
+ENV PATH /opt/conda/envs/gpf/bin:$PATH
+
+RUN mkdir -p /data && mkdir -p /code
+
+ENV DAE_DB_DIR "/data"
+
+WORKDIR /code
+
+SHELL ["/bin/bash", "-c"]

--- a/federation/docker-compose.yaml
+++ b/federation/docker-compose.yaml
@@ -1,0 +1,41 @@
+version: "3.9"
+services:
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
+    ports:
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+
+  setup:
+    build:
+      context: ../
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    restart: "no"
+    environment:
+      DAE_DB_DIR: /wd/data/data-hg19-local
+      GRR_DEFINITION_FILE: /wd/integration/grr_definition.yaml
+      DAE_IMPALA_HOST: localhost
+      DAE_HDFS_HOST: localhost
+      TEST_REMOTE_HOST: localhost
+    volumes:
+      - ../:/wd
+    entrypoint: /wd/integration/local/entrypoint.sh
+
+  remote:
+    build:
+      context: ../
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    depends_on:
+      - setup
+    ports:
+      - "21010:21010"
+    environment:
+      DAE_DB_DIR: /wd/data/data-hg19-remote
+      GRR_DEFINITION_FILE: /wd/integration/grr_definition.yaml
+    volumes:
+      - ../:/wd
+    entrypoint: /wd/integration/remote/entrypoint.sh

--- a/federation/federation/pytest.ini
+++ b/federation/federation/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+
+junit_family=xunit1
+
+# install pytest-cache and pytest-django
+# django_find_project = false
+
+DJANGO_SETTINGS_MODULE = wdae.test_settings
+# addopts = -v

--- a/federation/federation/remote/genomic_scores_registry.py
+++ b/federation/federation/remote/genomic_scores_registry.py
@@ -1,6 +1,5 @@
-from remote.rest_api_client import RESTClient
-
 from dae.genomic_scores.scores import GenomicScoresRegistry, ScoreDesc
+from federation.remote.rest_api_client import RESTClient
 
 
 class RemoteGenomicScoresRegistry(GenomicScoresRegistry):

--- a/federation/federation/remote/remote_extension.py
+++ b/federation/federation/remote/remote_extension.py
@@ -44,6 +44,12 @@ def load_extension(instance: WGPFInstance) -> None:
             wrapper = RemoteStudyWrapper(study)
 
             instance.register_genotype_data(study, study_wrapper=wrapper)
+            pheno_registry = instance._pheno_registry  # noqa: SLF001
+
+            if wrapper.phenotype_data is not None:
+                pheno_registry.register_phenotype_data(
+                    wrapper.phenotype_data,
+                )
             if instance.visible_datasets is not None:
                 instance.visible_datasets.append(wrapper.study_id)
 

--- a/federation/federation/remote/remote_extension.py
+++ b/federation/federation/remote/remote_extension.py
@@ -57,7 +57,9 @@ def load_extension(instance: WGPFInstance) -> None:
                 client, wrapper.remote_study_id,
             )
 
-            instance.register_pheno_tool_adapter(pheno_tool_adapter)
+            instance.register_pheno_tool_adapter(
+                wrapper.study_id, pheno_tool_adapter,
+            )
 
         gs_db = instance.gene_sets_db
         for collection in client.get_gene_set_collections():

--- a/federation/federation/remote/remote_phenotype_data.py
+++ b/federation/federation/remote/remote_phenotype_data.py
@@ -84,6 +84,15 @@ class RemotePhenotypeData(PhenotypeData):
         )
         return {m["measureName"]: Measure.from_json(m) for m in measures}
 
+    def count_measures(
+        self, instrument: str | None,
+        search_term: str | None,
+        page: int | None = None,  # noqa: ARG002
+    ) -> int:
+        return self.rest_client.get_browser_measure_count(
+            self.remote_dataset_id, instrument, search_term,
+        )
+
     def get_people_measure_values(  # type: ignore
         self,
         measure_ids: Iterable[str],

--- a/federation/federation/remote/remote_phenotype_data.py
+++ b/federation/federation/remote/remote_phenotype_data.py
@@ -140,10 +140,21 @@ class RemotePhenotypeData(PhenotypeData):
         )
         pheno_folder = self._extract_pheno_dir(output["base_image_url"])
         output["base_image_url"] = (
-            "/api/v3/pheno_browser/remote_images/"
-            f"{self.rest_client.remote_id}/{pheno_folder}/"
+            f"/api/v3/pheno_browser/images/{self.pheno_id}/"
+            f"{pheno_folder}/"
         )
         return cast(dict[str, Any], output)
+
+    def get_image(self, image_path: str) -> tuple[bytes, str]:
+        """Return binary image data with mimetype."""
+        image, mimetype = self.rest_client.get_pheno_image(image_path)
+        if image is None or mimetype is None:
+            raise ValueError(
+                f"Cannot get remote image at {image_path} for "
+                f"{self.remote_dataset_id} with remote pheno"
+                f"{self._remote_pheno_id}",
+            )
+        return image, mimetype
 
     def search_measures(
         self,

--- a/federation/federation/remote/remote_study.py
+++ b/federation/federation/remote/remote_study.py
@@ -6,6 +6,7 @@ from dae.configuration.gpf_config_parser import FrozenBox
 from dae.pedigrees.families_data import FamiliesData, tag_families_data
 from dae.pedigrees.family import Family, Person
 from dae.person_sets import PersonSetCollection
+from dae.person_sets.person_sets import parse_person_set_collection_config
 from dae.studies.study import GenotypeData
 from dae.utils.regions import Region
 from dae.variants.family_variant import FamilyVariant
@@ -89,7 +90,8 @@ class RemoteGenotypeData(GenotypeData):
             self.remote_study_id,
         )
         for conf in configs.values():
-            psc = PersonSetCollection.from_families(conf, self._families)
+            psc_config = parse_person_set_collection_config(conf)
+            psc = PersonSetCollection.from_families(psc_config, self._families)
             result[psc.id] = psc
         return result
 
@@ -99,8 +101,8 @@ class RemoteGenotypeData(GenotypeData):
     ) -> PersonSetCollection:
         raise NotImplementedError
 
-    def get_studies_ids(  # pylint: disable=arguments-differ
-        self, *, _leaves: bool = True,
+    def get_studies_ids(
+        self, *, leaves: bool = True,  # noqa: ARG002
     ) -> list[str]:
         return [self.study_id]
 

--- a/federation/federation/remote/rest_api_client.py
+++ b/federation/federation/remote/rest_api_client.py
@@ -364,6 +364,33 @@ class RESTClient:
         )
         return response.json()["instruments"]
 
+    def get_browser_measure_count(
+        self,
+        dataset_id: str,
+        instrument: str | None,
+        search_term: str | None,
+    ) -> int:
+        """Post download request for pheno measures."""
+        response = self._get(
+            "pheno_browser/measures_count",
+            query_values={
+                "dataset_id": dataset_id,
+                "search_term": search_term,
+                "instrument": instrument,
+            },
+            stream=True,
+        )
+        res = response.json()
+        if res.status_code != 200:
+            raise ValueError(
+                f"{self.remote_id}: Failed to get measure count"
+                f"from {dataset_id}",
+            )
+        if "count" not in res:
+            raise ValueError(f"{self.remote_id}: Invalid response")
+
+        return cast(int, res["count"])
+
     def get_measures_download(
             self, dataset_id: str,
             search_term: str | None = None,

--- a/federation/federation/remote/rest_api_client.py
+++ b/federation/federation/remote/rest_api_client.py
@@ -78,8 +78,8 @@ class RESTClient:
         """Build a url for accessing remote GPF static images."""
         host_url = self.build_host_url()
         if self.gpf_prefix:
-            return f"{host_url}/{self.gpf_prefix}/static/images/{url}"
-        return f"{host_url}/static/images/{url}"
+            return f"{host_url}/{self.gpf_prefix}/static/{url}"
+        return f"{host_url}/static/{url}"
 
     def _build_url(
         self, url: str, query_values: dict | None = None,

--- a/federation/federation/remote/tests/conftest.py
+++ b/federation/federation/remote/tests/conftest.py
@@ -1,0 +1,177 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import os
+import pathlib
+import textwrap
+from typing import cast
+
+import pytest
+import pytest_mock
+from django.test import Client
+from gpf_instance.gpf_instance import (
+    WGPFInstance,
+    reload_datasets,
+)
+from utils.testing import (
+    _study_1_pheno,
+    _t4c8_dataset,
+    _t4c8_default_study_config,
+    _t4c8_study_1,
+    _t4c8_study_2,
+    _t4c8_study_4,
+    setup_gpf_instance,
+    setup_t4c8_grr,
+)
+
+from dae.gene_sets.denovo_gene_set_helpers import DenovoGeneSetHelpers
+from dae.testing import (
+    setup_directories,
+)
+from federation.remote.remote_extension import load_extension
+from federation.remote.rest_api_client import RESTClient
+
+
+def setup_remote_t4c8_instance(
+    root_path: pathlib.Path,
+) -> WGPFInstance:
+    t4c8_grr = setup_t4c8_grr(root_path)
+
+    instance_path = root_path / "gpf_instance"
+
+    _t4c8_default_study_config(instance_path)
+
+    setup_directories(
+        instance_path, {
+            "gpf_instance.yaml": textwrap.dedent("""
+                instance_id: t4c8_instance
+                annotation:
+                  conf_file: annotation.yaml
+                reference_genome:
+                  resource_id: t4c8_genome
+                gene_models:
+                  resource_id: t4c8_genes
+                gene_scores_db:
+                  gene_scores:
+                  - "gene_scores/t4c8_score"
+                gene_sets_db:
+                  gene_set_collections:
+                  - gene_sets/main
+                default_study_config:
+                  conf_file: default_study_configuration.yaml
+                genotype_storage:
+                  default: duckdb_wgpf_test
+                  storages:
+                  - id: duckdb_wgpf_test
+                    storage_type: duckdb_parquet
+                    memory_limit: 16GB
+                    base_dir: '%(wd)s/duckdb_storage'
+                gpfjs:
+                  visible_datasets:
+                  - t4c8_dataset
+                  - t4c8_study_1
+                  - nonexistend_dataset
+                remotes:
+                  - id: "TEST_REMOTE"
+                    host: "localhost"
+                    base_url: "api/v3"
+                    port: 21010
+                    credentials: "ZmVkZXJhdGlvbjpzZWNyZXQ="
+            """),
+            "annotation.yaml": textwrap.dedent("""
+               - position_score: genomic_scores/score_one
+            """),
+        },
+    )
+
+    _study_1_pheno(
+        root_path,
+        instance_path,
+    )
+
+    gpf_instance = setup_gpf_instance(
+        instance_path,
+        grr=t4c8_grr,
+    )
+
+    _t4c8_study_1(root_path, gpf_instance)
+    _t4c8_study_2(root_path, gpf_instance)
+    _t4c8_dataset(gpf_instance)
+    _t4c8_study_4(root_path, gpf_instance)
+
+    gpf_instance.reload()
+
+    for study_id in [
+            "t4c8_study_1", "t4c8_study_2", "t4c8_dataset", "t4c8_study_4"]:
+        study = gpf_instance.get_genotype_data(study_id)
+        assert study is not None, study_id
+        DenovoGeneSetHelpers.build_collection(study)
+
+    gpf_instance.reload()
+
+    instance_filename = str(instance_path / "gpf_instance.yaml")
+    wgpf_instance = WGPFInstance.build(instance_filename, grr=t4c8_grr)
+
+    load_extension(wgpf_instance)
+    return cast(WGPFInstance, gpf_instance)
+
+
+@pytest.fixture(scope="session")
+def remote_t4c8_instance(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> WGPFInstance:
+    root_path = tmp_path_factory.mktemp("remote_t4c8_instance")
+    return setup_remote_t4c8_instance(root_path)
+
+
+@pytest.fixture()
+def remote_t4c8_wgpf_instance(
+    remote_t4c8_instance: WGPFInstance,
+    db: None,  # noqa: ARG001
+    mocker: pytest_mock.MockFixture,
+) -> WGPFInstance:
+    reload_datasets(remote_t4c8_instance)
+    mocker.patch(
+        "gpf_instance.gpf_instance.get_wgpf_instance",
+        return_value=remote_t4c8_instance,
+    )
+    mocker.patch(
+        "datasets_api.permissions.get_wgpf_instance",
+        return_value=remote_t4c8_instance,
+    )
+    mocker.patch(
+        "query_base.query_base.get_wgpf_instance",
+        return_value=remote_t4c8_instance,
+    )
+
+    return remote_t4c8_instance
+
+
+@pytest.fixture()
+def remote_config() -> dict[str, str]:
+    host = os.environ.get("TEST_REMOTE_HOST", "localhost")
+    return {
+        "id": "TEST_REMOTE",
+        "host": host,
+        "base_url": "api/v3",
+        "port": "21010",
+        "credentials": "ZmVkZXJhdGlvbjpzZWNyZXQ=",
+    }
+
+
+@pytest.fixture()
+def rest_client(
+    admin_client: Client,  # noqa: ARG001
+    remote_config: dict[str, str],
+    remote_t4c8_wgpf_instance,  # noqa: ARG001
+) -> RESTClient:
+    client = RESTClient(
+        remote_config["id"],
+        remote_config["host"],
+        remote_config["credentials"],
+        base_url=remote_config["base_url"],
+        port=int(remote_config["port"]),
+    )
+
+    assert client.token is not None, \
+        "Failed to get auth token for REST client"
+
+    return client

--- a/federation/federation/remote/tests/test_remote_gene_sets.py
+++ b/federation/federation/remote/tests/test_remote_gene_sets.py
@@ -1,6 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-from remote.gene_sets_db import RemoteGeneSetCollection
-from remote.rest_api_client import RESTClient
+from federation.remote.gene_sets_db import RemoteGeneSetCollection
+from federation.remote.rest_api_client import RESTClient
 
 
 def test_get_gene_set(rest_client: RESTClient) -> None:

--- a/federation/federation/remote/tests/test_remote_genomic_scores.py
+++ b/federation/federation/remote/tests/test_remote_genomic_scores.py
@@ -10,7 +10,7 @@ from federation.remote.rest_api_client import RESTClient
 
 def test_remote_genomic_scores(
     mocker: MockerFixture, rest_client: RESTClient,
-    wdae_gpf_instance: WGPFInstance,
+    remote_t4c8_wgpf_instance: WGPFInstance,
 ) -> None:
     patch = mocker.patch.object(rest_client, "get_genomic_scores")
     patch.return_value = [{
@@ -60,7 +60,7 @@ def test_remote_genomic_scores(
         "description": "ala bala",
         "help": "bala ala",
     }]
-    local_db = wdae_gpf_instance.genomic_scores
+    local_db = remote_t4c8_wgpf_instance.genomic_scores
 
     db = RemoteGenomicScoresRegistry({"remote": rest_client}, local_db)
     assert len(db.remote_scores) == 1

--- a/federation/federation/remote/tests/test_remote_genomic_scores.py
+++ b/federation/federation/remote/tests/test_remote_genomic_scores.py
@@ -1,8 +1,11 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 from gpf_instance.gpf_instance import WGPFInstance
 from pytest_mock import MockerFixture
-from remote.genomic_scores_registry import RemoteGenomicScoresRegistry
-from remote.rest_api_client import RESTClient
+
+from federation.remote.genomic_scores_registry import (
+    RemoteGenomicScoresRegistry,
+)
+from federation.remote.rest_api_client import RESTClient
 
 
 def test_remote_genomic_scores(

--- a/federation/federation/remote/tests/test_remote_pheno_db.py
+++ b/federation/federation/remote/tests/test_remote_pheno_db.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-from remote.remote_phenotype_data import RemotePhenotypeData
+from federation.remote.remote_phenotype_data import RemotePhenotypeData
 
 
 def test_extract_url() -> None:

--- a/federation/federation/remote/tests/test_remote_variant.py
+++ b/federation/federation/remote/tests/test_remote_variant.py
@@ -3,9 +3,12 @@ from typing import Any
 
 import numpy as np
 import pytest
-from remote.remote_variant import RemoteFamilyAllele, RemoteFamilyVariant
 
 from dae.pedigrees.family import Family, Person
+from federation.remote.remote_variant import (
+    RemoteFamilyAllele,
+    RemoteFamilyVariant,
+)
 
 
 @pytest.fixture()
@@ -123,7 +126,6 @@ def test_remote_variant_alleles(
     attributes, columns = sample_attributes_columns
     variant = RemoteFamilyVariant(attributes, sample_family, columns)
 
-    # assert isinstance(variant.family_genotype, np.ndarray)
     assert variant.family_genotype == [[0, 0], [0, 0], [1, 0], [0, 0]]
 
     assert isinstance(variant.best_state, np.ndarray)

--- a/federation/federation/remote/tests/test_rest_api_client.py
+++ b/federation/federation/remote/tests/test_rest_api_client.py
@@ -1,6 +1,7 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
-from remote.rest_api_client import RESTClient
 from requests import Response
+
+from federation.remote.rest_api_client import RESTClient
 
 
 def test_get_datasets(rest_client: RESTClient) -> None:

--- a/integration/remote/entrypoint.sh
+++ b/integration/remote/entrypoint.sh
@@ -32,7 +32,7 @@ cd /wd/integration/fixtures/pheno/comp-data
 
 mkdir -p $DAE_DB_DIR/pheno/images
 cp -r $DAE_DB_DIR/pheno/comp_pheno/images/comp_pheno \
-    $DAE_DB_DIR/pheno/
+    $DAE_DB_DIR/pheno/images
 
 cd /wd
 
@@ -51,6 +51,9 @@ cd /wd/integration/fixtures/hg19/micro_iossifov2014
 cat >> /wd/data/data-hg19-remote/studies/iossifov_2014/iossifov_2014.yaml << EOT
 
 phenotype_data: comp_pheno
+
+phenotype_browser: true
+phenotype_tool: true
 
 enrichment:
   enabled: true

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -14,6 +14,7 @@ from dae.pheno.pheno_data import PhenotypeStudy
 
 URL = "/api/v3/pheno_browser/instruments"
 MEASURES_URL = "/api/v3/pheno_browser/measures"
+MEASURES_COUNT_URL = "/api/v3/pheno_browser/measures_count"
 MEASURE_VALUES_URL = "/api/v3/pheno_browser/measure_values"
 MEASURES_INFO_URL = "/api/v3/pheno_browser/measures_info"
 MEASURE_DESCRIPTION_URL = "/api/v3/pheno_browser/measure_description"
@@ -135,6 +136,18 @@ def test_measures(
 
     res = json.loads("".join([x.decode("utf-8") for x in response]))
     assert len(res) == 7
+
+
+def test_measures_count(
+    admin_client: Client,
+    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+) -> None:
+    url = f"{MEASURES_COUNT_URL}?dataset_id=t4c8_study_1&instrument=i1"
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    res = response.json()
+
+    assert res["count"] == 7
 
 
 def test_measures_forbidden(

--- a/wdae/wdae/pheno_browser_api/urls.py
+++ b/wdae/wdae/pheno_browser_api/urls.py
@@ -39,11 +39,6 @@ urlpatterns = [
         name="pheno_browser_values",
     ),
     re_path(
-        r"^/remote_images/(?P<remote_id>[^/]+)/(?P<image_path>.+)?",
-        views.PhenoRemoteImages.as_view(),
-        name="pheno_browser_remote_images",
-    ),
-    re_path(
         r"^/images/(?P<pheno_id>[^/]+)/(?P<image_path>.+)?",
         views.PhenoImagesView.as_view(),
         name="pheno_browser_images",

--- a/wdae/wdae/pheno_browser_api/urls.py
+++ b/wdae/wdae/pheno_browser_api/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
         name="pheno_browser_measures",
     ),
     re_path(
+        r"^/measures_count/?$",
+        views.PhenoMeasuresCount.as_view(),
+        name="pheno_browser_measures_count",
+    ),
+    re_path(
         r"^/measure_description/?$",
         views.PhenoMeasureDescriptionView.as_view(),
         name="pheno_browser_measure_description",

--- a/wdae/wdae/pheno_browser_api/urls.py
+++ b/wdae/wdae/pheno_browser_api/urls.py
@@ -43,4 +43,9 @@ urlpatterns = [
         views.PhenoRemoteImages.as_view(),
         name="pheno_browser_remote_images",
     ),
+    re_path(
+        r"^/images/(?P<pheno_id>[^/]+)/(?P<image_path>.+)?",
+        views.PhenoImagesView.as_view(),
+        name="pheno_browser_images",
+    ),
 ]

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -353,27 +353,6 @@ class PhenoMeasureValues(QueryDatasetView):
         )
 
 
-class PhenoRemoteImages(QueryDatasetView):
-    """Remote pheno images view."""
-
-    @method_decorator(etag(get_permissions_etag))
-    def get(
-        self, _request: Request, remote_id: str, image_path: str,
-    ) -> Response | HttpResponse:
-        """Return raw image data from a remote GPF instance."""
-        if image_path == "":
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
-        client = self.gpf_instance.get_remote_client(remote_id)
-
-        if client is None:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
-        image, mimetype = client.get_pheno_image(image_path)
-
-        return HttpResponse(image, content_type=mimetype)
-
-
 class PhenoImagesView(QueryDatasetView):
     """Remote pheno images view."""
 

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -308,6 +308,52 @@ class PhenoMeasuresDownload(QueryDatasetView):
         return Response(status=status.HTTP_200_OK)
 
 
+class PhenoMeasuresCount(QueryDatasetView):
+    """Phenotype measure search count view."""
+
+    def get_count(self, request: Request) -> int:
+        """Return measure count for request."""
+        data = request.query_params
+        data = {k: str(v) for k, v in data.items()}
+
+        if "dataset_id" not in data:
+            raise ValueError
+        dataset_id = data["dataset_id"]
+
+        dataset = self.gpf_instance.get_wdae_wrapper(dataset_id)
+        if not dataset or dataset.phenotype_data is None:
+            raise KeyError
+
+        search_term = data.get("search_term", None)
+        instrument = data.get("instrument", None)
+
+        if (instrument is not None
+                and instrument != ""
+                and instrument not in dataset.phenotype_data.instruments):
+            raise KeyError
+
+        return dataset.phenotype_data.count_measures(
+            instrument, search_term,
+        )
+
+    @method_decorator(etag(get_instance_timestamp_etag))
+    def get(self, request: Request) -> Response:
+        """Return a CSV file stream for measures."""
+        try:
+            count = self.get_count(request)
+        except ValueError:
+            logger.exception("Error")
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except KeyError:
+            logger.exception("Measures not found")
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        except CountError:
+            logger.exception("Measure count is too large")
+            return Response(status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+
+        return Response({"count": count})
+
+
 class PhenoMeasureValues(QueryDatasetView):
     """Phenotype measure values view."""
 


### PR DESCRIPTION
## Background
When we moved the federation code into a separate module, parts of the way the federation worked changed and due to focus being on other tasks, the federation was outdated and didn't work.

## Aim
Restore the federation, federation tests and fix phenotype browser images.

## Implementation
The `PhenotypeData` class now has a method for getting an image as binary data, which allows remote phenotype data to handle images without special handling. This method is mapped to a new API view and should be used only by remote studies, but can be used by local studies.