### PR TITLE
Enable pheno tool anonymous

### DIFF
--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -25,7 +25,6 @@ from datasets_api.permissions import (
     get_instance_timestamp_etag,
     get_permissions_etag,
     get_wdae_parents,
-    user_has_permission,
 )
 
 from .models import Dataset, DatasetHierarchy

--- a/wdae/wdae/datasets_api/views.py
+++ b/wdae/wdae/datasets_api/views.py
@@ -140,25 +140,15 @@ class DatasetView(QueryBaseView):
             return Response({"error": f"Dataset {dataset_id} not found"},
                             status=status.HTTP_404_NOT_FOUND)
 
-        dataset_object = Dataset.objects.get(dataset_id=dataset_id)
-
-        if user_has_permission(
-            self.instance_id, user, dataset_object.dataset_id,
-        ):
-            person_set_collection_configs = {
-                psc.id: psc.domain_json()
-                for psc in dataset.person_set_collections.values()
-            }
-            res = StudyWrapperBase.build_genotype_data_description(
-                self.gpf_instance,
-                dataset.config,
-                person_set_collection_configs,
-            )
-        else:
-            res = StudyWrapperBase.build_genotype_data_all_datasets(
-                dataset.config,
-            )
-            res["description"] = dataset.description
+        person_set_collection_configs = {
+            psc.id: psc.domain_json()
+            for psc in dataset.person_set_collections.values()
+        }
+        res = StudyWrapperBase.build_genotype_data_description(
+            self.gpf_instance,
+            dataset.config,
+            person_set_collection_configs,
+        )
 
         allowed_datasets = self.get_permitted_datasets(user)
 

--- a/wdae/wdae/measures_api/tests/test_measures_api.py
+++ b/wdae/wdae/measures_api/tests/test_measures_api.py
@@ -19,7 +19,7 @@ def test_measures_api_permissions(
 ) -> None:
     response = anonymous_client.get(url)
     assert response
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.status_code == status.HTTP_200_OK
 
 
 def test_measures_list_categorical(

--- a/wdae/wdae/measures_api/views.py
+++ b/wdae/wdae/measures_api/views.py
@@ -15,7 +15,7 @@ from dae.pheno.common import MeasureType
 logger = logging.getLogger(__name__)
 
 
-class PhenoMeasuresView(QueryBaseView, DatasetAccessRightsView):
+class PhenoMeasuresView(QueryBaseView):
     """View for phenotype measures."""
 
     @method_decorator(etag(get_instance_timestamp_etag))
@@ -56,7 +56,7 @@ class PhenoMeasuresView(QueryBaseView, DatasetAccessRightsView):
         return Response(res, status=status.HTTP_200_OK)
 
 
-class PhenoMeasureHistogramView(QueryBaseView, DatasetAccessRightsView):
+class PhenoMeasureHistogramView(QueryBaseView):
     """View for phenotype measure histograms."""
 
     def post(self, request: Request) -> Response:
@@ -148,7 +148,7 @@ class PhenoMeasurePartitionsView(QueryBaseView, DatasetAccessRightsView):
         return Response(res)
 
 
-class PhenoMeasureRegressionsView(QueryBaseView, DatasetAccessRightsView):
+class PhenoMeasureRegressionsView(QueryBaseView):
     """View for phenotype measure regressions."""
 
     @method_decorator(etag(get_instance_timestamp_etag))

--- a/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
+++ b/wdae/wdae/pheno_browser_api/tests/test_pheno_browser_api.py
@@ -51,7 +51,7 @@ DOWNLOAD_URL = "/api/v3/pheno_browser/download"
         ),
         "get",
         None,
-        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_200_OK,
     ),
 ])
 def test_pheno_browser_api_permissions(

--- a/wdae/wdae/pheno_browser_api/views.py
+++ b/wdae/wdae/pheno_browser_api/views.py
@@ -79,7 +79,7 @@ class PhenoMeasuresInfoView(QueryBaseView):
         return Response(res)
 
 
-class PhenoMeasureDescriptionView(QueryBaseView, DatasetAccessRightsView):
+class PhenoMeasureDescriptionView(QueryBaseView):
     """Phenotype measures description view."""
 
     @method_decorator(etag(get_permissions_etag))

--- a/wdae/wdae/pheno_tool_api/views.py
+++ b/wdae/wdae/pheno_tool_api/views.py
@@ -27,7 +27,7 @@ from dae.pheno_tool.tool import PhenoResult, PhenoTool
 logger = logging.getLogger(__name__)
 
 
-class PhenoToolView(QueryBaseView, DatasetAccessRightsView):
+class PhenoToolView(QueryBaseView):
     """View for returning pheno tool results."""
 
     @staticmethod
@@ -92,7 +92,7 @@ class PhenoToolView(QueryBaseView, DatasetAccessRightsView):
         return Response(result)
 
 
-class PhenoToolDownload(PhenoToolView):
+class PhenoToolDownload(PhenoToolView, DatasetAccessRightsView):
     """Pheno tool download view."""
 
     def generate_columns(


### PR DESCRIPTION
## Background
Pheno tool should be enabled for anonymous users.

## Aim
Allow anonymous access to APIs used in the pheno tool functionality.

## Implementation
Remove various API permission checks.
Remove dataset API permission checks for configurations sent with the dataset.