### PR TITLE
Reimplement pheno common

### DIFF
--- a/dae/dae/pheno/pheno_import.py
+++ b/dae/dae/pheno/pheno_import.py
@@ -302,6 +302,7 @@ def import_pheno_data(args: Any) -> None:
         instr: defaultdict(default_row)
         for instr in instruments
     }
+    imported_instruments = set()
     description_builder = load_descriptions(args.data_dictionary)
     with TaskGraphCli.create_executor(task_cache, **vars(args)) as xtor:
         try:
@@ -338,6 +339,7 @@ def import_pheno_data(args: Any) -> None:
                             report.rank,
                         ],
                     )
+                imported_instruments.add(report.instrument_name)
 
         except Exception:
             logger.exception("Failed to classify measure")
@@ -346,6 +348,10 @@ def import_pheno_data(args: Any) -> None:
 
     print("WRITING RESULTS")
     start = time.time()
+
+    for k in list(instrument_tables.keys()):
+        if k not in imported_instruments:
+            del instrument_tables[k]
 
     write_results(connection, instrument_tables, ped_df)
 

--- a/dae/dae/pheno/pheno_import.py
+++ b/dae/dae/pheno/pheno_import.py
@@ -486,6 +486,7 @@ def read_and_classify_measure(
 def add_pheno_common_inference(
     config: dict[str, Any],
 ) -> None:
+    """Add pedigree columns as skipped columns to the inference config."""
     default_cols = [
         "familyId",
         "personId",

--- a/dae/dae/pheno/pheno_import.py
+++ b/dae/dae/pheno/pheno_import.py
@@ -21,6 +21,7 @@ from box import Box
 
 from dae.configuration.gpf_config_parser import GPFConfigParser
 from dae.configuration.schemas.phenotype_data import regression_conf_schema
+from dae.pedigrees.family import ALL_FAMILY_TAG_LABELS
 from dae.pedigrees.loader import (
     FamiliesLoader,
 )
@@ -249,6 +250,7 @@ def import_pheno_data(args: Any) -> None:
             Path(args.inference_config).read_text(),
         )
     inference_configs = load_inference_configs(args.inference_config)
+    add_pheno_common_inference(inference_configs)
 
     connection = duckdb.connect(args.pheno_db_filename)
 
@@ -265,6 +267,10 @@ def import_pheno_data(args: Any) -> None:
     start = time.time()
 
     instruments = collect_instruments(args.instruments)
+
+    if not args.skip_pheno_common:
+        instruments["pheno_common"] = [Path(args.pedigree).absolute()]
+
     instrument_measure_names = read_instrument_measure_names(
         instruments, tab_separated=args.tab_separated,
     )
@@ -432,6 +438,9 @@ def read_and_classify_measure(
     """Read a measure's values and classify from an instrument file."""
     output = {}
 
+    if instrument_name == "pheno_common":
+        person_id_column = "personId"
+
     def transform_value(val: str) -> str | None:
         if val == "":
             return None
@@ -446,8 +455,10 @@ def read_and_classify_measure(
     for instrument_filepath in instrument_filepaths:
         with instrument_filepath.open() as csvfile:
             reader = csv.DictReader(
-                    filter(lambda x: x.strip() != "", csvfile),
-                delimiter="\t" if tab_separated else ",",
+                filter(lambda x: x.strip() != "", csvfile),
+                delimiter="\t"
+                if tab_separated or instrument_name == "pheno_common"
+                else ",",
             )
 
             for row in reader:
@@ -464,6 +475,30 @@ def read_and_classify_measure(
     for idx, person_id in enumerate(output):
         output[person_id] = values[idx]
     return output, report
+
+
+def add_pheno_common_inference(
+    config: dict[str, Any],
+) -> None:
+    default_cols = [
+        "familyId",
+        "personId",
+        "momId",
+        "dadId",
+        "sex",
+        "status",
+        "role",
+        "sample_id",
+        "layout",
+        "generated",
+        "proband",
+        "not_sequenced",
+        "missing",
+    ]
+    default_cols.extend(ALL_FAMILY_TAG_LABELS)
+    for col in default_cols:
+        entry = f"pheno_common.{col}"
+        config[entry] = {"skip": True}
 
 
 def load_inference_configs(
@@ -614,9 +649,11 @@ def read_instrument_measure_names(
     tab_separated: bool = False,
 ) -> dict[str, list[str]]:
     """Read the headers of all the instrument files."""
-    delimiter = "\t" if tab_separated else ","
     instrument_measure_names = {}
     for instrument_name, instrument_files in instruments.items():
+        delimiter = "\t" \
+            if tab_separated or instrument_name == "pheno_common" \
+            else ","
         file_to_read = instrument_files[0]
         with file_to_read.open() as csvfile:
             reader = filter(

--- a/dae/dae/pheno/prepare/measure_classifier.py
+++ b/dae/dae/pheno/prepare/measure_classifier.py
@@ -240,15 +240,18 @@ def classification_reference_impl(
         measure_type = classifier.classify(report)
     report.measure_type = measure_type
 
+    non_null_numeric_values = list(
+        filter(lambda x: x is not None, report.numeric_values))
+
     if measure_type in {MeasureType.continuous, MeasureType.ordinal}:
-        report.min_value = np.min(
-            cast(np.ndarray, report.numeric_values),
-        )
+        if len(non_null_numeric_values) == 0:
+            raise ValueError(
+                "Measure %s is set as numeric but has no numeric values!",
+            )
+        report.min_value = np.min(cast(np.ndarray, non_null_numeric_values))
         if isinstance(report.min_value, np.bool_):
             report.min_value = np.int8(report.min_value)
-        report.max_value = np.max(
-            cast(np.ndarray, report.numeric_values),
-        )
+        report.max_value = np.max(cast(np.ndarray, non_null_numeric_values))
         if isinstance(report.max_value, np.bool_):
             report.max_value = np.int8(report.max_value)
         report.values_domain = f"[{report.min_value}, {report.max_value}]"

--- a/dae/dae/pheno/tests/test_pheno_db.py
+++ b/dae/dae/pheno/tests/test_pheno_db.py
@@ -15,8 +15,6 @@ def df_check(
     df: pd.DataFrame, expected_count: int, expected_cols: list[str],
 ) -> None:
     assert df is not None
-    # FIXME Should we drop na vals, and when?
-    # df = df.dropna()
     assert all(col in df for col in expected_cols)
     assert expected_count == len(df)
 

--- a/wdae/wdae/measures_api/tests/test_measures_api.py
+++ b/wdae/wdae/measures_api/tests/test_measures_api.py
@@ -31,7 +31,7 @@ def test_measures_list_categorical(
     )
 
     assert response.status_code == 200
-    assert len(response.data) == 1  # type: ignore
+    assert len(response.data) == 2  # type: ignore
 
 
 def test_measures_list_continuous(

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -102,7 +102,7 @@ def test_instruments(
     data = response.json()
     assert "default" in data
     assert "instruments" in data
-    assert len(data["instruments"]) == 1
+    assert len(data["instruments"]) == 2
 
 
 def test_anonymous_instruments_allowed(
@@ -227,8 +227,9 @@ def test_download_all_instruments(
     header = header.split()[0].split(",")
 
     print("header:\n", header)
-    assert len(header) == 8
+    assert len(header) == 9
     assert set(header) == {
+        "pheno_common.phenotype",
         "i1.age",
         "i1.iq",
         "i1.m1",


### PR DESCRIPTION
## Background
When changing to the reference implementation, pheno_common instrument was skipped over.

## Aim
Reintroduce pheno_common import functionality.

## Implementation
Skip entries for the default columns in our pedigree format are added to the inference configurations and the pedigree is read as an instrument file, streamlining the whole process of adding pheno_common
