### PR TITLE
Fix permitted datasets not checking children

### DIFF
--- a/wdae/wdae/datasets_api/permissions.py
+++ b/wdae/wdae/datasets_api/permissions.py
@@ -225,6 +225,15 @@ class IsDatasetAllowed(permissions.BasePermission):
                 for group in dataset.groups.all():
                     if group.name == "any_user":
                         allowed_datasets.add(dataset_id)
+                        allowed_datasets.update(
+                            [
+                                child.dataset_id for child in
+                                DatasetHierarchy.get_children(
+                                    instance_id,
+                                    dataset,
+                                )
+                            ],
+                        )
                         break
 
             return allowed_datasets


### PR DESCRIPTION
## Background
Datasets api was not correctly adding access rights for anonymous users. Such users had permissions to datasets belonging to the "any user" group but not the dataset's children.

## Aim
Fix permitted datasets method not adding children of a dataset that has "any user" group.

## Implementation
Use dataset hierarchy model for finding dataset children.