### PR TITLE
Gpdb convert tool

### DIFF
--- a/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
+++ b/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
@@ -41,9 +41,7 @@ def main(
 
     conn = sqlite3.connect(database=args.dbfile)
 
-    df = pd.read_sql(query, conn)
-
-    df.to_csv("gpdb_data.csv", index=False)
+    df = pd.read_sql(query, conn)  # noqa: F841
 
     with duckdb.connect(f"{gpdb.dbfile}") as connection:
-        connection.execute('COPY gene_profile FROM "gpdb_data.csv"')
+        connection.execute("INSERT INTO gene_profile SELECT * FROM df")

--- a/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
+++ b/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
@@ -13,10 +13,10 @@ def main(
     gpf_instance: GPFInstance | None = None,
     argv: list[str] | None = None,
 ) -> None:
-    """Entry point for the generate GP script."""
+    """Simple gpdb converter from sqlite to duckdb."""
     # flake8: noqa: C901
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-    description = "Generate gene profile statistics tool"
+    description = "Gene profiles database converter from sqlite to duckdb"
     parser = argparse.ArgumentParser(description=description)
     default_dbfile = os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb")
     parser.add_argument("--dbfile", default=default_dbfile)

--- a/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
+++ b/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sqlite3
+from pathlib import Path
 
 import duckdb
 import pandas as pd
@@ -18,8 +19,14 @@ def main(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     description = "Gene profiles database converter from sqlite to duckdb"
     parser = argparse.ArgumentParser(description=description)
-    default_dbfile = os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb")
+
+    dae_db_dir = Path(os.getenv("DAE_DB_DIR", "./"))
+
+    default_dbfile = str(dae_db_dir / "gpdb")
     parser.add_argument("--dbfile", default=default_dbfile)
+
+    default_output = str(dae_db_dir / "gpdb.duckdb")
+    parser.add_argument("--output", default=default_output)
 
     args = parser.parse_args(argv)
 
@@ -33,7 +40,7 @@ def main(
 
     gpdb = GeneProfileDBWriter(
         config.to_dict(),
-        os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb.duckdb"),
+        args.output,
     )
 
     table_name = "gene_profile"

--- a/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
+++ b/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
@@ -1,0 +1,49 @@
+import argparse
+import os
+import sqlite3
+
+import duckdb
+import pandas as pd
+
+from dae.gene_profile.db import GeneProfileDBWriter
+from dae.gpf_instance.gpf_instance import GPFInstance
+
+
+def main(
+    gpf_instance: GPFInstance | None = None,
+    argv: list[str] | None = None,
+) -> None:
+    """Entry point for the generate GP script."""
+    # flake8: noqa: C901
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    description = "Generate gene profile statistics tool"
+    parser = argparse.ArgumentParser(description=description)
+    default_dbfile = os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb")
+    parser.add_argument("--dbfile", default=default_dbfile)
+
+    args = parser.parse_args(argv)
+
+    if gpf_instance is None:
+        gpf_instance = GPFInstance.build()
+
+    # pylint: disable=protected-access, invalid-name
+    config = gpf_instance._gene_profile_config  # noqa: SLF001
+
+    assert config is not None, "No GP configuration found."
+
+    gpdb = GeneProfileDBWriter(
+        config.to_dict(),
+        os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb"),
+    )
+
+    table_name = "gene_profile"
+    query = f"SELECT * from {table_name}"  # noqa: S608
+
+    conn = sqlite3.connect(database=args.dbfile)
+
+    df = pd.read_sql(query, conn)
+
+    df.to_csv("gpdb_data.csv", index=False)
+
+    with duckdb.connect(f"{gpdb.dbfile}") as connection:
+        connection.execute('COPY gene_profile FROM "gpdb_data.csv"')

--- a/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
+++ b/dae/dae/gene_profile/convert_gene_profile_to_duckdb.py
@@ -33,7 +33,7 @@ def main(
 
     gpdb = GeneProfileDBWriter(
         config.to_dict(),
-        os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb"),
+        os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb.duckdb"),
     )
 
     table_name = "gene_profile"

--- a/dae/dae/gene_profile/generate_gene_profile.py
+++ b/dae/dae/gene_profile/generate_gene_profile.py
@@ -268,7 +268,7 @@ def main(
     description = "Generate gene profile statistics tool"
     parser = argparse.ArgumentParser(description=description)
     VerbosityConfiguration.set_arguments(parser)
-    default_dbfile = os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb")
+    default_dbfile = os.path.join(os.getenv("DAE_DB_DIR", "./"), "gpdb.duckdb")
     parser.add_argument("--dbfile", default=default_dbfile)
     parser.add_argument(
         "--gene-sets-genes",

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -274,6 +274,7 @@ class GPFInstance:
         if os.path.isfile(os.path.join(self.dae_dir, "gpdb.duckdb")):
             db_name = "gpdb.duckdb"
         else:
+            logger.warning("Using legacy sqlite gpdb!")
             db_name = "gpdb"
         return GeneProfileDB(
             config,

--- a/dae/dae/gpf_instance/gpf_instance.py
+++ b/dae/dae/gpf_instance/gpf_instance.py
@@ -270,9 +270,14 @@ class GPFInstance:
         config = None if self._gene_profile_config is None else\
             self._gene_profile_config.to_dict()
 
+        # In case of sqlite db still used
+        if os.path.isfile(os.path.join(self.dae_dir, "gpdb.duckdb")):
+            db_name = "gpdb.duckdb"
+        else:
+            db_name = "gpdb"
         return GeneProfileDB(
             config,
-            os.path.join(self.dae_dir, "gpdb"),
+            os.path.join(self.dae_dir, db_name),
         )
 
     def reload(self) -> None:

--- a/dae/setup.py
+++ b/dae/setup.py
@@ -127,6 +127,7 @@ setuptools.setup(
 
     import_tools=dae.import_tools.cli:main
     generate_gene_profile=dae.gene_profile.generate_gene_profile:main
+    convert_gene_profile_to_duckdb=dae.gene_profile.convert_gene_profile_to_duckdb:main
     generate_common_report=dae.common_reports.generate_common_report:main
     generate_denovo_gene_sets=dae.gene_sets.generate_denovo_gene_sets:main
 


### PR DESCRIPTION
## Background
Sqlite gpdb databases need to be converted to duckdb.

## Aim
Create crude tool that converts sqlite gpdb into duckdb gpdb.
Add suffix to the new gpdb that says it has been converted - "gpdb.duckdb".
