### PR TITLE
Fix pheno_import task-log race under pytest-xdist -n 5

### DIFF
--- a/core/gpf/pheno/pheno_import.py
+++ b/core/gpf/pheno/pheno_import.py
@@ -177,7 +177,14 @@ def pheno_cli_parser() -> argparse.ArgumentParser:
         metavar="<person column>",
     )
 
-    TaskGraphCli.add_arguments(parser, use_commands=False)
+    # default_task_status_dir=None: opt into None-as-sentinel so the
+    # default-resolution block in main() (see #869) can anchor the
+    # status dir under the import's work_dir. Without this override,
+    # TaskGraphCli supplies the literal "./.task-progress" default and
+    # the relative path resolves against the caller's CWD — which is
+    # the race-prone behaviour we are fixing.
+    TaskGraphCli.add_arguments(
+        parser, use_commands=False, default_task_status_dir=None)
 
     return parser
 
@@ -283,6 +290,20 @@ def main(argv: list[str] | None = None) -> int:
     try:
         import_config = transform_cli_args(args)
         gpf_instance = get_gpf_instance(import_config)
+        # Default the task graph status + log dirs to paths anchored
+        # under the import's work_dir when the caller didn't pass
+        # --task-status-dir / --task-log-dir explicitly. Mirrors the
+        # canonical entry point in import_tools.py:72-74. Without these
+        # defaults, gain's TaskGraphCli falls back to
+        # os.getcwd() + ".task-log", which (a) leaks state into the
+        # CWD and (b) makes parallel pytest-xdist workers race on the
+        # shared mkdir. See iossifovlab/gpf#869.
+        if args.task_status_dir is None:
+            args.task_status_dir = os.path.join(
+                import_config.work_dir, ".task-progress", import_config.id)
+        if args.task_log_dir is None:
+            args.task_log_dir = os.path.join(
+                import_config.work_dir, ".task-log", import_config.id)
         import_pheno_data(import_config, gpf_instance, args)
     except KeyboardInterrupt:
         return 0

--- a/core/gpf/utils/testing.py
+++ b/core/gpf/utils/testing.py
@@ -680,6 +680,7 @@ f1.4     s4       dad4  mom4  2   1      sib  unaffected
         "--person-column", "personId",
         "-o", str(instance_path / "pheno" / "study_1_pheno"),
         "--task-status-dir", str(pheno_path / "status"),
+        "--task-log-dir", str(pheno_path / "task-log"),
     ])
 
 

--- a/core/tests/small/pheno/test_pheno_import.py
+++ b/core/tests/small/pheno/test_pheno_import.py
@@ -399,3 +399,66 @@ def test_import_generates_necessary_pedigree_columns(
         "status",
         "sex",
     })
+
+
+def test_main_defaults_task_log_dir_under_work_dir(
+    import_data_fixture: tuple[Path, Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Regression test for #869.
+
+    When ``--task-log-dir`` is not passed, ``main()`` must anchor
+    the log dir under ``work_dir`` (== ``-o``), not under the
+    current working directory. Without this, parallel
+    pytest-xdist workers race on a shared CWD-rooted ``.task-log``.
+    """
+    ped_path, instruments_dir, out_dir, tasks_dir = import_data_fixture
+    cwd_isolated = tmp_path_factory.mktemp("cwd_isolated")
+    monkeypatch.chdir(cwd_isolated)
+
+    argv = [
+        "-p", str(ped_path.absolute()),
+        "-i", str(instruments_dir.absolute()),
+        "-j", "1",
+        "-o", str(out_dir.absolute()),
+        "-d", str(tasks_dir.absolute()),
+        "--pheno-id", "test",
+    ]
+    main(argv)
+
+    assert not (cwd_isolated / ".task-log").exists()
+    assert (out_dir / ".task-log" / "test").exists()
+
+
+def test_main_defaults_task_status_dir_under_work_dir(
+    import_data_fixture: tuple[Path, Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Regression test for #869, sibling of the task-log default.
+
+    When ``-d``/``--task-status-dir`` is not passed, ``main()``
+    must anchor the status dir under ``work_dir``, not under CWD.
+    """
+    ped_path, instruments_dir, out_dir, _ = import_data_fixture
+    cwd_isolated = tmp_path_factory.mktemp("cwd_isolated_status")
+    monkeypatch.chdir(cwd_isolated)
+
+    argv = [
+        "-p", str(ped_path.absolute()),
+        "-i", str(instruments_dir.absolute()),
+        "-j", "1",
+        "-o", str(out_dir.absolute()),
+        "--pheno-id", "test",
+    ]
+    main(argv)
+
+    # The bug is "task-progress leaks into CWD". Gain only
+    # materialises .task-progress on disk when a task actually writes
+    # status (unlike .task-log, which ensure_log_dir creates eagerly),
+    # so asserting on its work_dir-side presence would test gain's
+    # internals rather than the regression. The negative-only check
+    # is enough: as long as the dir is not CWD-rooted, the race
+    # surface is gone.
+    assert not (cwd_isolated / ".task-progress").exists()

--- a/web_api/gpf_web/utils/testing.py
+++ b/web_api/gpf_web/utils/testing.py
@@ -865,6 +865,7 @@ s4,121.0199895975403,39.74107684421966,77.32212831797972,51.37116746952451,36.55
         "--person-column", "personId",
         "-o", str(instance_path / "pheno" / "study_1_pheno"),
         "--task-status-dir", str(pheno_path / "status"),
+        "--task-log-dir", str(pheno_path / "task-log"),
         "--regression", str(pheno_path / "regressions.yaml"),
     ])
     build_browser([
@@ -873,6 +874,7 @@ s4,121.0199895975403,39.74107684421966,77.32212831797972,51.37116746952451,36.55
         "-j", "1",
         "--force",
         "--task-status-dir", str(pheno_path / "status"),
+        "--task-log-dir", str(pheno_path / "task-log"),
     ])
 
 


### PR DESCRIPTION
## Summary

- `gpf.pheno.pheno_import:main` (deprecated CLI entry point, used by both `core/gpf/utils/testing.py` and `web_api/gpf_web/utils/testing.py` `_study_1_pheno` helpers) left `args.task_log_dir = None` when the flag was absent. Gain's `task_graph.logging.ensure_log_dir` then falls back to `os.path.join(os.getcwd(), ".task-log")` — a path shared by all pytest-xdist workers because the docker WORKDIR is `/workspace/web_api`. `fsspec`'s LocalFileSystem.mkdir silently drops the `exists_ok` kwarg, so the check-then-mkdir in `ensure_log_dir` has a real TOCTOU window. With `-n 5`, four workers race and crash with `FileExistsError`, taking 200+ tests with them. Branch CI #1 of #868 hit this; master happened to win the race.
- `pheno_import.py:main` now defaults `task_status_dir` and `task_log_dir` from `import_config.work_dir`, mirroring the canonical `import_tools.py:72-74`. Also passes `default_task_status_dir=None` to `TaskGraphCli.add_arguments` so None is actually reachable as the argparse default (without that, CLI default is the literal `"./.task-progress"` and the resolution block never fires).
- Both `_study_1_pheno` helpers + the `build_browser` call in the web_api one now pass `--task-log-dir str(pheno_path / "task-log")` next to the existing `--task-status-dir`. Belt-and-braces: the production default in `pheno_import.py:main` already anchors the path under `work_dir`, so the race is gone even without these explicit flags; keeping them explicit makes the convention "wherever `--task-status-dir` is passed, `--task-log-dir` is too" enforceable in future review.

## Test plan

- [x] `cd core && pytest tests/small/pheno/ -n 5` → 220 passed locally, no race.
- [x] `cd web_api && pytest gpf_web/common_reports_api/tests/ -n 5` → 22/22 passed locally (the first cluster of 218 CI failures).
- [ ] Branch CI runs green on this PR.
- [ ] After merge: rebase #868 onto new master, expect that PR's CI green.

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)