### PR TITLE
Create grr statistics index

### DIFF
--- a/dae/dae/enrichment_tool/resource_implementations/enrichment_resource_impl.py
+++ b/dae/dae/enrichment_tool/resource_implementations/enrichment_resource_impl.py
@@ -50,6 +50,9 @@ class EnrichmentBackgroundResourceImplementation(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def calc_info_hash(self) -> bytes:
         return b"placeholder"
 

--- a/dae/dae/gene_scores/implementations/gene_scores_impl.py
+++ b/dae/dae/gene_scores/implementations/gene_scores_impl.py
@@ -53,6 +53,9 @@ class GeneScoreImplementation(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def add_statistics_build_tasks(
         self, task_graph: TaskGraph,
         **kwargs: str,  # noqa: ARG002

--- a/dae/dae/gene_sets/gene_sets_db.py
+++ b/dae/dae/gene_sets/gene_sets_db.py
@@ -235,6 +235,9 @@ class GeneSetCollection(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def calc_info_hash(self) -> bytes:
         return b"placeholder"
 

--- a/dae/dae/genomic_resources/cli.py
+++ b/dae/dae/genomic_resources/cli.py
@@ -746,6 +746,14 @@ def _do_resource_info_command(
         content = implementation.get_info(repo=repo)
         outfile.write(content)
 
+    with proto.open_raw_file(
+        res,
+        "statistics/index.html",
+        mode="wt",
+    ) as outfile:
+        content = implementation.get_statistics_info(repo=repo)
+        outfile.write(content)
+
 
 def _run_resource_info_command(
         repo: GenomicResourceRepo,

--- a/dae/dae/genomic_resources/cnv_collection.py
+++ b/dae/dae/genomic_resources/cnv_collection.py
@@ -126,6 +126,9 @@ class CnvCollectionImplementation(GenomicResourceImplementation,
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     @property
     def files(self) -> set[str]:
         cnv_collection = CnvCollection(self.resource)

--- a/dae/dae/genomic_resources/implementations/annotation_pipeline_impl.py
+++ b/dae/dae/genomic_resources/implementations/annotation_pipeline_impl.py
@@ -44,6 +44,11 @@ class AnnotationPipelineImplementation(
         self.pipeline = load_pipeline_from_yaml(self.raw, grr)
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:
+        grr = kwargs["repo"]
+        self.pipeline = load_pipeline_from_yaml(self.raw, grr)
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def get_template(self) -> Template:
         return Template(textwrap.dedent("""
             {% extends base %}

--- a/dae/dae/genomic_resources/implementations/gene_models_impl.py
+++ b/dae/dae/genomic_resources/implementations/gene_models_impl.py
@@ -173,6 +173,9 @@ class GeneModelsImpl(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def calc_info_hash(self) -> bytes:
         return b"placeholder"
 

--- a/dae/dae/genomic_resources/implementations/genomic_scores_impl.py
+++ b/dae/dae/genomic_resources/implementations/genomic_scores_impl.py
@@ -84,6 +84,9 @@ class GenomicScoreImplementation(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def add_statistics_build_tasks(
         self,
         task_graph: TaskGraph,

--- a/dae/dae/genomic_resources/implementations/liftover_chain_impl.py
+++ b/dae/dae/genomic_resources/implementations/liftover_chain_impl.py
@@ -94,6 +94,9 @@ class LiftoverChainImplementation(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def calc_info_hash(self) -> bytes:
         return b"placeholder"
 

--- a/dae/dae/genomic_resources/implementations/reference_genome_impl.py
+++ b/dae/dae/genomic_resources/implementations/reference_genome_impl.py
@@ -460,6 +460,9 @@ class ReferenceGenomeImplementation(
     def get_info(self, **kwargs: Any) -> str:  # noqa: ARG002
         return InfoImplementationMixin.get_info(self)
 
+    def get_statistics_info(self, **kwargs: Any) -> str:  # noqa: ARG002
+        return InfoImplementationMixin.get_statistics_info(self)
+
     def calc_info_hash(self) -> bytes:
         return b"placeholder"
 


### PR DESCRIPTION
## Background
Statistics folder contents in resource pages are not displayed properly.

## Aim
Create statistics index page that can be viewed when selecting statistics/ folder in Files section in resource index page.

## Implementation details
Statistics folder contents cannot be embedded within the resource page because the content count can be in the thousands.
