### PR TITLE
Bring back partions api

### DIFF
--- a/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
+++ b/wdae/wdae/gene_scores/tests/test_gene_scores_views.py
@@ -1,4 +1,7 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import json
+
+import pytest
 from django.test.client import Client
 from gpf_instance.gpf_instance import WGPFInstance
 
@@ -20,6 +23,70 @@ def test_gene_scores_list_view(
         assert "score" in score
         assert "bars" in score
         assert "bins" in score
+
+
+def test_gene_scores_partitions(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/gene_scores/partitions"
+    data = {
+        "score": "t4c8_score",
+        "min": 1.5,
+        "max": 5.0,
+    }
+
+    response = user_client.post(
+        url, json.dumps(data), content_type="application/json", format="json",
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 3
+    assert data["left"]["count"] == 0  # type: ignore
+    assert data["right"]["count"] == 2  # type: ignore
+
+
+@pytest.mark.parametrize("data", [
+    {
+        "score": "t4c8_score",
+        "min": 1.5,
+    },
+    {
+        "score": "t4c8_score",
+        "max": 5.0,
+    },
+    {
+        "score": "t4c8_score",
+        "min": "non-float-value",
+        "max": 5.0,
+    },
+    {
+        "score": "t4c8_score",
+        "min": 1.5,
+        "max": "non-float-value",
+    },
+    {
+        "score": "t4c8_score",
+        "min": None,
+        "max": 5.0,
+    },
+    {
+        "score": "t4c8_score",
+        "min": 1.5,
+        "max": None,
+    },
+])
+def test_gene_scores_partitions_bad_request(
+    user_client: Client,
+    data: dict[str, str | float | None],
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/gene_scores/partitions"
+    response = user_client.post(
+        url, json.dumps(data), content_type="application/json", format="json",
+    )
+    assert response.status_code == 400
 
 
 def test_gene_score_download(

--- a/wdae/wdae/gene_scores/tests/test_scores_partitions.py
+++ b/wdae/wdae/gene_scores/tests/test_scores_partitions.py
@@ -1,0 +1,37 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613
+import json
+
+from django.test.client import Client
+from gpf_instance.gpf_instance import WGPFInstance
+
+
+def test_gene_scores_partitions(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/gene_scores/partitions"
+    data = {
+        "score": "t4c8_score",
+        "min": 1.5,
+        "max": 5.0,
+    }
+    response = user_client.post(
+        url, json.dumps(data), content_type="application/json", format="json",
+    )
+    assert response.status_code == 200
+
+
+def test_bad_gene_score_partition(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/gene_scores/partitions"
+    data = {
+        "score": "ala-bala",
+        "min": -8,
+        "max": -3,
+    }
+    response = user_client.post(
+        url, json.dumps(data), content_type="application/json", format="json",
+    )
+    assert response.status_code == 404

--- a/wdae/wdae/gene_scores/urls.py
+++ b/wdae/wdae/gene_scores/urls.py
@@ -14,4 +14,9 @@ urlpatterns = [
         views.GeneScoresDownloadView.as_view(),
         name="gene_scores_download",
     ),
+    re_path(
+        r"^/partitions/?$",
+        views.GeneScoresPartitionsView.as_view(),
+        name="gene_scores_partitions",
+    ),
 ]

--- a/wdae/wdae/measures_api/views.py
+++ b/wdae/wdae/measures_api/views.py
@@ -104,7 +104,11 @@ class PhenoMeasureHistogramView(QueryBaseView):
 
 
 class PhenoMeasurePartitionsView(QueryBaseView, DatasetAccessRightsView):
-    """View for phenotype measure partitions."""
+    """View for phenotype measure partitions.
+    Histograms can calculate gene count when min and max are not inside bins.
+    Using a range that has min/max somewhere inside a bin needs a more
+    accurate calculation of genes.
+    """
 
     def post(self, request: Request) -> Response:
         """Get phenotype measure partitions."""


### PR DESCRIPTION
## Background
Permissions API was removed because it seemed unnecessary (decision based on manual testing).
Later automated tests proved that the API had an actual use. 

## Aim
Revert removal of the API.

## Implementation
Simple commit revert.
