### PR TITLE
docs/build_docs.sh: document gpf-docs-deploy credential

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -13,6 +13,9 @@
 # `docs/**` tree changes (see `when { changeset 'docs/**' }` in
 # Jenkinsfile). Edits outside docs/ do not refresh the rendered
 # autodoc page until a subsequent docs-tree commit lands.
+#
+# The Deploy docs stage authenticates to iossifovlab.com via the
+# `gpf-docs-deploy` Jenkins-managed SSH credential.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Trivial 3-line comment addition to `docs/build_docs.sh` to retrigger Build docs + Deploy docs on master after re-pasting the `gpf-docs-deploy` Jenkins credential.

Master #5714 failed with `Load key "/deploy.key": error in libcrypto` — credential's private-key content was mangled on first paste in the Jenkins UI. With the credential re-pasted, this PR's merge commit will re-exercise the deploy end-to-end.

## Test plan
- [ ] Branch CI: Build docs stage runs (changeset matches `docs/**`), Deploy docs skipped (not master)
- [ ] After merge: master Build docs + Deploy docs both run; `https://iossifovlab.com/gpfdocs/` Last-Modified updates past 11:45 UTC
