### PR TITLE
ci: harden gpf-web-e2e — db healthcheck start_period + per-agent lock fix

### DIFF
--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -465,30 +465,40 @@ pipeline {
         }
 
         stage('Run e2e') {
-            options {
-                // tb-cj9: per-agent lock for the heaviest stage.
-                // 16 Playwright workers + a full backend stack
-                // contend hard with a sibling build on the same
-                // agent (32 workers fighting one docker daemon ->
-                // load-induced flakes). The `!dory` agent label
-                // doesn't pin to a dedicated host, so concurrent
-                // builds CAN land together. This lock keyed by
-                // NODE_NAME serialises Run-e2e stages on the same
-                // agent while still allowing parallel runs on
-                // different agents.
-                //
-                // Image-build stages (Prepare backend/frontend
-                // images, Build e2e image) and instance-import
-                // intentionally remain unlocked: they're cached
-                // on master, rarely wall-time-bound, and adding
-                // a synthetic outer-stage lock to cover them
-                // would require re-indenting the entire stages
-                // tree. Extend if measured contention there
-                // surfaces.
-                lock(resource: "e2e-on-${env.NODE_NAME}")
-            }
             steps {
                 script {
+                    // tb-cj9: per-agent lock for the heaviest stage.
+                    // 16 Playwright workers + a full backend stack
+                    // contend hard with a sibling build on the same
+                    // agent (32 workers fighting one docker daemon ->
+                    // load-induced flakes). The `!dory` agent label
+                    // doesn't pin to a dedicated host, so concurrent
+                    // builds CAN land together. This lock keyed by
+                    // NODE_NAME serialises Run-e2e stages on the same
+                    // agent while still allowing parallel runs on
+                    // different agents.
+                    //
+                    // The lock MUST be taken here in `steps`, never
+                    // in a stage `options{}` block: declarative
+                    // evaluates stage options before the agent is
+                    // allocated, so env.NODE_NAME is unbound there and
+                    // the resource interpolated to the literal string
+                    // "e2e-on-null" — collapsing the per-agent lock
+                    // into ONE global lock every build queued on.
+                    // Under a trigger burst the whole e2e fleet
+                    // serialised and the 1h pipeline timeout (it
+                    // counts the lock wait) aborted the waiters
+                    // before they ran a single test.
+                    //
+                    // Image-build stages (Prepare backend/frontend
+                    // images, Build e2e image) and instance-import
+                    // intentionally remain unlocked: they're cached
+                    // on master, rarely wall-time-bound, and adding
+                    // a synthetic outer-stage lock to cover them
+                    // would require re-indenting the entire stages
+                    // tree. Extend if measured contention there
+                    // surfaces.
+                    lock(resource: "e2e-on-${env.NODE_NAME}") {
                     try {
                         sh '''
                             mkdir -p web_e2e/reports
@@ -605,6 +615,7 @@ pipeline {
                                 -f $COMPOSE_OVERLAY \
                                 down -v --remove-orphans || true
                         '''
+                    }
                     }
                 }
             }

--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -63,6 +63,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      # Cold init every build: mysql-data declares no volume, so the
+      # data dir is ephemeral and MariaDB does a full first-boot
+      # bootstrap each run. Under concurrent e2e builds on one agent
+      # that can blow past retries*interval (~50s) and get marked
+      # unhealthy with no DB fault — gpf-web-e2e #109 failed here on
+      # the same SHA that #108 ran green. start_period stops failing
+      # checks from counting until init has had time to finish; a
+      # fast cold init still flips healthy at once, so the grace is
+      # effectively free.
+      start_period: 60s
 
   mail:
     image: mailhog/mailhog


### PR DESCRIPTION
Two independent gpf-web-e2e CI-reliability fixes, both surfaced by the 2026-05-19 build storm.

## Fix 1 — `db` healthcheck `start_period` (`web_infra/compose-jenkins.yaml`)

The `db` (MariaDB) healthcheck used `interval 10s / timeout 5s / retries 5` with **no `start_period`**, giving a cold first-boot init only ~50s before the container is marked unhealthy. Because `mysql-data` declares no volume, the data dir is ephemeral and *every* build is a cold init.

Under concurrent e2e builds on one agent the init can exceed that ~50s budget. `instance-import` (`depends_on: db: service_healthy`) then never starts and the run dies before any test executes.

`start_period: 60s` keeps failing checks from counting toward `retries` until init has had time to finish. A fast cold init still flips healthy immediately, so the grace is effectively free on the happy path (effective patience ~50s → ~110s).

Evidence:
- [gpf-web-e2e #109](https://nemo.seqpipe.org/job/gpf-web-e2e/109/) failed in 2.3 min at "Import e2e instance": `container gpf-web-e2e-109-db-1 is unhealthy`.
- [#108](https://nemo.seqpipe.org/job/gpf-web-e2e/108/) ran the **same commit** (`712449b`) to a full ~45-min SUCCESS — resource contention, not a code regression.

## Fix 2 — Run-e2e lock keyed on the real agent (`web_e2e/Jenkinsfile.e2e`)

The per-agent lock was declared in the `stage('Run e2e')` `options{}` block. Declarative evaluates stage `options` **before the agent is allocated**, so `env.NODE_NAME` is unbound and `"e2e-on-${env.NODE_NAME}"` interpolated to the literal **`e2e-on-null`** — collapsing the intended per-agent lock into a single **global** lock every gpf-web-e2e build (every branch/SHA/stack-mode/agent) had to queue on.

Under a trigger burst the whole fleet serialised on `e2e-on-null`, and because the 1h pipeline `timeout` counts the lock wait, queued builds were **ABORTED before running a single test**.

The lock is moved into the `steps`/`script` body, where the stage is executing on its agent and `env.NODE_NAME` resolves to the real node (`e2e-on-pooh`, …) — restoring per-agent serialisation with cross-agent parallelism.

Evidence: gpf-web-e2e #112–#115 — `#112` held `e2e-on-null` ~53 min while `#113` (ABORTED at the 1h timeout), `#114`, `#115` ("added into queue at position 3") starved behind it.

Note: not local-lintable — there is no Jenkins declarative linter / Groovy linter in the repo; verified by structure (brace-balanced) and review of the restructured stage. Real validation is a green gpf-web-e2e run.

## Test plan

- [ ] gpf-web-e2e green on this branch (exercises both fixes end-to-end once the Docker Hub `docker pull` flake clears upstream)
- [ ] No recurrence of "db is unhealthy" under the nightly + upstream double-run
- [ ] Concurrent builds take per-agent locks (`e2e-on-<host>`, not `e2e-on-null`) and run in parallel across agents
