### PR TITLE
ci: per-build DOCKER_CONFIG to fix docker auth race in image push (#855)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -953,12 +953,29 @@ pipeline {
                                 // push fails — agents are shared, don't
                                 // leave registry auth lying around.
                                 sh '''
+                                    # #855: docker login/logout mutate a
+                                    # shared per-user ~/.docker/config.json.
+                                    # On a shared agent a concurrent job's
+                                    # `docker logout` EXIT trap (e.g. the
+                                    # release-pipeline registry preflight)
+                                    # wipes our auth between two pushes —
+                                    # master #5742: push :$BUILD_NUMBER OK,
+                                    # push :$GIT_SHORT -> "no basic auth
+                                    # credentials". Auth instance of the
+                                    # tb-w8d race documented below. A
+                                    # per-build DOCKER_CONFIG makes
+                                    # login/logout build-local; scoped to
+                                    # this sh (not the stage env) so the
+                                    # base-image pulls above keep using the
+                                    # default config.
+                                    export DOCKER_CONFIG="$WORKSPACE/.docker-cfg-$BUILD_NUMBER"
+                                    mkdir -p "$DOCKER_CONFIG"
                                     echo "REGISTRY_USER bytes: $(printf '%s' "$REGISTRY_USER" | wc -c)"
                                     echo "REGISTRY_PASS bytes: $(printf '%s' "$REGISTRY_PASS" | wc -c)"
                                     printf '%s' "$REGISTRY_PASS" | docker login \
                                         -u "$REGISTRY_USER" \
                                         --password-stdin "$REGISTRY"
-                                    trap 'docker logout "$REGISTRY" || true' EXIT
+                                    trap 'docker logout "$REGISTRY" || true; rm -rf "$DOCKER_CONFIG"' EXIT
                                     # tb-w8d: tag :latest INSIDE the loop,
                                     # immediately before pushing it. gain
                                     # build #137 hit a race where a bulk

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -381,10 +381,20 @@ pipeline {
                         anaconda --token "$ANACONDA_TOKEN" whoami
                 '''
                 sh '''
+                    # #855: validate registry creds in an isolated
+                    # per-build DOCKER_CONFIG. The old bare `docker
+                    # logout "$REGISTRY"` here mutated the shared
+                    # ~/.docker/config.json and could wipe a
+                    # concurrent master build's push auth — this
+                    # preflight is a prime trigger of #5742. Removing
+                    # the private config dir IS the logout, and
+                    # touches no shared state.
+                    export DOCKER_CONFIG="$WORKSPACE/.docker-cfg-$BUILD_NUMBER-preflight"
+                    mkdir -p "$DOCKER_CONFIG"
+                    trap 'rm -rf "$DOCKER_CONFIG"' EXIT
                     printf '%s' "$REGISTRY_PASS" | docker login \
                         -u "$REGISTRY_USER" \
                         --password-stdin "$REGISTRY"
-                    docker logout "$REGISTRY"
                 '''
             }
         }
@@ -747,10 +757,16 @@ EOF
                 // shared daemon untagging :latest between a bulk
                 // tag step and the push).
                 sh '''
+                    # #855: per-build DOCKER_CONFIG so a concurrent
+                    # job's `docker logout` can't drop our auth
+                    # between pushes (auth instance of the tb-w8d /
+                    # gain #137 shared-daemon race noted above).
+                    export DOCKER_CONFIG="$WORKSPACE/.docker-cfg-$BUILD_NUMBER-push"
+                    mkdir -p "$DOCKER_CONFIG"
                     printf '%s' "$REGISTRY_PASS" | docker login \
                         -u "$REGISTRY_USER" \
                         --password-stdin "$REGISTRY"
-                    trap 'docker logout "$REGISTRY" || true' EXIT
+                    trap 'docker logout "$REGISTRY" || true; rm -rf "$DOCKER_CONFIG"' EXIT
 
                     for repo in "$BACKEND_REPO" "$FRONTEND_REPO" "$BUNDLE_REPO"; do
                         docker push "$repo:$TAG_NAME"


### PR DESCRIPTION
## What

Scope every `registry.seqpipe.org` `docker login`/`logout` to a **per-build `DOCKER_CONFIG`** so registry auth is build-local and concurrent jobs on a shared agent can't wipe each other's credentials mid-push.

`Closes #855`

## Why

`iossifovlab/gpf/master` [#5742](https://nemo.seqpipe.org/job/iossifovlab/job/gpf/job/master/5742/) failed with `result: FAILURE` but **0/3904 tests failed**. It died in the image-push stage:

```
+ docker push registry.seqpipe.org/gpf-web-api:5742      ← OK
+ docker push registry.seqpipe.org/gpf-web-api:de1b354a
  no basic auth credentials                               ← FAIL
```

`docker login`/`docker logout` mutate a **shared per-user `~/.docker/config.json`**. There was no per-build auth isolation, so a concurrent job's `docker logout "$REGISTRY"` EXIT trap removed the auth entry for every process on the agent — between our first and second push. First push reused a cached token; the second re-authed and found nothing.

This is the **auth instance** of the `tb-w8d` / gain #137 shared-daemon race. `tb-w8d` fixed only the `:latest` *tag* instance (tag inside the loop); registry auth is the same shared global state and was left unprotected.

## Changes

Per-build `DOCKER_CONFIG` (`$WORKSPACE/.docker-cfg-$BUILD_NUMBER…`), `mkdir -p`, and `rm -rf` on EXIT — scoped to the individual `sh` blocks (not the stage `environment {}`) so the earlier base-image `docker pull`s keep using the default config and any Docker Hub creds there:

- **`Jenkinsfile`** — master push loop (the block that broke in #5742).
- **`Jenkinsfile.release`** — push loop (`:$TAG_NAME` / `:stable`, the production-tagged images).
- **`Jenkinsfile.release`** — registry-creds **preflight**. It previously did a bare global `docker login` → `docker logout "$REGISTRY"`; that global logout is itself a **prime trigger** of #5742 for a concurrently-running master build. Now isolated; removing the private config dir is the logout and it touches no shared state.

`Jenkinsfile.nightly` has no registry push — unchanged.

## Out of scope / follow-up

`gain`'s Jenkinsfile shares the same push-with-login shape and the same shared agent pool (`tb-w8d` originated there). It needs the same isolation in a separate `iossifovlab/gain` PR — will file a follow-up.

## Testing

Not unit-testable (Jenkins declarative pipeline shell). The change is additive and structurally safe (single-quoted `trap` preserved inside the Groovy `'''…'''` strings; `DOCKER_CONFIG` reaches the shell because triple-single-quoted Groovy strings are not interpolated). Real verification: the next `master` build (and a `release` run) pushes all tags without `no basic auth credentials`, including under concurrent agent load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
