### PR TITLE
Change the VEP cache annotator to work in offline mode

### DIFF
--- a/external_vep_annotator/vep_annotator/vep_annotator.py
+++ b/external_vep_annotator/vep_annotator/vep_annotator.py
@@ -267,6 +267,7 @@ class VEPCacheAnnotator(VEPAnnotatorBase):
                 "-i", cast(str, input_file.name),
                 "-o", cast(str, out_file.name),
                 "--tab", "--cache",
+                "--offline",
                 "--dir", str(self.vep_cache_dir),
                 "--everything",
                 "--symbol",


### PR DESCRIPTION
## Background

The VEP test builds started failing due to an outage in the VEP servers, due to the default online DB connection made