### PR TITLE
Bundle SPA into gpf-web conda package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,61 @@ members from path sources via `uv sync`, which requires
 hatchling to build the package metadata — strict
 wheels-only would fail by design there.
 
+### Conda packaging: gpf-web bundles the SPA
+
+The `gpf-web` conda recipe
+(`web_api/conda-recipe/recipe.yaml`) bundles the Angular SPA
+into the installed Django app at
+`<site-packages>/gpfjs/static/gpfjs/gpfjs/` — note the install
+prefix is `gpfjs/`, NOT `gpf_web/gpfjs/`: hatchling's
+`[tool.hatch.build.targets.wheel] packages` directive in
+`web_api/pyproject.toml` lifts each app to the top level.
+The `gpfjs/views.py` `index` view probes
+`finders.find("gpfjs/gpfjs/index.html")` and falls back to
+`templates/gpfjs/empty/empty.html` only when nothing's there
+— so a conda install gets the live SPA, a plain
+`pip install` of the wheel gets the empty fallback.
+
+The bundle is **conda-only**. The wheel stays SPA-free
+because `web_api/Dockerfile.production` consumes the same
+wheel and pairs it with the apache-served `gpf-web-ui`
+image; duplicating the SPA into the wheel would inflate the
+backend image without changing what's served.
+
+CI flow (master multibranch — `Jenkinsfile`):
+
+1. `web_ui` stage builds the SPA with
+   `npm run build -- --configuration conda --base-href '/gpfjs/' --deploy-url '/static/gpfjs/gpfjs/'`
+   and tars `web_ui/dist/gpfjs/` into
+   `dist/web_ui/gpfjs-spa.tar.gz`.
+2. `Conda packages` stage iterates the recipes in order
+   `core federation rest_client web_api`. The web_api recipe
+   lists the SPA tarball as a required `source:` and
+   asserts `index.html` exists post-untar; missing tarball
+   fails the recipe loudly. The ordering means a SPA-side
+   regression doesn't block the other three artefacts.
+3. `archiveArtifacts` includes
+   `dist/web_ui/gpfjs-spa.tar.gz` with `fingerprint: true`,
+   mirroring the gain wheel pattern so the release pipeline
+   can find it later.
+
+Release flow (`Jenkinsfile.release`): `Fetch upstream
+artefacts` copies the SPA tarball (alongside
+`dist/base-images.lock` and `dist/gain/*.whl`) from the
+master CI build matching the tagged commit, then
+`Build conda packages` uses it — same reordered loop.
+No re-build, so the released conda's SPA is byte-identical
+to what master CI tested with.
+
+For the local-build three-step (when iterating on the recipe
+itself), see `README.md` → "Conda packaging".
+
+The `--deploy-url '/static/gpfjs/gpfjs/'` baked into the
+build hardcodes the SPA's asset URLs to assume
+`STATIC_URL == '/static/'`. Don't change Django's
+`STATIC_URL` for conda-installed gpf-web without rebuilding
+the SPA with a matching deploy-url.
+
 ## Commands
 
 ### Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,25 +136,28 @@ CI flow (master multibranch — `Jenkinsfile`):
 
 1. `web_ui` stage builds the SPA with
    `npm run build -- --configuration conda --base-href '/gpfjs/' --deploy-url '/static/gpfjs/gpfjs/'`
-   and copies `web_ui/dist/gpfjs/` to `dist/web_ui/gpfjs/`
-   (directory, not tarball — rattler-build auto-extracts
-   `.tar.gz` `path:` sources but treats directories as
-   copy-as-is, which preserves the on-disk layout the recipe
-   expects).
-2. `Conda packages` stage iterates the recipes in order
-   `core federation rest_client web_api`. The web_api recipe
-   lists the SPA tree as a required `source:` with
-   `target_directory: gpfjs-spa-src` and asserts `index.html`
-   exists post-copy; missing tree fails the recipe loudly.
-   The ordering means a SPA-side regression doesn't block the
-   other three artefacts.
+   and packages `web_ui/dist/gpfjs/` as
+   `dist/web_ui/gpfjs-spa.tar.gz`.
+2. `Conda packages` stage extracts the tarball back into
+   `dist/web_ui/gpfjs/` (with `--strip-components=1` to drop
+   the leading `gpfjs/` prefix the tar carries), then iterates
+   the recipes in order `core federation rest_client web_api`.
+   The web_api recipe lists the extracted SPA tree as a
+   required `source:` with `target_directory: gpfjs-spa-src`
+   and asserts `index.html` exists post-copy; missing tree
+   fails the recipe loudly. The ordering means a SPA-side
+   regression doesn't block the other three artefacts.
+   (Feeding the tarball directly to rattler-build does not
+   work — it auto-extracts `.tar.gz` `path:` sources with an
+   undocumented strip-top-level behaviour, so we control the
+   extraction explicitly in the Jenkinsfile.)
 3. `archiveArtifacts` includes
-   `dist/web_ui/gpfjs/**` with `fingerprint: true`,
+   `dist/web_ui/gpfjs-spa.tar.gz` with `fingerprint: true`,
    mirroring the gain wheel pattern so the release pipeline
    can find it later.
 
 Release flow (`Jenkinsfile.release`): `Fetch upstream
-artefacts` copies the SPA tree (alongside
+artefacts` copies the SPA tarball (alongside
 `dist/base-images.lock` and `dist/gain/*.whl`) from the
 master CI build matching the tagged commit, then
 `Build conda packages` uses it — same reordered loop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,21 +136,25 @@ CI flow (master multibranch — `Jenkinsfile`):
 
 1. `web_ui` stage builds the SPA with
    `npm run build -- --configuration conda --base-href '/gpfjs/' --deploy-url '/static/gpfjs/gpfjs/'`
-   and tars `web_ui/dist/gpfjs/` into
-   `dist/web_ui/gpfjs-spa.tar.gz`.
+   and copies `web_ui/dist/gpfjs/` to `dist/web_ui/gpfjs/`
+   (directory, not tarball — rattler-build auto-extracts
+   `.tar.gz` `path:` sources but treats directories as
+   copy-as-is, which preserves the on-disk layout the recipe
+   expects).
 2. `Conda packages` stage iterates the recipes in order
    `core federation rest_client web_api`. The web_api recipe
-   lists the SPA tarball as a required `source:` and
-   asserts `index.html` exists post-untar; missing tarball
-   fails the recipe loudly. The ordering means a SPA-side
-   regression doesn't block the other three artefacts.
+   lists the SPA tree as a required `source:` with
+   `target_directory: gpfjs-spa-src` and asserts `index.html`
+   exists post-copy; missing tree fails the recipe loudly.
+   The ordering means a SPA-side regression doesn't block the
+   other three artefacts.
 3. `archiveArtifacts` includes
-   `dist/web_ui/gpfjs-spa.tar.gz` with `fingerprint: true`,
+   `dist/web_ui/gpfjs/**` with `fingerprint: true`,
    mirroring the gain wheel pattern so the release pipeline
    can find it later.
 
 Release flow (`Jenkinsfile.release`): `Fetch upstream
-artefacts` copies the SPA tarball (alongside
+artefacts` copies the SPA tree (alongside
 `dist/base-images.lock` and `dist/gain/*.whl`) from the
 master CI build matching the tagged commit, then
 `Build conda packages` uses it — same reordered loop.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -547,13 +547,45 @@ pipeline {
                                     // runProject() is Python-specific (uv build,
                                     // pylint, mypy, pytest). Single sh -c so all
                                     // four reports land in one bind mount.
+                                    //
+                                    // The same stage also produces the conda-flavoured
+                                    // SPA tarball (dist/web_ui/gpfjs-spa.tar.gz)
+                                    // consumed by web_api/conda-recipe/recipe.yaml.
+                                    // `--configuration conda` swaps environment.ts →
+                                    // environment.conda.ts (fileReplacements in
+                                    // angular.json); --base-href and --deploy-url
+                                    // bake the URL layout the Django gpfjs app
+                                    // expects (view serves the SPA from
+                                    // staticfile gpfjs/gpfjs/index.html;
+                                    // STATIC_URL='/static/'). Built here — not in
+                                    // conda-builder — so the heavy node toolchain
+                                    // stays out of the python-only conda-builder
+                                    // image. Built first within the sh -c so a
+                                    // broken angular build fails fast without
+                                    // paying for lint + jest first.
                                     sh label: 'Run web_ui CI', script: """
-                                        mkdir -p reports/web_ui
+                                        mkdir -p reports/web_ui dist/web_ui
                                         docker run --rm \\
                                             -v \$PWD/reports/web_ui:/reports \\
+                                            -v \$PWD/dist/web_ui:/dist \\
                                             ${imageTag} \\
                                             sh -c '
                                                 set +e
+                                                # 1) conda-flavoured SPA build +
+                                                #    tarball. Fail fast if angular
+                                                #    build is broken.
+                                                npm run build -- \\
+                                                    --configuration conda \\
+                                                    --base-href "/gpfjs/" \\
+                                                    --deploy-url "/static/gpfjs/gpfjs/"
+                                                ng_exit=\$?
+                                                if [ \$ng_exit -ne 0 ]; then
+                                                    exit \$ng_exit
+                                                fi
+                                                tar -czf /dist/gpfjs-spa.tar.gz \\
+                                                    -C dist gpfjs
+                                                chmod 644 /dist/gpfjs-spa.tar.gz
+                                                # 2) lint + test as before.
                                                 mkdir -p /reports/coverage
                                                 npx eslint "**/*.{html,ts}" \\
                                                     --format checkstyle \\
@@ -807,7 +839,14 @@ pipeline {
                             # redirected to /tmp because /home/mambauser is not
                             # writable by an arbitrary UID.
                             DOCKER_USER="$(id -u):$(id -g)"
-                            for proj in core web_api federation rest_client; do
+                            # web_api built LAST so a missing/malformed
+                            # dist/web_ui/gpfjs-spa.tar.gz (required by its
+                            # recipe) doesn't abort core/federation/rest_client
+                            # before they get a chance to publish. set -e in
+                            # this script means a web_api conda failure still
+                            # fails the stage — we just stop blocking the other
+                            # three artefacts on a SPA-side regression.
+                            for proj in core federation rest_client web_api; do
                                 mkdir -p conda/$proj
                                 docker run --rm \
                                     --user "$DOCKER_USER" \
@@ -1159,8 +1198,14 @@ pipeline {
                         allowEmptyArchive: true,
                         fingerprint: false,
                     )
+                    // dist/web_ui/gpfjs-spa.tar.gz is the conda-flavoured
+                    // Angular dist tarball; gpf-release fetches it from this
+                    // archive via copyArtifacts and feeds it to the gpf-web
+                    // conda recipe. fingerprint:true makes it findable even
+                    // if the build record itself rotates out, mirroring the
+                    // gain wheel pattern.
                     archiveArtifacts(
-                        artifacts: 'dist/**/*.whl, dist/**/*.tar.gz, dist/conda/*.conda, dist/base-images.lock',
+                        artifacts: 'dist/**/*.whl, dist/**/*.tar.gz, dist/web_ui/gpfjs-spa.tar.gz, dist/conda/*.conda, dist/base-images.lock',
                         allowEmptyArchive: true,
                         fingerprint: true,
                     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -549,8 +549,8 @@ pipeline {
                                     // four reports land in one bind mount.
                                     //
                                     // The same stage also produces the conda-flavoured
-                                    // SPA tarball (dist/web_ui/gpfjs-spa.tar.gz)
-                                    // consumed by web_api/conda-recipe/recipe.yaml.
+                                    // SPA dist tree (dist/web_ui/gpfjs/) consumed by
+                                    // web_api/conda-recipe/recipe.yaml.
                                     // `--configuration conda` swaps environment.ts →
                                     // environment.conda.ts (fileReplacements in
                                     // angular.json); --base-href and --deploy-url
@@ -572,8 +572,16 @@ pipeline {
                                             sh -c '
                                                 set +e
                                                 # 1) conda-flavoured SPA build +
-                                                #    tarball. Fail fast if angular
-                                                #    build is broken.
+                                                #    copy the dist tree out. Fail fast
+                                                #    if angular build is broken.
+                                                #    Directory (not tarball) because
+                                                #    rattler-build auto-extracts
+                                                #    .tar.gz path: sources but treats
+                                                #    directory path: sources as
+                                                #    contents-copied-as-is — and we
+                                                #    need the on-disk gpfjs/ subdir
+                                                #    preserved so the recipe can find
+                                                #    index.html.
                                                 npm run build -- \\
                                                     --configuration conda \\
                                                     --base-href "/gpfjs/" \\
@@ -582,9 +590,8 @@ pipeline {
                                                 if [ \$ng_exit -ne 0 ]; then
                                                     exit \$ng_exit
                                                 fi
-                                                tar -czf /dist/gpfjs-spa.tar.gz \\
-                                                    -C dist gpfjs
-                                                chmod 644 /dist/gpfjs-spa.tar.gz
+                                                cp -r dist/gpfjs /dist/
+                                                chmod -R a+r /dist/gpfjs
                                                 # 2) lint + test as before.
                                                 mkdir -p /reports/coverage
                                                 npx eslint "**/*.{html,ts}" \\
@@ -840,7 +847,7 @@ pipeline {
                             # writable by an arbitrary UID.
                             DOCKER_USER="$(id -u):$(id -g)"
                             # web_api built LAST so a missing/malformed
-                            # dist/web_ui/gpfjs-spa.tar.gz (required by its
+                            # dist/web_ui/gpfjs/ (required by its
                             # recipe) doesn't abort core/federation/rest_client
                             # before they get a chance to publish. set -e in
                             # this script means a web_api conda failure still
@@ -1198,14 +1205,17 @@ pipeline {
                         allowEmptyArchive: true,
                         fingerprint: false,
                     )
-                    // dist/web_ui/gpfjs-spa.tar.gz is the conda-flavoured
-                    // Angular dist tarball; gpf-release fetches it from this
-                    // archive via copyArtifacts and feeds it to the gpf-web
-                    // conda recipe. fingerprint:true makes it findable even
-                    // if the build record itself rotates out, mirroring the
-                    // gain wheel pattern.
+                    // dist/web_ui/gpfjs/** is the conda-flavoured Angular
+                    // dist tree; gpf-release fetches it from this archive
+                    // via copyArtifacts and feeds it to the gpf-web conda
+                    // recipe. Archived as a tree (not tarball) because
+                    // rattler-build auto-extracts .tar.gz path: sources,
+                    // which loses the gpfjs/ prefix we need; directory
+                    // sources are copied as-is. fingerprint:true makes
+                    // the tree findable even if the build record itself
+                    // rotates out, mirroring the gain wheel pattern.
                     archiveArtifacts(
-                        artifacts: 'dist/**/*.whl, dist/**/*.tar.gz, dist/web_ui/gpfjs-spa.tar.gz, dist/conda/*.conda, dist/base-images.lock',
+                        artifacts: 'dist/**/*.whl, dist/**/*.tar.gz, dist/web_ui/gpfjs/**, dist/conda/*.conda, dist/base-images.lock',
                         allowEmptyArchive: true,
                         fingerprint: true,
                     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -549,8 +549,11 @@ pipeline {
                                     // four reports land in one bind mount.
                                     //
                                     // The same stage also produces the conda-flavoured
-                                    // SPA dist tree (dist/web_ui/gpfjs/) consumed by
-                                    // web_api/conda-recipe/recipe.yaml.
+                                    // SPA tarball (dist/web_ui/gpfjs-spa.tar.gz)
+                                    // consumed by web_api/conda-recipe/recipe.yaml
+                                    // (the Conda packages stage below extracts it
+                                    // back into dist/web_ui/gpfjs/ before
+                                    // rattler-build runs).
                                     // `--configuration conda` swaps environment.ts →
                                     // environment.conda.ts (fileReplacements in
                                     // angular.json); --base-href and --deploy-url
@@ -572,16 +575,22 @@ pipeline {
                                             sh -c '
                                                 set +e
                                                 # 1) conda-flavoured SPA build +
-                                                #    copy the dist tree out. Fail fast
-                                                #    if angular build is broken.
-                                                #    Directory (not tarball) because
-                                                #    rattler-build auto-extracts
-                                                #    .tar.gz path: sources but treats
-                                                #    directory path: sources as
-                                                #    contents-copied-as-is — and we
-                                                #    need the on-disk gpfjs/ subdir
-                                                #    preserved so the recipe can find
-                                                #    index.html.
+                                                #    tarball. Fail fast if angular
+                                                #    build is broken.
+                                                #    Archived as a single .tar.gz for
+                                                #    a clean Jenkins artefact list /
+                                                #    fingerprint surface (vs. ~150
+                                                #    files in a directory tree). The
+                                                #    Conda packages stage extracts it
+                                                #    back into dist/web_ui/gpfjs/
+                                                #    before rattler-build runs;
+                                                #    feeding the tarball directly to
+                                                #    rattler-build does not work
+                                                #    (it auto-extracts .tar.gz path:
+                                                #    sources with an undocumented
+                                                #    strip-top-level behaviour, so
+                                                #    we control the extraction
+                                                #    explicitly).
                                                 npm run build -- \\
                                                     --configuration conda \\
                                                     --base-href "/gpfjs/" \\
@@ -590,8 +599,9 @@ pipeline {
                                                 if [ \$ng_exit -ne 0 ]; then
                                                     exit \$ng_exit
                                                 fi
-                                                cp -r dist/gpfjs /dist/
-                                                chmod -R a+r /dist/gpfjs
+                                                tar -czf /dist/gpfjs-spa.tar.gz \\
+                                                    -C dist gpfjs
+                                                chmod 644 /dist/gpfjs-spa.tar.gz
                                                 # 2) lint + test as before.
                                                 mkdir -p /reports/coverage
                                                 npx eslint "**/*.{html,ts}" \\
@@ -836,6 +846,25 @@ pipeline {
                                 | sed 's#-py3-none-any.whl$##')
                             echo "VCS_VERSION=$VCS_VERSION"
 
+                            # Expand the SPA tarball into dist/web_ui/gpfjs/
+                            # — the gpf-web conda recipe consumes that
+                            # directory as a `path:` source. Archived as a
+                            # tarball for a clean Jenkins artefact list;
+                            # extracted here so rattler-build sees the
+                            # directory directly (it would otherwise auto-
+                            # extract the tarball with an undocumented
+                            # strip-top-level behaviour). --strip-components=1
+                            # drops the leading gpfjs/ prefix the tar carries,
+                            # so the extracted layout sits at
+                            # dist/web_ui/gpfjs/index.html etc., matching the
+                            # recipe's source spec exactly. rm -rf first so a
+                            # re-run on a dirty workspace doesn't accumulate
+                            # stale content.
+                            rm -rf dist/web_ui/gpfjs
+                            mkdir -p dist/web_ui/gpfjs
+                            tar -xzf dist/web_ui/gpfjs-spa.tar.gz \
+                                -C dist/web_ui/gpfjs --strip-components=1
+
                             mkdir -p dist/conda
                             # Run the conda-builder container as the Jenkins user
                             # (instead of the image's default `mambauser`, UID
@@ -847,7 +876,7 @@ pipeline {
                             # writable by an arbitrary UID.
                             DOCKER_USER="$(id -u):$(id -g)"
                             # web_api built LAST so a missing/malformed
-                            # dist/web_ui/gpfjs/ (required by its
+                            # dist/web_ui/gpfjs-spa.tar.gz (required by its
                             # recipe) doesn't abort core/federation/rest_client
                             # before they get a chance to publish. set -e in
                             # this script means a web_api conda failure still
@@ -1205,17 +1234,15 @@ pipeline {
                         allowEmptyArchive: true,
                         fingerprint: false,
                     )
-                    // dist/web_ui/gpfjs/** is the conda-flavoured Angular
-                    // dist tree; gpf-release fetches it from this archive
-                    // via copyArtifacts and feeds it to the gpf-web conda
-                    // recipe. Archived as a tree (not tarball) because
-                    // rattler-build auto-extracts .tar.gz path: sources,
-                    // which loses the gpfjs/ prefix we need; directory
-                    // sources are copied as-is. fingerprint:true makes
-                    // the tree findable even if the build record itself
+                    // dist/web_ui/gpfjs-spa.tar.gz is the conda-flavoured
+                    // Angular dist tarball; gpf-release fetches it from
+                    // this archive via copyArtifacts and the Conda
+                    // packages stage extracts it before feeding it to
+                    // the gpf-web conda recipe. fingerprint:true makes
+                    // the file findable even if the build record itself
                     // rotates out, mirroring the gain wheel pattern.
                     archiveArtifacts(
-                        artifacts: 'dist/**/*.whl, dist/**/*.tar.gz, dist/web_ui/gpfjs/**, dist/conda/*.conda, dist/base-images.lock',
+                        artifacts: 'dist/**/*.whl, dist/**/*.tar.gz, dist/web_ui/gpfjs-spa.tar.gz, dist/conda/*.conda, dist/base-images.lock',
                         allowEmptyArchive: true,
                         fingerprint: true,
                     )

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -400,7 +400,7 @@ pipeline {
         }
 
         stage('Fetch upstream artefacts') {
-            // Pull two files from the master build identified
+            // Pull three files from the master build identified
             // above:
             //   - dist/base-images.lock: digests of python-slim /
             //     node-alpine / httpd-alpine used by the master
@@ -413,29 +413,37 @@ pipeline {
             //     /wheels — pinning here means the release publishes
             //     exactly what passed CI, not whatever gain happens
             //     to be at when the release dispatches.
+            //   - dist/web_ui/gpfjs-spa.tar.gz: the conda-flavoured
+            //     Angular SPA tarball, fed into the gpf-web conda
+            //     recipe so the released gpf-web package bundles the
+            //     SPA. Pulled here (not rebuilt) so the released
+            //     conda's SPA is byte-identical to what master CI
+            //     tested with — same precedent as the gain wheel,
+            //     no GAIN_PIN_VERSION-equivalent override (the SPA
+            //     is part of the gpf repo itself).
             //
             // V2 override: if params.GAIN_PIN_VERSION is set, the
             // gain wheel comes from wheels.seqpipe.org/gain/
             // instead of upstream copyArtifacts. base-images.lock
-            // still comes from upstream master (it's the digest
-            // record for THIS gpf commit's build, unrelated to
-            // gain). Trusted-override semantics — the swapped wheel
-            // is NOT re-tested; the operator certifies API
-            // compatibility (see V2 design grilling Q3).
+            // and the SPA tarball still come from upstream master
+            // (the SPA is gpf-side, unrelated to gain). Trusted-
+            // override semantics — the swapped wheel is NOT re-
+            // tested; the operator certifies API compatibility
+            // (see V2 design grilling Q3).
             //
             // fingerprintArtifacts:true pairs with the master
-            // archiveArtifacts' fingerprint:true so both files are
+            // archiveArtifacts' fingerprint:true so all files are
             // locatable even if the build record itself rotated.
             steps {
                 script {
                     if (params.GAIN_PIN_VERSION) {
-                        // Pinned path: base-images.lock only from
-                        // upstream; gain wheel from
+                        // Pinned path: base-images.lock + SPA
+                        // tarball from upstream; gain wheel from
                         // wheels.seqpipe.org/gain/.
                         copyArtifacts(
                             projectName: params.UPSTREAM_PROJECT,
                             selector: specific(env.UPSTREAM_BUILD_NUMBER),
-                            filter: 'dist/base-images.lock',
+                            filter: 'dist/base-images.lock, dist/web_ui/gpfjs-spa.tar.gz',
                             fingerprintArtifacts: true,
                         )
                         sh '''
@@ -450,12 +458,12 @@ pipeline {
                                 "$gain_url"
                         '''
                     } else {
-                        // Default V1 path: copy both files from
+                        // Default V1 path: copy all three from
                         // upstream gpf-master CI build.
                         copyArtifacts(
                             projectName: params.UPSTREAM_PROJECT,
                             selector: specific(env.UPSTREAM_BUILD_NUMBER),
-                            filter: 'dist/base-images.lock, dist/gain/*.whl',
+                            filter: 'dist/base-images.lock, dist/gain/*.whl, dist/web_ui/gpfjs-spa.tar.gz',
                             fingerprintArtifacts: true,
                         )
                     }
@@ -464,6 +472,14 @@ pipeline {
                     cat dist/base-images.lock
                     ls -la dist/gain/
                     test -n "$(ls dist/gain/gain_core-*.whl 2>/dev/null)"
+                    # SPA tarball is REQUIRED — gpf-web conda recipe
+                    # will fail rattler-build's source-staging if it
+                    # is missing, but fail loud here so the operator
+                    # sees a clear "upstream master build did not
+                    # archive the SPA tarball" message instead of a
+                    # rattler-build internals trace later.
+                    ls -la dist/web_ui/
+                    test -f dist/web_ui/gpfjs-spa.tar.gz
                 '''
                 // Surface the bundled gain version everywhere it
                 // matters: top-of-build log, Notify Zulip message,
@@ -578,7 +594,15 @@ pipeline {
 
                     mkdir -p dist/conda
                     DOCKER_USER="$(id -u):$(id -g)"
-                    for proj in core web_api federation rest_client; do
+                    # web_api built LAST so a missing/malformed
+                    # dist/web_ui/gpfjs-spa.tar.gz (required by its
+                    # recipe) doesn't abort core/federation/rest_client
+                    # before they get a chance to be built. set -e in
+                    # this script means a web_api conda failure still
+                    # fails the stage and blocks the release — we just
+                    # stop coupling the other three artefacts to a
+                    # SPA-side regression.
+                    for proj in core federation rest_client web_api; do
                         mkdir -p conda/$proj
                         docker run --rm \
                             --user "$DOCKER_USER" \

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -413,21 +413,22 @@ pipeline {
             //     /wheels — pinning here means the release publishes
             //     exactly what passed CI, not whatever gain happens
             //     to be at when the release dispatches.
-            //   - dist/web_ui/gpfjs/**: the conda-flavoured Angular
-            //     SPA dist tree, fed into the gpf-web conda recipe
-            //     so the released gpf-web package bundles the SPA.
-            //     Pulled here (not rebuilt) so the released conda's
-            //     SPA is byte-identical to what master CI tested
-            //     with — same precedent as the gain wheel, no
-            //     GAIN_PIN_VERSION-equivalent override (the SPA is
-            //     part of the gpf repo itself). Archived/fetched as
-            //     a directory tree rather than a tarball because
-            //     rattler-build auto-extracts .tar.gz path: sources.
+            //   - dist/web_ui/gpfjs-spa.tar.gz: the conda-flavoured
+            //     Angular SPA tarball, fed into the gpf-web conda
+            //     recipe so the released gpf-web package bundles
+            //     the SPA. Pulled here (not rebuilt) so the
+            //     released conda's SPA is byte-identical to what
+            //     master CI tested with — same precedent as the
+            //     gain wheel, no GAIN_PIN_VERSION-equivalent
+            //     override (the SPA is part of the gpf repo
+            //     itself). The Build conda packages stage below
+            //     extracts the tarball into dist/web_ui/gpfjs/
+            //     before rattler-build runs.
             //
             // V2 override: if params.GAIN_PIN_VERSION is set, the
             // gain wheel comes from wheels.seqpipe.org/gain/
             // instead of upstream copyArtifacts. base-images.lock
-            // and the SPA tree still come from upstream master
+            // and the SPA tarball still come from upstream master
             // (the SPA is gpf-side, unrelated to gain). Trusted-
             // override semantics — the swapped wheel is NOT re-
             // tested; the operator certifies API compatibility
@@ -439,13 +440,13 @@ pipeline {
             steps {
                 script {
                     if (params.GAIN_PIN_VERSION) {
-                        // Pinned path: base-images.lock + SPA tree
-                        // from upstream; gain wheel from
+                        // Pinned path: base-images.lock + SPA
+                        // tarball from upstream; gain wheel from
                         // wheels.seqpipe.org/gain/.
                         copyArtifacts(
                             projectName: params.UPSTREAM_PROJECT,
                             selector: specific(env.UPSTREAM_BUILD_NUMBER),
-                            filter: 'dist/base-images.lock, dist/web_ui/gpfjs/**',
+                            filter: 'dist/base-images.lock, dist/web_ui/gpfjs-spa.tar.gz',
                             fingerprintArtifacts: true,
                         )
                         sh '''
@@ -465,7 +466,7 @@ pipeline {
                         copyArtifacts(
                             projectName: params.UPSTREAM_PROJECT,
                             selector: specific(env.UPSTREAM_BUILD_NUMBER),
-                            filter: 'dist/base-images.lock, dist/gain/*.whl, dist/web_ui/gpfjs/**',
+                            filter: 'dist/base-images.lock, dist/gain/*.whl, dist/web_ui/gpfjs-spa.tar.gz',
                             fingerprintArtifacts: true,
                         )
                     }
@@ -474,16 +475,14 @@ pipeline {
                     cat dist/base-images.lock
                     ls -la dist/gain/
                     test -n "$(ls dist/gain/gain_core-*.whl 2>/dev/null)"
-                    # SPA tree is REQUIRED — gpf-web conda recipe
+                    # SPA tarball is REQUIRED — gpf-web conda recipe
                     # will fail rattler-build's source-staging if it
                     # is missing, but fail loud here so the operator
                     # sees a clear "upstream master build did not
-                    # archive the SPA dist tree" message instead of a
-                    # rattler-build internals trace later. Probing
-                    # index.html (the SPA shell) is sufficient since
-                    # the angular build always emits it.
-                    ls -la dist/web_ui/gpfjs/ 2>&1 | head -20
-                    test -f dist/web_ui/gpfjs/index.html
+                    # archive the SPA tarball" message instead of a
+                    # rattler-build internals trace later.
+                    ls -la dist/web_ui/
+                    test -f dist/web_ui/gpfjs-spa.tar.gz
                 '''
                 // Surface the bundled gain version everywhere it
                 // matters: top-of-build log, Notify Zulip message,
@@ -596,10 +595,21 @@ pipeline {
                         | sed 's#-py3-none-any.whl$##')
                     echo "VCS_VERSION=$VCS_VERSION"
 
+                    # Expand the SPA tarball into dist/web_ui/gpfjs/
+                    # — the gpf-web conda recipe consumes that
+                    # directory as a `path:` source. See the master
+                    # Jenkinsfile's Conda packages stage for the
+                    # explanation; same logic here. --strip-components=1
+                    # drops the leading gpfjs/ prefix the tar carries.
+                    rm -rf dist/web_ui/gpfjs
+                    mkdir -p dist/web_ui/gpfjs
+                    tar -xzf dist/web_ui/gpfjs-spa.tar.gz \
+                        -C dist/web_ui/gpfjs --strip-components=1
+
                     mkdir -p dist/conda
                     DOCKER_USER="$(id -u):$(id -g)"
                     # web_api built LAST so a missing/malformed
-                    # dist/web_ui/gpfjs/ (required by its
+                    # dist/web_ui/gpfjs-spa.tar.gz (required by its
                     # recipe) doesn't abort core/federation/rest_client
                     # before they get a chance to be built. set -e in
                     # this script means a web_api conda failure still

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -413,19 +413,21 @@ pipeline {
             //     /wheels — pinning here means the release publishes
             //     exactly what passed CI, not whatever gain happens
             //     to be at when the release dispatches.
-            //   - dist/web_ui/gpfjs-spa.tar.gz: the conda-flavoured
-            //     Angular SPA tarball, fed into the gpf-web conda
-            //     recipe so the released gpf-web package bundles the
-            //     SPA. Pulled here (not rebuilt) so the released
-            //     conda's SPA is byte-identical to what master CI
-            //     tested with — same precedent as the gain wheel,
-            //     no GAIN_PIN_VERSION-equivalent override (the SPA
-            //     is part of the gpf repo itself).
+            //   - dist/web_ui/gpfjs/**: the conda-flavoured Angular
+            //     SPA dist tree, fed into the gpf-web conda recipe
+            //     so the released gpf-web package bundles the SPA.
+            //     Pulled here (not rebuilt) so the released conda's
+            //     SPA is byte-identical to what master CI tested
+            //     with — same precedent as the gain wheel, no
+            //     GAIN_PIN_VERSION-equivalent override (the SPA is
+            //     part of the gpf repo itself). Archived/fetched as
+            //     a directory tree rather than a tarball because
+            //     rattler-build auto-extracts .tar.gz path: sources.
             //
             // V2 override: if params.GAIN_PIN_VERSION is set, the
             // gain wheel comes from wheels.seqpipe.org/gain/
             // instead of upstream copyArtifacts. base-images.lock
-            // and the SPA tarball still come from upstream master
+            // and the SPA tree still come from upstream master
             // (the SPA is gpf-side, unrelated to gain). Trusted-
             // override semantics — the swapped wheel is NOT re-
             // tested; the operator certifies API compatibility
@@ -437,13 +439,13 @@ pipeline {
             steps {
                 script {
                     if (params.GAIN_PIN_VERSION) {
-                        // Pinned path: base-images.lock + SPA
-                        // tarball from upstream; gain wheel from
+                        // Pinned path: base-images.lock + SPA tree
+                        // from upstream; gain wheel from
                         // wheels.seqpipe.org/gain/.
                         copyArtifacts(
                             projectName: params.UPSTREAM_PROJECT,
                             selector: specific(env.UPSTREAM_BUILD_NUMBER),
-                            filter: 'dist/base-images.lock, dist/web_ui/gpfjs-spa.tar.gz',
+                            filter: 'dist/base-images.lock, dist/web_ui/gpfjs/**',
                             fingerprintArtifacts: true,
                         )
                         sh '''
@@ -463,7 +465,7 @@ pipeline {
                         copyArtifacts(
                             projectName: params.UPSTREAM_PROJECT,
                             selector: specific(env.UPSTREAM_BUILD_NUMBER),
-                            filter: 'dist/base-images.lock, dist/gain/*.whl, dist/web_ui/gpfjs-spa.tar.gz',
+                            filter: 'dist/base-images.lock, dist/gain/*.whl, dist/web_ui/gpfjs/**',
                             fingerprintArtifacts: true,
                         )
                     }
@@ -472,14 +474,16 @@ pipeline {
                     cat dist/base-images.lock
                     ls -la dist/gain/
                     test -n "$(ls dist/gain/gain_core-*.whl 2>/dev/null)"
-                    # SPA tarball is REQUIRED — gpf-web conda recipe
+                    # SPA tree is REQUIRED — gpf-web conda recipe
                     # will fail rattler-build's source-staging if it
                     # is missing, but fail loud here so the operator
                     # sees a clear "upstream master build did not
-                    # archive the SPA tarball" message instead of a
-                    # rattler-build internals trace later.
-                    ls -la dist/web_ui/
-                    test -f dist/web_ui/gpfjs-spa.tar.gz
+                    # archive the SPA dist tree" message instead of a
+                    # rattler-build internals trace later. Probing
+                    # index.html (the SPA shell) is sufficient since
+                    # the angular build always emits it.
+                    ls -la dist/web_ui/gpfjs/ 2>&1 | head -20
+                    test -f dist/web_ui/gpfjs/index.html
                 '''
                 // Surface the bundled gain version everywhere it
                 // matters: top-of-build log, Notify Zulip message,
@@ -595,7 +599,7 @@ pipeline {
                     mkdir -p dist/conda
                     DOCKER_USER="$(id -u):$(id -g)"
                     # web_api built LAST so a missing/malformed
-                    # dist/web_ui/gpfjs-spa.tar.gz (required by its
+                    # dist/web_ui/gpfjs/ (required by its
                     # recipe) doesn't abort core/federation/rest_client
                     # before they get a chance to be built. set -e in
                     # this script means a web_api conda failure still

--- a/README.md
+++ b/README.md
@@ -324,18 +324,21 @@ testing, run the three-step:
 #    recipe in this repo).
 cd web_api && uv build --package gpf-web --out-dir ../dist/web_api && cd ..
 
-# 2. Build the conda-flavoured SPA tarball. --base-href /
+# 2. Build the conda-flavoured SPA dist tree. --base-href /
 #    --deploy-url match the URL layout the Django gpfjs app
 #    expects (STATIC_URL='/static/', index served at
 #    /gpfjs/). environment.conda.ts is swapped in by
-#    angular.json's `conda` configuration.
+#    angular.json's `conda` configuration. Copy (don't tar)
+#    because rattler-build auto-extracts .tar.gz path: sources;
+#    directory path: sources are copied as-is, preserving the
+#    on-disk layout the recipe expects.
 cd web_ui
 npm ci
 npm run build -- --configuration conda \
     --base-href '/gpfjs/' \
     --deploy-url '/static/gpfjs/gpfjs/'
 mkdir -p ../dist/web_ui
-tar -czf ../dist/web_ui/gpfjs-spa.tar.gz -C dist gpfjs
+cp -r dist/gpfjs ../dist/web_ui/
 cd ..
 
 # 3. Build the conda package.
@@ -345,7 +348,7 @@ rattler-build build \
 ```
 
 The recipe in `web_api/conda-recipe/recipe.yaml` lists the
-SPA tarball as a required source; rattler-build fails fast
+SPA tree as a required source; rattler-build fails fast
 if step 2 was skipped. The other three recipes (`core`,
 `federation`, `rest_client`) don't need the SPA and can
 build standalone with just step 1 + 3.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,52 @@ To bypass the pre-commit hook when committing:
 git commit --no-verify
 ```
 
+### Conda packaging
+
+The `gpf-web` conda package bundles the Angular SPA so
+`conda install gpf-web && wgpf` serves a fully working UI in
+one process — handy for poking at newly imported studies
+without a full split-mode docker deployment. CI assembles
+the package automatically; to rebuild it locally for
+testing, run the three-step:
+
+```bash
+# 1. Build the gpf-web wheel (same as for any other conda
+#    recipe in this repo).
+cd web_api && uv build --package gpf-web --out-dir ../dist/web_api && cd ..
+
+# 2. Build the conda-flavoured SPA tarball. --base-href /
+#    --deploy-url match the URL layout the Django gpfjs app
+#    expects (STATIC_URL='/static/', index served at
+#    /gpfjs/). environment.conda.ts is swapped in by
+#    angular.json's `conda` configuration.
+cd web_ui
+npm ci
+npm run build -- --configuration conda \
+    --base-href '/gpfjs/' \
+    --deploy-url '/static/gpfjs/gpfjs/'
+mkdir -p ../dist/web_ui
+tar -czf ../dist/web_ui/gpfjs-spa.tar.gz -C dist gpfjs
+cd ..
+
+# 3. Build the conda package.
+rattler-build build \
+    --recipe web_api/conda-recipe/recipe.yaml \
+    --output-dir conda/web_api
+```
+
+The recipe in `web_api/conda-recipe/recipe.yaml` lists the
+SPA tarball as a required source; rattler-build fails fast
+if step 2 was skipped. The other three recipes (`core`,
+`federation`, `rest_client`) don't need the SPA and can
+build standalone with just step 1 + 3.
+
+The released wheel itself stays SPA-free — the bundle is
+conda-only. Production deploys consume the same wheel via
+`web_api/Dockerfile.production` and pair it with the
+apache-served `gpf-web-ui` image, so duplicating the SPA in
+the wheel would just inflate the production backend image.
+
 ## Common pitfalls
 
 - Prefer `uv run <cmd>` over activating the venv — works

--- a/README.md
+++ b/README.md
@@ -328,10 +328,12 @@ cd web_api && uv build --package gpf-web --out-dir ../dist/web_api && cd ..
 #    --deploy-url match the URL layout the Django gpfjs app
 #    expects (STATIC_URL='/static/', index served at
 #    /gpfjs/). environment.conda.ts is swapped in by
-#    angular.json's `conda` configuration. Copy (don't tar)
-#    because rattler-build auto-extracts .tar.gz path: sources;
-#    directory path: sources are copied as-is, preserving the
-#    on-disk layout the recipe expects.
+#    angular.json's `conda` configuration. For local builds
+#    we copy the dist tree directly; the recipe consumes it as
+#    a `path:` directory source. (CI archives the same tree as
+#    dist/web_ui/gpfjs-spa.tar.gz for a clean Jenkins artefact
+#    list and extracts it back in the Conda packages stage —
+#    locally there's no archival step, so cp is sufficient.)
 cd web_ui
 npm ci
 npm run build -- --configuration conda \

--- a/web_api/conda-recipe/recipe.yaml
+++ b/web_api/conda-recipe/recipe.yaml
@@ -1,3 +1,30 @@
+# rattler-build recipe for the gpf-web conda package.
+#
+# Bundles the Angular SPA into the installed Django app so
+# `conda install gpf-web && wgpf` serves a fully working UI in
+# one process — the rapid-experimentation flow for poking at
+# newly imported studies. Two inputs:
+#
+#   1. The gpf-web wheel built by the upstream `uv build`
+#      stage (../../dist/web_api/gpf_web-*.whl). The wheel
+#      itself stays SPA-free — production deploys consume the
+#      same wheel via web_api/Dockerfile.production and pair
+#      it with the apache-served frontend image; bundling the
+#      SPA into the wheel would duplicate it in that path.
+#
+#   2. The conda-flavoured SPA tarball
+#      (../../dist/web_ui/gpfjs-spa.tar.gz), produced by the
+#      web_ui Jenkins stage with
+#      `ng build --configuration conda
+#       --base-href '/gpfjs/'
+#       --deploy-url '/static/gpfjs/gpfjs/'`.
+#
+# REQUIRED — recipe fails fast if the SPA tarball is missing.
+# Locally, build it via the three-step in README.md ("Conda
+# packaging"). In CI it falls out of the master multibranch
+# Jenkinsfile's web_ui stage; gpf-release fetches it through
+# copyArtifacts from the upstream master build.
+
 schema_version: 1
 
 context:
@@ -11,6 +38,7 @@ package:
 source:
   - path: ../../dist/web_api
     use_gitignore: false
+  - path: ../../dist/web_ui/gpfjs-spa.tar.gz
   - path: ../../LICENSE
 
 build:
@@ -22,6 +50,24 @@ build:
       set -euo pipefail
       ls -la
       "$PYTHON" -m pip install --no-deps --no-build-isolation -vv ./*.whl
+
+      # Untar the SPA on top of the placeholder tree the wheel
+      # ships at <site-packages>/gpfjs/static/gpfjs/empty/.
+      # The gpfjs Django app installs as a top-level package
+      # (hatchling [tool.hatch.build.targets.wheel] packages
+      # strips the source-side gpf_web/ prefix), so the install
+      # path is just $SITE_PACKAGES/gpfjs/, NOT
+      # $SITE_PACKAGES/gpf_web/gpfjs/. The view in gpfjs/views.py
+      # probes finders.find("gpfjs/gpfjs/index.html") and falls
+      # back to the empty template only when nothing's there;
+      # the two trees coexist as siblings without collision.
+      # Assertion at the end converts a malformed tarball or
+      # wrong-prefix archive into a loud build failure.
+      SITE_PACKAGES=$("$PYTHON" -c 'import site; print(site.getsitepackages()[0])')
+      TARGET="$SITE_PACKAGES/gpfjs/static/gpfjs"
+      mkdir -p "$TARGET"
+      tar -xzf gpfjs-spa.tar.gz -C "$TARGET"
+      test -f "$TARGET/gpfjs/index.html"
 
 requirements:
   host:
@@ -43,6 +89,6 @@ requirements:
 
 about:
   homepage: https://github.com/iossifovlab/gpf
-  summary: GPF Web — Django REST API on top of GPF
+  summary: GPF Web — Django REST API on top of GPF (SPA bundled)
   license: MIT
   license_file: LICENSE

--- a/web_api/conda-recipe/recipe.yaml
+++ b/web_api/conda-recipe/recipe.yaml
@@ -12,14 +12,19 @@
 #      it with the apache-served frontend image; bundling the
 #      SPA into the wheel would duplicate it in that path.
 #
-#   2. The conda-flavoured SPA tarball
-#      (../../dist/web_ui/gpfjs-spa.tar.gz), produced by the
-#      web_ui Jenkins stage with
+#   2. The conda-flavoured SPA dist tree
+#      (../../dist/web_ui/gpfjs/), produced by the web_ui
+#      Jenkins stage with
 #      `ng build --configuration conda
 #       --base-href '/gpfjs/'
 #       --deploy-url '/static/gpfjs/gpfjs/'`.
+#      Plain directory (not tarball) because rattler-build
+#      auto-extracts .tar.gz path: sources but treats directory
+#      path: sources as contents-copied-as-is. target_directory
+#      isolates the SPA contents from the wheel + LICENSE sources
+#      that share the work dir root.
 #
-# REQUIRED — recipe fails fast if the SPA tarball is missing.
+# REQUIRED — recipe fails fast if the SPA tree is missing.
 # Locally, build it via the three-step in README.md ("Conda
 # packaging"). In CI it falls out of the master multibranch
 # Jenkinsfile's web_ui stage; gpf-release fetches it through
@@ -38,7 +43,8 @@ package:
 source:
   - path: ../../dist/web_api
     use_gitignore: false
-  - path: ../../dist/web_ui/gpfjs-spa.tar.gz
+  - path: ../../dist/web_ui/gpfjs
+    target_directory: gpfjs-spa-src
   - path: ../../LICENSE
 
 build:
@@ -51,7 +57,7 @@ build:
       ls -la
       "$PYTHON" -m pip install --no-deps --no-build-isolation -vv ./*.whl
 
-      # Untar the SPA on top of the placeholder tree the wheel
+      # Copy the SPA tree next to the placeholder tree the wheel
       # ships at <site-packages>/gpfjs/static/gpfjs/empty/.
       # The gpfjs Django app installs as a top-level package
       # (hatchling [tool.hatch.build.targets.wheel] packages
@@ -61,13 +67,13 @@ build:
       # probes finders.find("gpfjs/gpfjs/index.html") and falls
       # back to the empty template only when nothing's there;
       # the two trees coexist as siblings without collision.
-      # Assertion at the end converts a malformed tarball or
-      # wrong-prefix archive into a loud build failure.
+      # Assertion at the end converts a missing-source or
+      # broken-build into a loud build failure.
       SITE_PACKAGES=$("$PYTHON" -c 'import site; print(site.getsitepackages()[0])')
-      TARGET="$SITE_PACKAGES/gpfjs/static/gpfjs"
+      TARGET="$SITE_PACKAGES/gpfjs/static/gpfjs/gpfjs"
       mkdir -p "$TARGET"
-      tar -xzf gpfjs-spa.tar.gz -C "$TARGET"
-      test -f "$TARGET/gpfjs/index.html"
+      cp -r gpfjs-spa-src/. "$TARGET/"
+      test -f "$TARGET/index.html"
 
 requirements:
   host:

--- a/web_api/conda-recipe/recipe.yaml
+++ b/web_api/conda-recipe/recipe.yaml
@@ -22,13 +22,18 @@
 #      auto-extracts .tar.gz path: sources but treats directory
 #      path: sources as contents-copied-as-is. target_directory
 #      isolates the SPA contents from the wheel + LICENSE sources
-#      that share the work dir root.
+#      that share the work dir root. (CI archives this tree as a
+#      single .tar.gz for a clean Jenkins artefact list and
+#      extracts it back into this directory in the Conda packages
+#      stage before rattler-build runs; the recipe itself only
+#      ever sees the extracted directory.)
 #
 # REQUIRED — recipe fails fast if the SPA tree is missing.
 # Locally, build it via the three-step in README.md ("Conda
 # packaging"). In CI it falls out of the master multibranch
-# Jenkinsfile's web_ui stage; gpf-release fetches it through
-# copyArtifacts from the upstream master build.
+# Jenkinsfile's web_ui stage; gpf-release fetches the tarball
+# through copyArtifacts from the upstream master build and
+# extracts it before invoking rattler-build.
 
 schema_version: 1
 


### PR DESCRIPTION
## Summary

- Restores the legacy "conda install gpf-web && wgpf serves a working SPA" flow for rapid experimentation with newly imported studies. Bundle is **conda-only** — the wheel stays SPA-free because `web_api/Dockerfile.production` consumes the same wheel for split-mode production and duplicating the SPA would just inflate the backend image.
- `web_ui` Jenkins stage now builds the SPA with `--configuration conda --base-href '/gpfjs/' --deploy-url '/static/gpfjs/gpfjs/'` before lint+jest, tars it into `dist/web_ui/gpfjs-spa.tar.gz`, archived with `fingerprint:true`. The `gpf-web` conda recipe lists it as a required `source:` and untars into `<site-packages>/gpfjs/static/gpfjs/gpfjs/` (top-level `gpfjs/` — hatchling lifts each app to the wheel top level). Conda loop reordered `core federation rest_client web_api` so a SPA-side regression doesn't block the three SPA-independent artefacts.
- `Jenkinsfile.release` pulls the SPA tarball via `copyArtifacts` from the master CI build matching the tagged commit — same precedent as the gain wheel. No re-build; the released conda's SPA is byte-identical to what master CI tested with.

## Test plan

- [ ] Master CI runs green (lint-only UNSTABLE acceptable)
- [ ] `dist/web_ui/gpfjs-spa.tar.gz` appears in the master CI archived artifacts with `fingerprint:true`
- [ ] `dist/conda/gpf_web-*.conda` contains `gpfjs/static/gpfjs/gpfjs/index.html` (extract the .conda or install + `python -c "import gpfjs, os; print(os.listdir(os.path.dirname(gpfjs.__file__) + '/static/gpfjs/gpfjs/'))"`)
- [ ] Next `gpf-release` tag-build successfully pulls the SPA tarball via `Fetch upstream artefacts` and the released `gpf-web` conda includes the SPA
- [ ] Manual: `conda install gpf-web && wgpf` serves the SPA at `/` and `/gpfjs/` instead of the empty-fallback page

🤖 Generated with [Claude Code](https://claude.com/claude-code)