### PR TITLE
datasets_api: convert identifier TextField columns to CharField(255)

### DIFF
--- a/web_api/gpf_web/datasets_api/migrations/0009_dataset_dataset_id_unique.py
+++ b/web_api/gpf_web/datasets_api/migrations/0009_dataset_dataset_id_unique.py
@@ -43,6 +43,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="dataset",
             name="dataset_id",
-            field=models.TextField(unique=True),
+            field=models.CharField(max_length=255, unique=True),
         ),
     ]

--- a/web_api/gpf_web/datasets_api/migrations/0010_identifier_fields_to_charfield.py
+++ b/web_api/gpf_web/datasets_api/migrations/0010_identifier_fields_to_charfield.py
@@ -1,0 +1,60 @@
+"""Convert identifier columns from TEXT to VARCHAR(255).
+
+Background (iossifovlab/gpf#836):
+
+- The previous shape of migration 0009 set ``Dataset.dataset_id`` to
+  ``TextField(unique=True)``. On MySQL/MariaDB that produces
+  ``TEXT UNIQUE`` and fails at apply time with::
+
+      MySQLdb.OperationalError: (1170, "BLOB/TEXT column 'dataset_id'
+      used in key specification without a key length")
+
+  0009 has therefore been amended in place to ``CharField(max_length=255,
+  unique=True)`` so fresh MySQL deploys (and fresh deploys on every
+  backend) get the right schema.
+
+- ``Dataset.dataset_name`` and ``DatasetHierarchy.instance_id`` were
+  also ``TextField`` for no good reason — they are short identifiers.
+  This migration switches them to ``CharField(max_length=255)``.
+
+- For existing Postgres deploys (e.g. SFARI / gain-web's ``gpfwa``)
+  that already applied the old 0009 against ``TEXT``, the column is
+  still ``TEXT UNIQUE``. The ``AlterField`` for ``dataset_id`` here
+  is a no-op against the *Django model state* (0009 already declares
+  ``CharField(max_length=255, unique=True)``), but ``schema_editor``
+  emits the actual ``ALTER COLUMN ... TYPE VARCHAR(255)`` SQL against
+  the DB, converting the column in place. On fresh deploys the
+  column is already ``VARCHAR(255) UNIQUE`` and the alter is a cheap
+  no-op.
+
+The same logic applies to ``dataset_name`` and ``instance_id``: the
+model state in 0005 / 0008 still says ``TextField``, so this
+migration is the one that records the switch to ``CharField`` for
+those two.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("datasets_api", "0009_dataset_dataset_id_unique"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="dataset",
+            name="dataset_id",
+            field=models.CharField(max_length=255, unique=True),
+        ),
+        migrations.AlterField(
+            model_name="dataset",
+            name="dataset_name",
+            field=models.CharField(max_length=255, default=""),
+        ),
+        migrations.AlterField(
+            model_name="datasethierarchy",
+            name="instance_id",
+            field=models.CharField(max_length=255),
+        ),
+    ]

--- a/web_api/gpf_web/datasets_api/models.py
+++ b/web_api/gpf_web/datasets_api/models.py
@@ -11,8 +11,10 @@ logger = logging.getLogger(__name__)
 class Dataset(models.Model):
     """Datasets and permissions on datasets."""
 
-    dataset_id: models.TextField = models.TextField(unique=True)
-    dataset_name: models.TextField = models.TextField(default="")
+    dataset_id: models.CharField = models.CharField(
+        max_length=255, unique=True)
+    dataset_name: models.CharField = models.CharField(
+        max_length=255, default="")
     broken: models.BooleanField = models.BooleanField(default=True)
     groups: models.ManyToManyField = models.ManyToManyField(Group)
 
@@ -67,7 +69,7 @@ class Dataset(models.Model):
 class DatasetHierarchy(models.Model):
     """Data for dataset hierarchy and inheritance."""
 
-    instance_id: models.TextField = models.TextField()
+    instance_id: models.CharField = models.CharField(max_length=255)
     ancestor: models.ForeignKey[Any, Dataset] = models.ForeignKey(
         Dataset, on_delete=models.CASCADE, related_name="ancestor",
     )

--- a/web_api/gpf_web/datasets_api/tests/test_dataset_uniqueness.py
+++ b/web_api/gpf_web/datasets_api/tests/test_dataset_uniqueness.py
@@ -6,11 +6,11 @@ from collections.abc import Callable
 
 import pytest
 from django.contrib.auth.models import Group
-from django.db import IntegrityError, connection, transaction
+from django.db import IntegrityError, connection, models, transaction
 from django.db.migrations.executor import MigrationExecutor
 from django.db.migrations.state import StateApps
 
-from datasets_api.models import Dataset
+from datasets_api.models import Dataset, DatasetHierarchy
 
 
 @pytest.fixture
@@ -118,3 +118,64 @@ def test_migration_repoints_hierarchy_fks_to_survivor(
         (survivor_pk, other_pk, True),
         (other_pk, survivor_pk, False),
     }
+
+
+# Identifier-field type regression (iossifovlab/gpf#836).
+#
+# These were ``TextField`` originally, which makes MySQL refuse to put a
+# UNIQUE constraint on the column ("BLOB/TEXT column used in key
+# specification without a key length"). The fields must be CharField with
+# a bounded ``max_length`` for the schema to apply on MySQL.
+
+
+def _field(model: type[models.Model], name: str) -> models.Field:
+    return model._meta.get_field(name)  # type: ignore[return-value]
+
+
+def test_dataset_id_is_charfield_255_and_unique() -> None:
+    field = _field(Dataset, "dataset_id")
+    assert isinstance(field, models.CharField), (
+        f"dataset_id must be CharField, got {type(field).__name__}"
+    )
+    assert field.max_length == 255
+    assert field.unique is True
+
+
+def test_dataset_name_is_charfield_255() -> None:
+    field = _field(Dataset, "dataset_name")
+    assert isinstance(field, models.CharField), (
+        f"dataset_name must be CharField, got {type(field).__name__}"
+    )
+    assert field.max_length == 255
+
+
+def test_datasethierarchy_instance_id_is_charfield_255() -> None:
+    field = _field(DatasetHierarchy, "instance_id")
+    assert isinstance(field, models.CharField), (
+        f"instance_id must be CharField, got {type(field).__name__}"
+    )
+    assert field.max_length == 255
+
+
+def test_migration_0010_leaves_models_as_charfield_255(
+    migrate_to: Callable,
+) -> None:
+    """Running through 0010 lands on CharField(255) for all three IDs."""
+    post = migrate_to([
+        ("datasets_api", "0010_identifier_fields_to_charfield"),
+    ])
+    PostDataset = post.get_model("datasets_api", "Dataset")
+    PostHierarchy = post.get_model("datasets_api", "DatasetHierarchy")
+
+    dataset_id = PostDataset._meta.get_field("dataset_id")
+    assert isinstance(dataset_id, models.CharField)
+    assert dataset_id.max_length == 255
+    assert dataset_id.unique is True
+
+    dataset_name = PostDataset._meta.get_field("dataset_name")
+    assert isinstance(dataset_name, models.CharField)
+    assert dataset_name.max_length == 255
+
+    instance_id = PostHierarchy._meta.get_field("instance_id")
+    assert isinstance(instance_id, models.CharField)
+    assert instance_id.max_length == 255


### PR DESCRIPTION
## Summary

- Amends migration `0009_dataset_dataset_id_unique` to use `CharField(max_length=255, unique=True)` instead of `TextField(unique=True)`, so fresh deploys on every backend (MySQL/MariaDB included) get a working schema. MySQL refuses to put a UNIQUE constraint on a TEXT column without a key prefix length, which broke today's `gpf-infra` deploy to dory.seqpipe.org with `MySQLdb.OperationalError: (1170, "BLOB/TEXT column 'dataset_id' used in key specification without a key length")`.
- Adds migration `0010_identifier_fields_to_charfield` that re-alters all three identifier columns (`Dataset.dataset_id`, `Dataset.dataset_name`, `DatasetHierarchy.instance_id`) to `CharField(max_length=255)`. This is the rolling-forward step for existing Postgres deploys (e.g. SFARI / gain-web's `gpfwa`) where the old 0009 had already applied against `TEXT` — `schema_editor` emits the actual `ALTER COLUMN ... TYPE VARCHAR(255)` SQL. On fresh deploys the column is already `VARCHAR(255)` and 0010 is a cheap no-op.
- Updates `datasets_api/models.py` to declare all three fields as `CharField(max_length=255)`.

## Strategy chosen

Strategy A from the issue: edit 0009 in place to do the right thing on fresh DBs, then add 0010 to perform the actual column-type conversion on already-migrated Postgres deploys.

Rationale: a fresh MySQL deploy never made it past 0009 (this is the bug). On Postgres, 0009 had applied and would now be a model-state no-op once 0009 itself declares CharField — but the column on disk is still TEXT, so the new 0010 is what actually converts it. No `--fake` footgun for any existing deploy.

`max_length=255` matches the issue text and existing identifiers in production (the longest dataset_id in `dataset_groups` configs is well under 100 chars — Lubo to confirm against `gpfwa` if there's any concern).

## Test plan

- [x] `cd web_api && uv run pytest -v -n 5 gpf_web/datasets_api/` — 48 passed (includes the 4 new regression tests that introspect model fields and run through 0010).
- [x] `uv run ruff check .` — no new errors on changed paths (migrations are intentionally excluded by `ruff.toml`).
- [x] `cd web_api && uv run mypy gpf_web --exclude docs/ --exclude conftest.py` — `Success: no issues found in 241 source files`.
- [x] `wdaemanage makemigrations --dry-run --check datasets_api` — `No changes detected in app 'datasets_api'` (model state matches migrations).
- [ ] CI to run on MySQL (none locally — verification was against the SQLite default).

Closes #836

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
