### PR TITLE
Jenkinsfile: ssh-keyscan iossifovlab.com into Deploy docs container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -685,6 +685,15 @@ pipeline {
                                     apt-get update
                                     apt-get install -y --no-install-recommends \
                                         ansible openssh-client
+                                    # Populate known_hosts deterministically.
+                                    # Different Jenkins agents (label is
+                                    # "!dory") have different ssh history,
+                                    # so the agent ~/.ssh/known_hosts copy
+                                    # above may or may not contain the docs
+                                    # host. Append the live host key here so
+                                    # the deploy works regardless of agent.
+                                    ssh-keyscan -H iossifovlab.com \
+                                        >> /root/.ssh/known_hosts 2>/dev/null
                                     bash docs/deploy/docs_deploy.sh
                                 '
                         '''


### PR DESCRIPTION
## Summary
- Second-stage hotfix following #847
- Master #5712 still failed at Deploy docs with `Host key verification failed` — the bind-mount perm issue from #847 was fixed, but known_hosts was missing the docs host on whatever agent the build landed on
- Fix: `ssh-keyscan -H iossifovlab.com >> /root/.ssh/known_hosts` inside the container before running ansible — deterministic regardless of agent

## Why this is a hotfix
- Live URL `https://iossifovlab.com/gpfdocs/` is currently serving #5710's content (10:04 UTC) — fresh enough but every subsequent master build is failing the deploy
- Without this, the next docs change won't reach the live URL

Continues #847.

## Test plan
- [ ] Branch CI green (Deploy docs gated to master, so just validating the rest)
- [ ] After merge: next master build's Deploy docs runs successfully
- [ ] `https://iossifovlab.com/gpfdocs/` Last-Modified updates past 10:04
