### PR TITLE
Jenkinsfile.nightly: add Run gpf-web-e2e stage

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -2,7 +2,7 @@
 // and re-runs the integration jobs unconditionally. Catches
 // dependency drift / silently-stale caches on quiet days.
 //
-// Three downstreams are exercised:
+// Four downstreams are exercised:
 //   - iossifovlab/gpf/master              — full rebuild, lint+tests+
 //                                           wheels for core + web_api +
 //                                           federation + rest_client
@@ -11,6 +11,9 @@
 //   - /gpf-rest-client-integration        — rest_client tests against
 //                                           a freshly seeded backend
 //                                           + MailHog
+//   - /gpf-web-e2e                        — Playwright UI tests against
+//                                           the freshly built prod
+//                                           images
 //
 // Each is wrapped in `catchError` so a failure in one doesn't mask
 // the others. By morning we want a single Zulip alert whose linked
@@ -72,6 +75,19 @@ pipeline {
                            stageResult: 'FAILURE') {
                     build(
                         job: '/gpf-rest-client-integration',
+                        wait: true,
+                        propagate: true,
+                    )
+                }
+            }
+        }
+
+        stage('Run gpf-web-e2e') {
+            steps {
+                catchError(buildResult: 'FAILURE',
+                           stageResult: 'FAILURE') {
+                    build(
+                        job: '/gpf-web-e2e',
                         wait: true,
                         propagate: true,
                     )


### PR DESCRIPTION
## Summary

- Adds a `Run gpf-web-e2e` stage to `Jenkinsfile.nightly`, symmetric with the existing federation + rest_client stages (`wait:true`, `propagate:true`, wrapped in `catchError`).
- Updates the file header to document the four downstreams.

## Why

Master's pipeline already triggers gpf-web-e2e fire-and-forget on every push (`wait:false`, `propagate:false`) so push response time stays fast. The trade-off is that e2e failures don't surface in master's status — they live in gpf-web-e2e's own job history.

Nightly's explicit wait-and-propagate stage is what surfaces those failures in the single morning Zulip alert, alongside federation + rest_client. That's the design intent in the file header (*"By morning we want a single Zulip alert whose linked build surfaces every failing downstream, not just whichever broke first"*) — web_e2e was just missing from it.

## Test plan

- [ ] Branch build of this PR is a touch to `Jenkinsfile.nightly`, not Jenkinsfile, so it runs the full master pipeline as a regression check.
- [ ] First nightly cron after merge runs all 4 stages sequentially: master rebuild → federation → rest_client → web_e2e. Verify the new stage shows up in the stage view.
- [ ] Force-fail web_e2e once (or just confirm next time it organically goes red) — the morning Zulip alert should reference the nightly build URL with the web_e2e stage marked red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
