### PR TITLE
Allow annotate columns to exclude columns

### DIFF
--- a/dae/dae/annotation/record_to_annotatable.py
+++ b/dae/dae/annotation/record_to_annotatable.py
@@ -158,26 +158,24 @@ def add_record_to_annotable_arguments(parser: argparse.ArgumentParser) -> None:
 
 
 def build_record_to_annotatable(
-        parameters: dict[str, str],
+        renamed_columns: dict[str, str],
         available_columns: set[str],
         ref_genome: ReferenceGenome | None = None) -> RecordToAnnotable:
     """Transform a variant record into an annotatable."""
-    for columns, record_to_annotatable_class in \
+    for annotatable_columns, record_to_annotatable_class in \
             RECORD_TO_ANNOTATABLE_CONFIGURATION.items():
-        renamed_columns = [
-            parameters.get(f"col_{col}", col) for col in columns
+        columns = [
+            renamed_columns.get(f"col_{annot_col}", annot_col)
+            for annot_col in annotatable_columns
         ]
-        all_available = len(
-            [cn for cn in renamed_columns if cn not in available_columns],
-        ) == 0
-        if all_available:
+        if set(columns).issubset(set(available_columns)):
             logger.info(
                 "record to annotatable using %s(%s, ref_genome=%s)",
                 record_to_annotatable_class.__name__,
-                tuple(renamed_columns),
+                tuple(columns),
                 ref_genome.resource_id if ref_genome else None,
             )
             return record_to_annotatable_class(
-                tuple(renamed_columns), ref_genome,
+                tuple(columns), ref_genome,
             )
     raise ValueError("no record to annotatable could be found.")

--- a/dae/dae/annotation/record_to_annotatable.py
+++ b/dae/dae/annotation/record_to_annotatable.py
@@ -153,22 +153,47 @@ def add_record_to_annotable_arguments(parser: argparse.ArgumentParser) -> None:
         col for cols in RECORD_TO_ANNOTATABLE_CONFIGURATION
         for col in cols}
     for col in all_columns:
-        parser.add_argument(f"--col-{col.replace('_', '-')}", default=col,
-                            help=f"The column name that stores {col}")
+        parser.add_argument(
+            f"--col-{col.replace('_', '-')}",
+            default=col,
+            help=(
+                f"The column name that stores {col}. "
+                f'Use "-" to exclude this column requirement, causing '
+                f'annotatable patterns that require {col} to be skipped.'
+            ),
+        )
 
 
 def build_record_to_annotatable(
         renamed_columns: dict[str, str],
         available_columns: set[str],
         ref_genome: ReferenceGenome | None = None) -> RecordToAnnotable:
-    """Transform a variant record into an annotatable."""
+    """
+    Transform a variant record into an annotatable.
+
+    Parameters
+    ----------
+    renamed_columns : dict[str, str]
+        Mapping from expected internal column identifiers (e.g. "col_<field>")
+        to the actual column names present in the input source.
+        A column can be excluded from usage if an identifier is mapped to "-".
+        Example rename:
+            "col_<field>": "<input source column name for the field>"
+        Example exclude:
+            "col_<field>": "-"
+    available_columns : set[str]
+        The set of column names available in the input records.
+    ref_genome : ReferenceGenome | None, optional
+        Optional reference genome context used for creating annotatables.
+        Not all annotatables require it.
+    """
     for annotatable_columns, record_to_annotatable_class in \
             RECORD_TO_ANNOTATABLE_CONFIGURATION.items():
         columns = [
             renamed_columns.get(f"col_{annot_col}", annot_col)
             for annot_col in annotatable_columns
         ]
-        if set(columns).issubset(set(available_columns)):
+        if set(columns).issubset(available_columns):
             logger.info(
                 "record to annotatable using %s(%s, ref_genome=%s)",
                 record_to_annotatable_class.__name__,

--- a/dae/tests/small/annotation/test_annotate_columns.py
+++ b/dae/tests/small/annotation/test_annotate_columns.py
@@ -202,6 +202,24 @@ def test_renamed_columns(
     assert str(annotatable) == str(expected)
 
 
+def test_renamed_columns_excludes() -> None:
+    record = {
+        "chromosome": "chr1",
+        "position": "4",
+        "ref": "C",
+        "alt": "CT",
+    }
+    annotatable = build_record_to_annotatable(
+        {
+            "col_chrom": "chromosome",
+            "col_pos": "position",
+            "col_alt": "-",
+        },
+        set(record.keys()),
+    ).build(record)
+    assert str(annotatable) == str(Position("chr1", 4))
+
+
 def test_annotate_columns_basic_setup(
     annotate_directory_fixture: pathlib.Path,
     tmp_path: pathlib.Path,


### PR DESCRIPTION
## Background
When annotating columns - record to annotatable logic reads all columns in the header of the file and uses them and the renamed columns to create the first matching annotatable.
The first matching annotatable may not be the one we want but since the columns support it - it's the one that will be built.
That's why sometimes we want to ignore certain columns when creating annotatables.

## Aim
Annotate columns should support a way to ignore columns when creating annotatables.