### PR TITLE
Sort pheno group children by config order

### DIFF
--- a/dae/dae/pheno/pheno_data.py
+++ b/dae/dae/pheno/pheno_data.py
@@ -748,6 +748,18 @@ class PhenotypeGroup(PhenotypeData):
         return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
 
 
+def _sort_group_children(
+    children_names: list[str], children: list[PhenotypeData],
+) -> None:
+    children_name_order = {
+        name: idx for idx, name in enumerate(children_names)
+    }
+
+    children.sort(
+        key=lambda pheno_data: children_name_order[pheno_data.pheno_id],
+    )
+
+
 def load_phenotype_data(
     config: dict[str, Any], extra_configs: list[dict[str, Any]] | None = None,
 ) -> PhenotypeStudy | PhenotypeGroup:
@@ -776,13 +788,5 @@ def load_phenotype_data(
             children.append(load_phenotype_data(extra_config))
         else:
             children.append(load_phenotype_data(extra_config, extra_configs))
-
-    children_name_order = {
-        name: idx for idx, name in enumerate(children_names)
-    }
-
-    children.sort(
-        key=lambda pheno_data: children_name_order[pheno_data.pheno_id],
-    )
 
     return PhenotypeGroup(config["name"], cast(list[PhenotypeData], children))

--- a/dae/dae/pheno/pheno_data.py
+++ b/dae/dae/pheno/pheno_data.py
@@ -777,4 +777,12 @@ def load_phenotype_data(
         else:
             children.append(load_phenotype_data(extra_config, extra_configs))
 
+    children_name_order = {
+        name: idx for idx, name in enumerate(children_names)
+    }
+
+    children.sort(
+        key=lambda pheno_data: children_name_order[pheno_data.pheno_id],
+    )
+
     return PhenotypeGroup(config["name"], cast(list[PhenotypeData], children))

--- a/dae/dae/pheno/tests/test_pheno_data.py
+++ b/dae/dae/pheno/tests/test_pheno_data.py
@@ -12,6 +12,12 @@ from dae.pheno.pheno_data import (
 
 
 @pytest.fixture
+def mock_sort(mocker: pytest_mock.MockerFixture) -> MagicMock:
+    return mocker.patch(
+        "dae.pheno.pheno_data._sort_group_children", autospec=True,
+    )
+
+@pytest.fixture
 def mock_classes(
     mocker: pytest_mock.MockerFixture,
 ) -> tuple[MagicMock, MagicMock]:
@@ -21,6 +27,7 @@ def mock_classes(
 
 def test_load_phenotype_data_study(
     mock_classes: tuple[MagicMock, MagicMock],
+    mock_sort: MagicMock,  # noqa: ARG001
 ) -> None:
     study_mock, _ = mock_classes
     config = {


### PR DESCRIPTION
Pheno group children order depended on the order of configuration file discovery, which could lead to cases where a group returns measures in wrong order.

