### PR TITLE
Refactor of pheno import tools

### DIFF
--- a/dae/dae/pheno/common.py
+++ b/dae/dae/pheno/common.py
@@ -26,19 +26,34 @@ class InferenceConfig(BaseModel):
     measure_type: str | None = None
 
 
-class ImportConfig(BaseModel):
-    """Pheno import tool configuration."""
-    model_config = ConfigDict(extra="forbid")
+class DataDictionary(BaseModel):
+    file: str | None = None
+    instrument_files: list[str] | None = None
 
-    report_only: bool = False
-    instruments_tab_separated: bool = False
-    person_column: str = "personId"
-    db_filename: str = "pheno.db"
-    default_inference: InferenceConfig = InferenceConfig()
-    output: str = "output"
-    verbose: int = 0
-    instruments_dir: str = ""
-    pedigree: str = ""
+    # {Instrument -> {Measure -> Description}}
+    dictionary: dict[str, dict[str, str]] | None = None
+
+
+class RegressionMeasure(BaseModel):
+    instrument_name: str
+    measure_name: str
+    jitter: float
+    display_name: str
+
+
+class PhenoImportConfig(BaseModel):
+    """Pheno import config."""
+    id: str
+    input_dir: str
+    output_dir: str
+    instrument_files: list[str]
+    pedigree: str
+    person_column: str
+    tab_separated: bool = False
+    skip_pedigree_measures: bool = False
+    inference_config: str | dict[str, InferenceConfig] | None = None
+    data_dictionary: DataDictionary | None = None
+    regression_config: str | dict[str, RegressionMeasure] | None = None
 
 
 class MeasureType(enum.Enum):

--- a/dae/dae/pheno/import_tools.py
+++ b/dae/dae/pheno/import_tools.py
@@ -1,44 +1,12 @@
 import argparse
-import os
 import pathlib
 import sys
 
 import yaml
-from pydantic import BaseModel
 
-from dae.pheno.common import InferenceConfig
+from dae.pheno.common import PhenoImportConfig
 from dae.pheno.pheno_import import import_pheno_data
 from dae.task_graph.cli_tools import TaskGraphCli
-
-
-class _DataDictionary(BaseModel):
-    file: str
-    instrument_files: list[str]
-
-    # {Instrument -> {Measure -> Description}}
-    dictionary: dict[str, dict[str, str]]
-
-
-class RegressionMeasure(BaseModel):
-    instrument_name: str
-    measure_name: str
-    jitter: float
-    display_name: str
-
-
-class PhenoImportConfig(BaseModel):
-    """Pheno import config."""
-    id: str
-    input_dir: str
-    output_dir: str
-    pedigree: str
-    skip_pedigree_measures: bool
-    # instrument_files: list[FilePath | DirectoryPath]
-    instruments: str
-    person_column: str
-    inference_config: str | dict[str, InferenceConfig] | None = None
-    data_dictionary: _DataDictionary | None = None
-    regression_config: str | dict[str, RegressionMeasure] | None = None
 
 
 def pheno_cli_parser() -> argparse.ArgumentParser:
@@ -62,33 +30,6 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def map_config_to_args(
-    args: argparse.Namespace,
-    import_config: PhenoImportConfig,
-) -> None:
-    """Map config values to argparse arguments."""
-    args.output = import_config.output_dir
-    args.pheno_name = import_config.id
-    if not os.path.isabs(import_config.instruments):
-        args.instruments = os.path.join(
-            import_config.input_dir, import_config.instruments,
-        )
-    if not os.path.isabs(import_config.pedigree):
-        args.pedigree = os.path.join(
-            import_config.input_dir, import_config.pedigree,
-        )
-    args.tab_separated = False
-    args.person_column = import_config.person_column
-    args.inference_config = import_config.inference_config
-    args.skip_pheno_common = import_config.skip_pedigree_measures
-    args.data_dictionary = import_config.data_dictionary
-    if isinstance(import_config.regression_config, str) and \
-       not os.path.isabs(import_config.regression_config):
-        args.regression = os.path.join(
-            import_config.input_dir, import_config.regression_config,
-        )
-
-
 def main(argv: list[str] | None = None) -> int:
     """Run phenotype import tool."""
     if argv is None:
@@ -98,7 +39,7 @@ def main(argv: list[str] | None = None) -> int:
 
     import_config = PhenoImportConfig.model_validate(
         yaml.safe_load(pathlib.Path(args.project).read_text()))
-    map_config_to_args(args, import_config)
-    import_pheno_data(args)
+    delattr(args, "project")
+    import_pheno_data(import_config, args)
 
     return 0


### PR DESCRIPTION
- Refactor the import_pheno_data method to work with a PhenoImportConfig instead of Namespace arguments from the CLI
- Added a method to convert CLI arguments to a PhenoImportConfig
- Implemented more flexible configuration of input instrument files
- Moved configuration-related classes back to pheno/common.py