### PR TITLE
Speed up tests with wrong instance

### DIFF
--- a/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
+++ b/wdae/wdae/common_reports_api/tests/test_common_reports_api.py
@@ -38,7 +38,7 @@ def test_variant_reports_permissions(
     url: str,
     method: str,
     body: dict[str, Any],
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     if method == "get":
         response = anonymous_client.get(url)
@@ -54,7 +54,7 @@ def test_variant_reports_permissions(
 
 def test_variant_reports(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/studies/t4c8_study_1"
     response = admin_client.get(url)
@@ -68,7 +68,7 @@ def test_variant_reports(
 
 def test_variant_reports_full(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/studies/t4c8_study_1/full"
     response = admin_client.get(url)
@@ -82,7 +82,7 @@ def test_variant_reports_full(
 
 def test_family_counters(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "study_id": "t4c8_study_1",
@@ -104,7 +104,7 @@ def test_family_counters(
 
 def test_family_counters_download(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "queryData": json.dumps({
@@ -129,7 +129,7 @@ def test_family_counters_download(
 
 def test_families_tags_download(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = (
         "/api/v3/common_reports/families_data/t4c8_dataset"
@@ -195,7 +195,7 @@ def test_families_tags_download(
 )
 def test_families_tags_download_errors_on_bad_body(
     admin_client: Client, body: dict[str, Any],
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = (
         "/api/v3/common_reports/families_data/t4c8_study_1"
@@ -210,7 +210,7 @@ def test_families_tags_download_errors_on_bad_body(
 
 def test_variant_reports_no_permissions(
     user_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/studies/t4c8_study_1"
     response = user_client.get(url)
@@ -224,9 +224,9 @@ def test_variant_reports_no_permissions(
 
 def test_autogenerate_common_report(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,
+    t4c8_wgpf_instance: WGPFInstance,
 ) -> None:
-    study = t4c8_wgpf.get_genotype_data("t4c8_study_1")
+    study = t4c8_wgpf_instance.get_genotype_data("t4c8_study_1")
     assert study is not None
     report_filename = study.config.common_report.file_path
     os.remove(report_filename)
@@ -243,7 +243,7 @@ def test_autogenerate_common_report(
 
 def test_families_data_download(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/families_data/t4c8_study_1"
     response = admin_client.post(url)
@@ -259,7 +259,7 @@ def test_families_data_download(
 
 def test_families_data_download_no_permissions(
     user_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/families_data/t4c8_study_1"
     response = user_client.post(url)
@@ -270,7 +270,7 @@ def test_families_data_download_no_permissions(
 
 def test_families_data_all_download(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/families_data/t4c8_study_1"
     response = admin_client.get(url)
@@ -286,7 +286,7 @@ def test_families_data_all_download(
 
 def test_families_data_all_download_no_permissions(
     user_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = "/api/v3/common_reports/families_data/t4c8_study_1"
     response = user_client.get(url)

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -50,7 +50,7 @@ def test_pheno_browser_api_permissions(
     url: str,
     method: str,
     body: dict,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     if method == "get":
         response = anonymous_client.get(url)
@@ -65,7 +65,7 @@ def test_pheno_browser_api_permissions(
 
 def test_instruments_missing_dataset_id(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     response = admin_client.get(URL)
 
@@ -74,7 +74,7 @@ def test_instruments_missing_dataset_id(
 
 def test_instruments_missing_dataset_id_forbidden(
     user_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     response = user_client.get(URL)
 
@@ -83,27 +83,28 @@ def test_instruments_missing_dataset_id_forbidden(
 
 def test_instruments(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = f"{URL}?dataset_id=t4c8_study_1"
     response = admin_client.get(url)
 
     assert response.status_code == 200
-    assert "default" in response.data
-    assert "instruments" in response.data
-    assert len(response.data["instruments"]) == 2
+    data = response.json()
+    assert "default" in data
+    assert "instruments" in data
+    assert len(data["instruments"]) == 2
 
 
 def test_instruments_forbidden(
     user_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = f"{URL}?dataset_id=t4c8_study_1"
     response = user_client.get(url)
 
     assert response.status_code == 403
 
-    header = response.data
+    header = response.json()
     assert len(header.keys()) == 1
     assert (
         header["detail"]
@@ -113,19 +114,20 @@ def test_instruments_forbidden(
 
 def test_measures_info(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = f"{MEASURES_INFO_URL}?dataset_id=t4c8_study_1"
     response = admin_client.get(url)
 
+    data = response.json()
     assert response.status_code == 200
-    assert "base_image_url" in response.data
-    assert "has_descriptions" in response.data
+    assert "base_image_url" in data
+    assert "has_descriptions" in data
 
 
 def test_measures(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = f"{MEASURES_URL}?dataset_id=t4c8_study_1&instrument=i1"
     response = admin_client.get(url)
@@ -138,7 +140,7 @@ def test_measures(
 def test_measures_forbidden(
     user_client: Client,
     user: User,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     print(user.groups.all())
     url = f"{MEASURES_URL}?dataset_id=t4c8_study_1&instrument=i1"
@@ -156,7 +158,7 @@ def test_measures_forbidden(
 
 def test_download(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "dataset_id": "t4c8_study_1",
@@ -176,7 +178,7 @@ def test_download(
 
 def test_download_specific_measures(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "dataset_id": "t4c8_study_1",
@@ -199,7 +201,7 @@ def test_download_specific_measures(
 
 def test_download_all_instruments(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "dataset_id": "t4c8_study_1",
@@ -234,7 +236,7 @@ def test_download_all_instruments(
 
 def test_download_all_instruments_specific_measures(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "dataset_id": "t4c8_study_1",
@@ -266,7 +268,7 @@ def test_download_all_instruments_specific_measures(
 
 def test_measure_details(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     url = (
         f"{MEASURE_DESCRIPTION_URL}?dataset_id=t4c8_study_1"
@@ -276,11 +278,11 @@ def test_measure_details(
 
     assert response.status_code == 200
 
-    print(response.data)
-    assert response.data["instrument_name"] == "i1"
-    assert response.data["measure_name"] == "age"
-    assert response.data["measure_type"] == "continuous"
-    assert response.data["values_domain"] == [
+    data = response.json()
+    assert data["instrument_name"] == "i1"
+    assert data["measure_name"] == "age"
+    assert data["measure_type"] == "continuous"
+    assert data["values_domain"] == [
         68.00148724003327,
         565.9100943623504,
     ]
@@ -288,7 +290,7 @@ def test_measure_details(
 
 def test_get_specific_measure_values(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "dataset_id": "t4c8_study_1",
@@ -327,7 +329,7 @@ def test_get_specific_measure_values(
 
 def test_get_measure_values(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data = {
         "dataset_id": "t4c8_study_1",
@@ -389,7 +391,7 @@ def test_get_measure_values(
 def test_measure_values_limits_measures(
     admin_client: Client,
     mocker: pytest_mock.MockerFixture,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     data: dict[str, Any] = {
         "dataset_id": "t4c8_study_1",

--- a/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
+++ b/wdae/wdae/pheno_tool_api/tests/test_pheno_tool_api.py
@@ -49,7 +49,7 @@ def test_pheno_tool_api_permissions(
     url: str,
     method: str,
     body: dict,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     if method == "get":
         response = anonymous_client.get(url)
@@ -64,7 +64,7 @@ def test_pheno_tool_api_permissions(
 
 def test_pheno_tool_view_valid_request(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
 
@@ -79,7 +79,7 @@ def test_pheno_tool_view_valid_request(
 
 def test_pheno_tool_view_missense(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["missense"]
@@ -114,7 +114,7 @@ def test_pheno_tool_view_missense(
 
 def test_pheno_tool_view_cnv_on_non_cnv_study(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["missense", "CNV+"]
@@ -130,7 +130,7 @@ def test_pheno_tool_view_cnv_on_non_cnv_study(
 
 def test_pheno_tool_view_normalize(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["missense"]
@@ -184,7 +184,7 @@ def test_pheno_tool_view_normalize(
 
 def test_pheno_tool_view_family_ids_filter(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["LGDs"]
@@ -206,7 +206,7 @@ def test_pheno_tool_view_family_ids_filter(
 
 def test_pheno_tool_view_na_values(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["frame-shift"]
@@ -233,7 +233,7 @@ def test_pheno_tool_view_na_values(
 
 def test_pheno_tool_view_pheno_filter(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["frame-shift"]
@@ -280,7 +280,7 @@ def test_pheno_tool_view_pheno_filter(
 
 def test_pheno_tool_view_missing_dataset(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["datasetId"] = "???"
@@ -296,7 +296,7 @@ def test_pheno_tool_view_missing_dataset(
 
 def test_pheno_tool_view_missing_measure(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["measureId"] = "???"
@@ -312,7 +312,7 @@ def test_pheno_tool_view_missing_measure(
 
 def test_pheno_tool_download_valid_request(
     admin_client: Client,
-    t4c8_wgpf: WGPFInstance,  # noqa: ARG001
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001
 ) -> None:
     query = copy.deepcopy(QUERY)
     query["effectTypes"] = ["missense"]


### PR DESCRIPTION
## Background
Updated wdae tests were slow because they used t4c8 wgpf instance that is created anew in every test.

## Aim
Switch the the wgpf instance to a session wide t4c8 instance that is created once for all tests.