### PR TITLE
Post-merge sweep: drop gpf-gain-split refs + obsolete build.sh doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,6 @@ Services defined in `docker-compose.yaml`:
   `grr_http` tests; serves
   `core/tests/.test_grr/`
 
-### Do NOT run locally
-
-`build.sh` requires Docker and a private `build-scripts`
-submodule — it's only for CI (Jenkins).
-
 ## Architecture
 
 ### Dependency Direction

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -823,8 +823,8 @@ pipeline {
                     // web_e2e/jenkins-jobs/e2e.groovy). Runs on every
                     // branch — the e2e job clones the same branch /
                     // commit and either pulls the prod images this
-                    // pipeline just pushed (master / gpf-gain-split)
-                    // or copies the wheel artefacts archived above
+                    // pipeline just pushed (master only) or copies
+                    // the wheel artefacts archived above
                     // (`dist/core/*.whl` + `dist/web/*.whl`) and
                     // builds the prod images locally.
                     steps {

--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -12,13 +12,13 @@
 //     `gpf-web-e2e` pipelineJob (loaded via the seed job).
 //
 // Self-contained: clones the gpf monorepo at the requested
-// branch/commit, then either (a) on master / gpf-gain-split:
-// pulls the prod images the parent already pushed to
-// `registry.seqpipe.org` (~30s) or (b) on other branches: copies
-// the wheels the parent archived (`dist/core/*.whl` +
-// `dist/web/*.whl`) and builds the wheel-based backend image and
-// Apache-based frontend image locally (~5 min). Either way, the
-// Playwright suite runs against the resulting images via the
+// branch/commit, then either (a) on master: pulls the prod
+// images the parent already pushed to `registry.seqpipe.org`
+// (~30s) or (b) on other branches: copies the wheels the
+// parent archived (`dist/core/*.whl` + `dist/web/*.whl`) and
+// builds the wheel-based backend image and Apache-based
+// frontend image locally (~5 min). Either way, the Playwright
+// suite runs against the resulting images via the
 // `web_infra/compose-jenkins.yaml` e2e stack.
 
 pipeline {
@@ -29,7 +29,7 @@ pipeline {
     parameters {
         string(
             name: 'BRANCH_NAME',
-            defaultValue: 'gpf-gain-split',
+            defaultValue: 'master',
             description: 'Branch the upstream gpf build was ' +
                 'triggered from. The pipeline checks out ' +
                 'this branch unless COMMIT_SHA is set.',
@@ -45,7 +45,7 @@ pipeline {
             name: 'UPSTREAM_PROJECT',
             defaultValue: '',
             description: 'Upstream Jenkins project name ' +
-                '(e.g. iossifovlab/gpf/gpf-gain-split) the ' +
+                '(e.g. iossifovlab/gpf/master) the ' +
                 'wheel artefacts are copied from. Empty = ' +
                 'build the wheels from source instead.',
         )
@@ -173,10 +173,10 @@ pipeline {
 
         stage('Prepare backend/frontend images') {
             // Three paths:
-            //   1. Master / gpf-gain-split triggered downstream
-            //      of the parent — the parent already pushed the
-            //      prod images to `registry.seqpipe.org` tagged
-            //      with its BUILD_NUMBER, which is passed in via
+            //   1. Master triggered downstream of the parent —
+            //      the parent already pushed the prod images to
+            //      `registry.seqpipe.org` tagged with its
+            //      BUILD_NUMBER, which is passed in via
             //      UPSTREAM_BUILD. Pull and retag locally;
             //      ~30s vs ~5 min for the wheels+build path.
             //   2. Branch triggered downstream — the parent does
@@ -208,10 +208,9 @@ pipeline {
                     // parent gpf Jenkinsfile (the
                     // `Build & push prod images` stage gates on
                     // env.BRANCH_NAME == 'master'). Pulling for
-                    // any other branch — including gpf-gain-split
-                    // — would 404 the way build #2 did. Branches
-                    // always fall through to the build-from-wheels
-                    // path below.
+                    // any other branch would 404 the way build
+                    // #2 did. Branches always fall through to
+                    // the build-from-wheels path below.
                     boolean canPull = \
                         params.BRANCH_NAME == 'master' \
                         && params.UPSTREAM_BUILD?.trim()

--- a/web_e2e/jenkins-jobs/e2e.groovy
+++ b/web_e2e/jenkins-jobs/e2e.groovy
@@ -8,8 +8,8 @@
 // `iossifovlab/gpf/<branch>`'s `Trigger web_e2e` stage on
 // every branch, after the parent build's `Build & push prod
 // images` stage finishes. It can also be triggered manually
-// from the Jenkins UI (defaults: gpf-gain-split, copy wheels
-// from the last successful build of that branch).
+// from the Jenkins UI (defaults: master, copy wheels from
+// the last successful build of that branch).
 
 // Declared at the Jenkins root (not under `iossifovlab/`):
 // that path is a GitHub Organization Folder and rejects
@@ -34,7 +34,7 @@ pipelineJob('gpf-web-e2e') {
     parameters {
         stringParam(
             'BRANCH_NAME',
-            'gpf-gain-split',
+            'master',
             'Branch the upstream gpf build was triggered ' +
             'from. The pipeline checks out this branch ' +
             'unless COMMIT_SHA is set.',
@@ -49,7 +49,7 @@ pipelineJob('gpf-web-e2e') {
             'UPSTREAM_PROJECT',
             '',
             'Upstream Jenkins project name ' +
-            '(e.g. iossifovlab/gpf/gpf-gain-split) the wheel ' +
+            '(e.g. iossifovlab/gpf/master) the wheel ' +
             'artefacts are copied from. Empty = build the ' +
             'wheels from source instead.',
         )


### PR DESCRIPTION
## Summary

Follow-up to #830 (`gpf-gain-split` → `master`, merged at `bd2c4b7e5`). Sweeps the residual references that were deferred to a post-merge PR.

### BRANCH_NAME defaults flipped to master

- `web_e2e/Jenkinsfile.e2e:32` — `defaultValue: 'gpf-gain-split'` → `'master'`
- `web_e2e/jenkins-jobs/e2e.groovy:37` — same

After this lands, manual `gpf-web-e2e` launches default to `master`. The `gpf-gain-split` branch on origin becomes safe to delete (the SCM-loading branch was already parameterized to `${BRANCH_NAME}` in commit `8959fe436`).

### Stale comments cleaned up

- `gpf/Jenkinsfile:826` — "(master / gpf-gain-split)" → "(master only)"
- `web_e2e/Jenkinsfile.e2e:15` — "(a) on master / gpf-gain-split:" → "(a) on master:"
- `web_e2e/Jenkinsfile.e2e:176` — "Master / gpf-gain-split triggered downstream" → "Master triggered downstream"
- `web_e2e/Jenkinsfile.e2e:211` — "any other branch — including gpf-gain-split — would 404" → "any other branch would 404"
- `web_e2e/jenkins-jobs/e2e.groovy:11` — UI defaults comment
- `web_e2e/jenkins-jobs/e2e.groovy:52` — example `UPSTREAM_PROJECT` path

### CLAUDE.md "Do NOT run locally" section removed

`build.sh` + the private `build-scripts` submodule were deleted in tb-qp5 (commit `edff40584`). The note no longer describes anything in the repo. The `Test Infrastructure (Docker)` section above it already covers what runs locally.

## Test plan

- [x] `git grep -n 'gpf-gain-split\|build.sh' Jenkinsfile web_e2e/ CLAUDE.md` → zero matches
- [ ] Reviewer confirms the BRANCH_NAME swap matches the convention used by `federation/jenkins-jobs/integration.groovy` and `rest_client/jenkins-jobs/integration.groovy`
- [ ] After merge: bump `genomics-toolbox` `gpf` submodule pin to new master HEAD; drop "branch `gpf-gain-split`" annotation in `genomics-toolbox/CLAUDE.md:12`; delete `gpf-gain-split` branch on `iossifovlab/gpf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)