### PR TITLE
Jenkinsfile: copy ssh into Deploy docs container instead of bind-mounting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -657,13 +657,31 @@ pipeline {
                     // build that merges iossifovlab/gpf#841.
                     steps {
                         sh '''
+                            # Mount the agent's ~/.ssh into /host-ssh
+                            # (not /root/.ssh) so we can copy it into
+                            # the container's /root/.ssh with the right
+                            # ownership and permissions. OpenSSH 10+
+                            # rejects ~/.ssh/config that isn't owned by
+                            # the user running ssh; mounting directly
+                            # leaves files owned by the agent UID (e.g.
+                            # 1000), which the container's root (UID 0)
+                            # then refuses with "Bad owner or
+                            # permissions on /root/.ssh/config". This
+                            # was an intermittent failure depending on
+                            # which agent picked up the build (gpf
+                            # master #5708 worked, #5709 didn't).
                             docker run --rm \
                                 -v $PWD:/workspace \
-                                -v $HOME/.ssh:/root/.ssh:ro \
+                                -v $HOME/.ssh:/host-ssh:ro \
                                 -w /workspace \
                                 gpf-web-api-ci:${BUILD_NUMBER} \
                                 sh -c '
                                     set -eu
+                                    mkdir -p /root/.ssh
+                                    cp -RL /host-ssh/. /root/.ssh/
+                                    chown -R root:root /root/.ssh
+                                    chmod 700 /root/.ssh
+                                    chmod 600 /root/.ssh/* 2>/dev/null || true
                                     apt-get update
                                     apt-get install -y --no-install-recommends \
                                         ansible openssh-client


### PR DESCRIPTION
## Summary
- Hotfix for `Deploy docs` stage I added in #842
- Was bind-mounting `$HOME/.ssh` straight into `/root/.ssh` inside the container; OpenSSH 10+ refuses to use `~/.ssh/config` not owned by the user running ssh, and a bind mount keeps host UIDs
- Fix: mount source as `/host-ssh`, `cp -RL` into a fresh `/root/.ssh`, chown root:root, chmod 700/600

## Why this is a hotfix
- Live URL `https://iossifovlab.com/gpfdocs/` is currently serving #5708's content (which deployed successfully — the first master build that happened to land on a compatible agent)
- gpf master #5709 (PR #843 merge) failed at Deploy docs because it picked a different agent. Until this fix lands, every master build risks failing on a coin-flip basis

## Test plan
- [ ] Branch CI green (Deploy docs is gated to master so it stays skipped; we're just validating the Jenkinsfile parses + Build docs still works)
- [ ] After merge: next master build runs Deploy docs successfully on any agent label `'!dory'`
- [ ] Live URL `https://iossifovlab.com/gpfdocs/` updates with new `Last-Modified`
