### PR TITLE
Refactor gp tests

### DIFF
--- a/wdae/wdae/gene_profiles_api/table_views.py
+++ b/wdae/wdae/gene_profiles_api/table_views.py
@@ -11,16 +11,6 @@ from rest_framework.request import Request
 LOGGER = logging.getLogger(__name__)
 
 
-class TableConfigurationView(QueryBaseView):
-    @method_decorator(etag(get_instance_timestamp_etag))
-    def get(self, _request):
-        configuration = self.gpf_instance.get_wdae_gp_table_configuration()
-        if configuration is None:
-            return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        return Response(configuration)
-
-
 class TableRowsView(QueryBaseView):
     @method_decorator(etag(get_instance_timestamp_etag))
     def get(self, request):

--- a/wdae/wdae/gene_profiles_api/tests/test_agp_api.py
+++ b/wdae/wdae/gene_profiles_api/tests/test_agp_api.py
@@ -44,13 +44,106 @@ def test_get_statistic(
     t4c8_wgpf_instance: WGPFInstance,
     mocker: MockerFixture,
 ) -> None:
+    mock_gp_statistic = GPStatistic(
+        "CHD8",
+        ["gene_set_1", "gene_set_2"],
+        {
+            "category_1": {
+                "genomic_score_1": {
+                    "score_1": {
+                        "value_1": 1,
+                        "value_2": 2,
+                    },
+                },
+            },
+        },
+        {
+            "study_1": {
+                "autism": {
+                    "lgds": {
+                        "count": 1.0,
+                        "rate": 1000.0,
+                    },
+                    "denovo_missense": {
+                        "count": 1.0,
+                        "rate": 1000.0,
+                    },
+                },
+                "unaffected": {
+                    "lgds": {
+                        "count": 0.0,
+                        "rate": 0.0,
+                    },
+                    "denovo_missense": {
+                        "count": 2.0,
+                        "rate": 2000.0,
+                    },
+                },
+            },
+        },
+    )
     mocker.patch.object(
         t4c8_wgpf_instance, "get_gp_statistic",
-        return_value=GPStatistic("CHD8", [], {}, {}),
+        return_value=mock_gp_statistic,
     )
 
     response = admin_client.get(f"{ROUTE_PREFIX}/single-view/gene/CHD8")
     assert response.data["geneSymbol"] == "CHD8"  # type: ignore
+    assert response.data["geneSets"] == ["gene_set_1", "gene_set_2"]  # type: ignore
+    assert response.data["genomicScores"] == [{  # type: ignore
+        "id": "category_1",
+        "scores": [{
+            "id": "genomic_score_1",
+            "score_1": {
+                "value_1": 1,
+                "value_2": 2,
+            },
+        }],
+    }]
+    assert response.data["studies"] == [{  # type: ignore
+        "id": "study_1",
+        "personSets": [
+            {
+                "id": "autism",
+                "effectTypes": [
+                    {
+                        "id": "lgds",
+                        "value": {
+                            "count": 1.0,
+                            "rate": 1000.0,
+                        },
+                    },
+                    {
+                        "id": "denovo_missense",
+                        "value": {
+                            "count": 1.0,
+                            "rate": 1000.0,
+                        },
+                    },
+                ],
+            },
+            {
+                "id": "unaffected",
+                "effectTypes": [
+                    {
+                        "id": "lgds",
+                        "value": {
+                            "count": 0.0,
+                            "rate": 0.0,
+                        },
+                    },
+                    {
+                        "id": "denovo_missense",
+                        "value": {
+                            "count": 2.0,
+                            "rate": 2000.0,
+                        },
+                    },
+                ],
+            },
+        ],
+    }]
+
     assert response.status_code == 200
     print(response.data)  # type: ignore
 

--- a/wdae/wdae/gene_profiles_api/urls.py
+++ b/wdae/wdae/gene_profiles_api/urls.py
@@ -4,11 +4,6 @@ from gene_profiles_api import table_views, views
 
 urlpatterns = [
     re_path(
-        r"^/table/configuration/?$",
-        table_views.TableConfigurationView.as_view(),
-        name="gp_table_configuration",
-    ),
-    re_path(
         r"^/table/rows/?$",
         table_views.TableRowsView.as_view(),
         name="gp_table_rows",


### PR DESCRIPTION
## Background
Gene profiles tests use complicated fixtures.

## Aim
Refactor gene profiles tests to not use complicated fixtures.

## Implementation
Use function mocks in place of using full dae code that needs proper fixtures.
Update gene profiles single view links test to be more comprehensive.