### PR TITLE
Gpdb write with duckdb

### DIFF
--- a/dae/dae/gene_profile/db.py
+++ b/dae/dae/gene_profile/db.py
@@ -25,7 +25,7 @@ from dae.utils.sql_utils import to_duckdb_transpile
 logger = logging.getLogger(__name__)
 
 
-class GeneProfileReadDB:
+class GeneProfileDB:
     """
     Class for managing the gene profile database.
 
@@ -44,7 +44,7 @@ class GeneProfileReadDB:
     ):
         self.dbfile = dbfile
         self.configuration = \
-            GeneProfileWriteDB.build_configuration(configuration)
+            GeneProfileDBWriter.build_configuration(configuration)
         self.table = table("gene_profile")
         self.gene_sets_categories = {}
         if len(self.configuration.keys()):
@@ -281,7 +281,7 @@ class GeneProfileReadDB:
             ]
 
 
-class GeneProfileWriteDB:
+class GeneProfileDBWriter:
     """
     Class for managing the gene profile database.
 
@@ -298,7 +298,7 @@ class GeneProfileWriteDB:
     ):
         self.dbfile = dbfile
         self.configuration = \
-            GeneProfileWriteDB.build_configuration(configuration)
+            GeneProfileDBWriter.build_configuration(configuration)
         self._create_gp_table()
         self.gene_sets_categories = {}
         self._clear_gp_table()

--- a/dae/dae/gene_profile/db.py
+++ b/dae/dae/gene_profile/db.py
@@ -551,10 +551,10 @@ class GeneProfileDBWriter:
     def update_gps_with_values(self, gs_values: dict[str, Any]) -> None:
         """Update gp statistic with values"""
         with duckdb.connect(f"{self.dbfile}") as connection:
-            for gs, values in gs_values.items():
+            for gs, vals in gs_values.items():
                 query = update(
                     self.table,
-                    values,
+                    vals,
                     where=column(
                         "symbol_name",
                         table=self.table.alias_or_name,

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Set, cast
 from box import Box
 
 from dae.effect_annotation.effect import expand_effect_types
-from dae.gene_profile.db import GeneProfileDB
+from dae.gene_profile.db import GeneProfileWriteDB
 from dae.gene_profile.statistic import GPStatistic
 from dae.gene_sets.gene_sets_db import GeneSet
 from dae.gpf_instance.gpf_instance import GPFInstance
@@ -295,10 +295,9 @@ def main(
 
     collections_gene_sets = []
 
-    gpdb = GeneProfileDB(
+    gpdb = GeneProfileWriteDB(
         config.to_dict(),
         args.dbfile,
-        clear=True,
     )
 
     for gs_category in config.gene_sets:

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -332,7 +332,7 @@ def main(
     person_ids: Dict[str, Any] = {}
     for dataset_id, filters in config.datasets.items():
         genotype_data = gpf_instance.get_genotype_data(dataset_id)
-        assert genotype_data is not None
+        assert genotype_data is not None, dataset_id
         genotype_data_children = {
             p.person_id
             for p in genotype_data.families.persons_with_parents()

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Set, cast
 from box import Box
 
 from dae.effect_annotation.effect import expand_effect_types
-from dae.gene_profile.db import GeneProfileWriteDB
+from dae.gene_profile.db import GeneProfileDBWriter
 from dae.gene_profile.statistic import GPStatistic
 from dae.gene_sets.gene_sets_db import GeneSet
 from dae.gpf_instance.gpf_instance import GPFInstance
@@ -295,7 +295,7 @@ def main(
 
     collections_gene_sets = []
 
-    gpdb = GeneProfileWriteDB(
+    gpdb = GeneProfileDBWriter(
         config.to_dict(),
         args.dbfile,
     )

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, Set, cast
 from box import Box
 
 from dae.effect_annotation.effect import expand_effect_types
-from dae.gene_sets.gene_sets_db import GeneSet
 from dae.gene_profile.db import GeneProfileDB
 from dae.gene_profile.statistic import GPStatistic
+from dae.gene_sets.gene_sets_db import GeneSet
 from dae.gpf_instance.gpf_instance import GPFInstance
 from dae.person_sets import PSCQuery
 from dae.utils.verbosity_configuration import VerbosityConfiguration
@@ -54,6 +54,15 @@ def generate_gp(
             scores[category_name][gene_score_name] = value
 
     variant_counts: dict[str, Any] = {}
+    for dataset_id, value in config["datasets"].items():
+        statistics = value["statistics"]
+        person_sets = value["person_sets"]
+        for person_set in person_sets:
+            for statistic in statistics:
+                col = f'{dataset_id}_{person_set["set_name"]}_{statistic["id"]}'
+                col_rate = f"{col}_rate"
+                variant_counts[col] = 0
+                variant_counts[col_rate] = 0
 
     return gene_symbol, GPStatistic(
         gene_symbol, sets_in,

--- a/dae/dae/gene_profile/tests/conftest.py
+++ b/dae/dae/gene_profile/tests/conftest.py
@@ -6,9 +6,9 @@ import pytest
 from box import Box
 from pytest_mock import MockerFixture
 
-from dae.gene_sets.gene_sets_db import GeneSet
-from dae.gene_profile.db import GeneProfileDB
+from dae.gene_profile.db import GeneProfileReadDB, GeneProfileWriteDB
 from dae.gene_profile.statistic import GPStatistic
+from dae.gene_sets.gene_sets_db import GeneSet
 from dae.gpf_instance import GPFInstance
 from dae.testing.alla_import import alla_gpf
 
@@ -140,16 +140,20 @@ def gp_gpf_instance(
             ["CHD8"]))
 
     gpf_instance._gene_profile_db = \
-        GeneProfileDB(
+        GeneProfileReadDB(
             gpf_instance._gene_profile_config,
             gpdb_filename,
-            clear=True,
         )
     print(gpdb_filename)
-    gpf_instance._gene_profile_db.insert_gp(sample_gp)
 
     return gpf_instance
 
+@pytest.fixture()
+def gpdb_write(
+        tmp_path: pathlib.Path,
+        gp_config: Box) -> GeneProfileWriteDB:
+    gpdb_filename = str(tmp_path / "gpdb")
+    return GeneProfileWriteDB(gp_config, gpdb_filename)
 
 @pytest.fixture()
 def local_gpf_instance(
@@ -192,13 +196,12 @@ def local_gpf_instance(
         "get_gene_set_ids",
         return_value=main_gene_sets,
     )
+
     gpf_instance._gene_profile_db = \
-        GeneProfileDB(
+        GeneProfileReadDB(
             gpf_instance._gene_profile_config,
             gpdb_filename,
-            clear=True,
         )
     print(gpdb_filename)
-    gpf_instance._gene_profile_db.insert_gp(sample_gp)
 
     return gpf_instance

--- a/dae/dae/gene_profile/tests/conftest.py
+++ b/dae/dae/gene_profile/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from box import Box
 from pytest_mock import MockerFixture
 
-from dae.gene_profile.db import GeneProfileReadDB, GeneProfileWriteDB
+from dae.gene_profile.db import GeneProfileDB, GeneProfileDBWriter
 from dae.gene_profile.statistic import GPStatistic
 from dae.gene_sets.gene_sets_db import GeneSet
 from dae.gpf_instance import GPFInstance
@@ -140,7 +140,7 @@ def gp_gpf_instance(
             ["CHD8"]))
 
     gpf_instance._gene_profile_db = \
-        GeneProfileReadDB(
+        GeneProfileDB(
             gpf_instance._gene_profile_config,
             gpdb_filename,
         )
@@ -151,9 +151,9 @@ def gp_gpf_instance(
 @pytest.fixture()
 def gpdb_write(
         tmp_path: pathlib.Path,
-        gp_config: Box) -> GeneProfileWriteDB:
+        gp_config: Box) -> GeneProfileDBWriter:
     gpdb_filename = str(tmp_path / "gpdb")
-    return GeneProfileWriteDB(gp_config, gpdb_filename)
+    return GeneProfileDBWriter(gp_config, gpdb_filename)
 
 @pytest.fixture()
 def local_gpf_instance(
@@ -198,7 +198,7 @@ def local_gpf_instance(
     )
 
     gpf_instance._gene_profile_db = \
-        GeneProfileReadDB(
+        GeneProfileDB(
             gpf_instance._gene_profile_config,
             gpdb_filename,
         )

--- a/dae/dae/gene_profile/tests/conftest.py
+++ b/dae/dae/gene_profile/tests/conftest.py
@@ -92,16 +92,14 @@ def sample_gp() -> GPStatistic:
         },
     }
     variant_counts = {
-        "iossifov_2014": {
-            "autism": {
-                "denovo_noncoding": {"count": 53, "rate": 1},
-                "denovo_missense": {"count": 21, "rate": 2},
-            },
-            "unaffected": {
-                "denovo_noncoding": {"count": 43, "rate": 3},
-                "denovo_missense": {"count": 51, "rate": 4},
-            },
-        },
+        "iossifov_2014_autism_denovo_noncoding": 53,
+        "iossifov_2014_autism_denovo_noncoding_rate": 1,
+        "iossifov_2014_autism_denovo_missense": 21,
+        "iossifov_2014_autism_denovo_missense_rate": 2,
+        "iossifov_2014_unaffected_denovo_noncoding": 43,
+        "iossifov_2014_unaffected_denovo_noncoding_rate": 3,
+        "iossifov_2014_unaffected_denovo_missense": 51,
+        "iossifov_2014_unaffected_denovo_missense_rate": 4,
     }
     return GPStatistic(
         "CHD8", gene_sets, genomic_scores, variant_counts,

--- a/dae/dae/gene_profile/tests/test_generate_gene_profile.py
+++ b/dae/dae/gene_profile/tests/test_generate_gene_profile.py
@@ -6,7 +6,7 @@ import textwrap
 import pytest
 import yaml
 
-from dae.gene_profile.db import GeneProfileReadDB
+from dae.gene_profile.db import GeneProfileDB
 from dae.gene_profile.generate_gene_profile import main
 from dae.genomic_resources.testing import (
     setup_directories,
@@ -276,7 +276,7 @@ def test_generate_gene_profile(
 
     gpf_instance = gp_gpf_instance(gp_config, tmp_path)
     main(gpf_instance, argv)
-    gpdb = GeneProfileReadDB(
+    gpdb = GeneProfileDB(
         gpf_instance._gene_profile_config,
         gpdb_filename,
     )

--- a/dae/dae/gene_profile/tests/test_generate_gene_profile.py
+++ b/dae/dae/gene_profile/tests/test_generate_gene_profile.py
@@ -6,7 +6,7 @@ import textwrap
 import pytest
 import yaml
 
-from dae.gene_profile.db import GeneProfileDB
+from dae.gene_profile.db import GeneProfileReadDB
 from dae.gene_profile.generate_gene_profile import main
 from dae.genomic_resources.testing import (
     setup_directories,
@@ -276,10 +276,9 @@ def test_generate_gene_profile(
 
     gpf_instance = gp_gpf_instance(gp_config, tmp_path)
     main(gpf_instance, argv)
-    gpdb = GeneProfileDB(
+    gpdb = GeneProfileReadDB(
         gpf_instance._gene_profile_config,
         gpdb_filename,
-        clear=False,
     )
 
     t4 = gpdb.get_gp("t4")

--- a/dae/dae/gene_profile/tests/test_gp_export.py
+++ b/dae/dae/gene_profile/tests/test_gp_export.py
@@ -5,7 +5,7 @@ import pytest
 from box import Box
 from pytest_mock import MockerFixture
 
-from dae.gene_profile.db import GeneProfileReadDB, GeneProfileWriteDB
+from dae.gene_profile.db import GeneProfileDB, GeneProfileDBWriter
 from dae.gene_profile.exporter import cli_export
 from dae.gene_profile.statistic import GPStatistic
 from dae.gpf_instance import GPFInstance
@@ -20,7 +20,7 @@ def two_rows_gp(
 ) -> GPFInstance:
     root_path = tmp_path
     gpdb_filename = str(root_path / "gpdb")
-    gpdb = GeneProfileWriteDB(gp_config, gpdb_filename)
+    gpdb = GeneProfileDBWriter(gp_config, gpdb_filename)
     gpdb.insert_gp(sample_gp)
 
     sample_gp.gene_symbol = "CHD7"
@@ -31,7 +31,7 @@ def two_rows_gp(
     mocker.patch.object(
         gp_gpf_instance,
         "_gene_profile_db",
-        GeneProfileReadDB(gp_config, gpdb_filename),
+        GeneProfileDB(gp_config, gpdb_filename),
     )
 
     return gp_gpf_instance

--- a/dae/dae/gene_profile/tests/test_gp_export.py
+++ b/dae/dae/gene_profile/tests/test_gp_export.py
@@ -5,7 +5,7 @@ import pytest
 from box import Box
 from pytest_mock import MockerFixture
 
-from dae.gene_profile.db import GeneProfileDB
+from dae.gene_profile.db import GeneProfileReadDB, GeneProfileWriteDB
 from dae.gene_profile.exporter import cli_export
 from dae.gene_profile.statistic import GPStatistic
 from dae.gpf_instance import GPFInstance
@@ -20,7 +20,7 @@ def two_rows_gp(
 ) -> GPFInstance:
     root_path = tmp_path
     gpdb_filename = str(root_path / "gpdb")
-    gpdb = GeneProfileDB(gp_config, gpdb_filename, clear=True)
+    gpdb = GeneProfileWriteDB(gp_config, gpdb_filename)
     gpdb.insert_gp(sample_gp)
 
     sample_gp.gene_symbol = "CHD7"
@@ -31,7 +31,8 @@ def two_rows_gp(
     mocker.patch.object(
         gp_gpf_instance,
         "_gene_profile_db",
-        gpdb)
+        GeneProfileReadDB(gp_config, gpdb_filename),
+    )
 
     return gp_gpf_instance
 

--- a/dae/dae/gene_profile/tests/test_gpdb.py
+++ b/dae/dae/gene_profile/tests/test_gpdb.py
@@ -5,7 +5,7 @@ import box
 import duckdb
 from pytest import approx
 
-from dae.gene_profile.db import GeneProfileWriteDB
+from dae.gene_profile.db import GeneProfileDBWriter
 from dae.gene_profile.statistic import GPStatistic
 from dae.gpf_instance import GPFInstance
 
@@ -15,7 +15,7 @@ def test_gpdb_table_building(
     gp_config: box.Box,
 ) -> None:
     gpdb_filename = str(tmp_path / "gpdb")
-    gpdb = GeneProfileWriteDB(gp_config, gpdb_filename)
+    gpdb = GeneProfileDBWriter(gp_config, gpdb_filename)
 
     cols = []
     with duckdb.connect(gpdb_filename, read_only=True) as connection:
@@ -52,7 +52,7 @@ def test_gpdb_table_building(
 
 def test_gpdb_insert_and_get_gp(
         gp_gpf_instance: GPFInstance,
-        gpdb_write: GeneProfileWriteDB,
+        gpdb_write: GeneProfileDBWriter,
         sample_gp: GPStatistic) -> None:
 
     gpdb_write.insert_gp(sample_gp)
@@ -92,7 +92,7 @@ def test_gpdb_insert_and_get_gp(
 
 def test_gpdb_sort(
         gp_gpf_instance: GPFInstance,
-        gpdb_write: GeneProfileWriteDB,
+        gpdb_write: GeneProfileDBWriter,
         sample_gp: GPStatistic) -> None:
     gpdb_write.insert_gp(sample_gp)
     sample_gp.gene_symbol = "CHD7"
@@ -123,7 +123,7 @@ def test_gpdb_sort(
 
 def test_gpdb_symbol_search(
         gp_gpf_instance: GPFInstance,
-        gpdb_write: GeneProfileWriteDB,
+        gpdb_write: GeneProfileDBWriter,
         sample_gp: GPStatistic) -> None:
     gpdb_write.insert_gp(sample_gp)
     sample_gp.gene_symbol = "CHD7"

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -24,7 +24,7 @@ from dae.enrichment_tool.enrichment_builder import (
     EnrichmentBuilder,
 )
 from dae.enrichment_tool.enrichment_helper import EnrichmentHelper
-from dae.gene_profile.db import GeneProfileReadDB
+from dae.gene_profile.db import GeneProfileDB
 from dae.gene_profile.statistic import GPStatistic
 from dae.gene_scores.gene_scores import GeneScore
 from dae.gene_scores.gene_scores import ScoreDesc as GeneScoreDesc
@@ -266,11 +266,11 @@ class GPFInstance:
         )
 
     @cached_property
-    def _gene_profile_db(self) -> GeneProfileReadDB:
+    def _gene_profile_db(self) -> GeneProfileDB:
         config = None if self._gene_profile_config is None else\
             self._gene_profile_config.to_dict()
 
-        return GeneProfileReadDB(
+        return GeneProfileDB(
             config,
             os.path.join(self.dae_dir, "gpdb"),
         )

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -24,7 +24,7 @@ from dae.enrichment_tool.enrichment_builder import (
     EnrichmentBuilder,
 )
 from dae.enrichment_tool.enrichment_helper import EnrichmentHelper
-from dae.gene_profile.db import GeneProfileDB
+from dae.gene_profile.db import GeneProfileReadDB
 from dae.gene_profile.statistic import GPStatistic
 from dae.gene_scores.gene_scores import GeneScore
 from dae.gene_scores.gene_scores import ScoreDesc as GeneScoreDesc
@@ -266,11 +266,11 @@ class GPFInstance:
         )
 
     @cached_property
-    def _gene_profile_db(self) -> GeneProfileDB:
+    def _gene_profile_db(self) -> GeneProfileReadDB:
         config = None if self._gene_profile_config is None else\
             self._gene_profile_config.to_dict()
 
-        return GeneProfileDB(
+        return GeneProfileReadDB(
             config,
             os.path.join(self.dae_dir, "gpdb"),
         )


### PR DESCRIPTION
## Background
Fully transition gpdb to use duckdb.

## Aim
Replace gpdb write methods to use sqlglot and duckdb.
Move gpdb write functions to another db class only for writes,
leave the original for reads.