### PR TITLE
Enable genotype browser query categorical values

### DIFF
--- a/wdae/wdae/genotype_browser/views.py
+++ b/wdae/wdae/genotype_browser/views.py
@@ -116,7 +116,9 @@ class GenotypeBrowserQueryView(QueryBaseView, DatasetAccessRightsView):
         if "genomicScores" in data:
             scores = data["genomicScores"]
             for score in scores:
-                if score["rangeStart"] is None and score["rangeEnd"] is None:
+                if score["rangeStart"] is None \
+                    and score["rangeEnd"] is None \
+                    and score["values"] is None:
                     return Response(status=status.HTTP_400_BAD_REQUEST)
 
         is_download = data.pop("download", False)

--- a/wdae/wdae/studies/query_transformer.py
+++ b/wdae/wdae/studies/query_transformer.py
@@ -406,9 +406,9 @@ class QueryTransformer:
                 kwargs["real_attr_filter"] = []
             kwargs["real_attr_filter"].extend(
                 self._transform_genomic_scores_continuous(genomic_scores))
-            if "categorical_value_filter" not in kwargs:
-                kwargs["categorical_value_filter"] = []
-            kwargs["categorical_value_filter"].extend(
+            if "categorical_attr_filter" not in kwargs:
+                kwargs["categorical_attr_filter"] = []
+            kwargs["categorical_attr_filter"].extend(
                 self._transform_genomic_scores_categorical(genomic_scores))
 
         if "frequencyScores" in kwargs:


### PR DESCRIPTION
## Background
Fully enable categorical genomic score histograms in genotype browser.

## Aim
- Add support for genomic score categorical values in genotype browser queries.
- Fix query transformer categorical attribute filter name.
