### PR TITLE
docs-e2e: drop unsupported disableConcurrentBuilds(abortPrevious)

### DIFF
--- a/docs_e2e/jenkins-jobs/docs_e2e.groovy
+++ b/docs_e2e/jenkins-jobs/docs_e2e.groovy
@@ -41,11 +41,15 @@ pipelineJob('gpf-docs-e2e') {
         )
     }
 
-    properties {
-        // Branch builds may queue while master is mid-run. Build
-        // discarder is set in the Jenkinsfile (numToKeepStr: 20).
-        disableConcurrentBuilds(abortPrevious: false)
-    }
+    // No properties{} block — matches the sibling DSLs
+    // (web_e2e/jenkins-jobs/e2e.groovy etc.). The
+    // disableConcurrentBuilds(abortPrevious: false) form added here
+    // initially is incompatible with this Jenkins's jobDsl version
+    // (it does not accept the abortPrevious arg). Per-agent
+    // serialisation that actually matters happens via the lock()
+    // around the Run-pytest stage in Jenkinsfile.docs-e2e — that's
+    // the meaningful concurrency guard. The buildDiscarder
+    // (numToKeepStr: 20) lives on the Jenkinsfile's options block.
 
     definition {
         cpsScm {


### PR DESCRIPTION
Hot-fix 2 for master Apply Job DSL — master is still red after the filename rename in #885.

## What broke

Master build [number 5786](https://nemo.seqpipe.org/job/iossifovlab/job/gpf/job/master/5786/) fails at `Apply Job DSL`:

```
ERROR: (docs_e2e.groovy, line 47) No signature of method:
  javaposse.jobdsl.dsl.helpers.properties.PropertiesContext
      .disableConcurrentBuilds()
  is applicable for argument types: (java.util.LinkedHashMap)
  values: [[abortPrevious:false]]
```

The `disableConcurrentBuilds(abortPrevious: false)` form I used was added in a newer jobDsl plugin version than this Jenkins runs.

## Fix

Drop the `properties{}` block. The sibling DSLs (`web_e2e/jenkins-jobs/e2e.groovy`, `jenkins-jobs/nightly.groovy`, `jenkins-jobs/release.groovy`) all omit it — that's the convention.

The meaningful concurrency guard is the per-agent `lock()` around the Run-pytest stage in `Jenkinsfile.docs-e2e`. Allowing distinct agents to run docs-e2e in parallel is fine — each container has its own port and gpf env prefix. `buildDiscarder` (numToKeepStr: 20) lives on the Jenkinsfile's `options` block, not here, so removing `properties{}` doesn't lose it.

## Test plan

- [ ] Merge → next master build passes `Apply Job DSL` (no jobDsl error).
- [ ] `gpf-docs-e2e` pipelineJob materializes on the Jenkins controller.
- [ ] `Trigger docs-e2e` dispatches the first real `gpf-docs-e2e` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)