### PR TITLE
docs-e2e: fix conda artefact glob (gpf_web → gpf-web)

### DIFF
--- a/docs_e2e/Jenkinsfile.docs-e2e
+++ b/docs_e2e/Jenkinsfile.docs-e2e
@@ -164,8 +164,14 @@ pipeline {
                 }
                 sh '''
                     ls -la dist/conda/
-                    test -n "$(ls dist/conda/gpf_web-*.conda 2>/dev/null)" \
-                        || { echo "ERROR: no gpf_web-*.conda in dist/conda/" >&2; exit 1; }
+                    # The conda package name is `gpf-web` (dash; per
+                    # web_api/conda-recipe/recipe.yaml). The Python
+                    # module is `gpf_web` (underscore). Conda
+                    # normalizes between the two for `mamba install`,
+                    # but the on-disk filename is always the dashed
+                    # form.
+                    test -n "$(ls dist/conda/gpf-web-*.conda 2>/dev/null)" \
+                        || { echo "ERROR: no gpf-web-*.conda in dist/conda/" >&2; exit 1; }
                 '''
             }
         }

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -69,12 +69,17 @@ def conda_channel():
             f"DOCS_E2E_CHANNEL={path} does not exist or is not a "
             f"directory. The Jenkinsfile copyArtifacts step should "
             f"populate dist/conda/; for local runs, point this at "
-            f"a directory of gpf_web-*.conda files.",
+            f"a directory of gpf-web-*.conda files.",
             pytrace=False,
         )
-    if not any(path.glob("gpf_web-*.conda")):
+    # The conda package name (per web_api/conda-recipe/recipe.yaml
+    # `name: gpf-web`) uses a dash. The Python module name
+    # `gpf_web` uses an underscore — conda normalizes between the
+    # two so `mamba install gpf_web` resolves to the dash-named
+    # package, but the on-disk artefact is always `gpf-web-*.conda`.
+    if not any(path.glob("gpf-web-*.conda")):
         pytest.fail(
-            f"No gpf_web-*.conda found in {path}. The freshly-built "
+            f"No gpf-web-*.conda found in {path}. The freshly-built "
             f"conda artefact this suite is supposed to test is "
             f"missing.",
             pytrace=False,


### PR DESCRIPTION
Hot-fix 3 for docs-e2e. The pipeline is now seeded and running, but the first two `gpf-docs-e2e` runs both fail fast at *Copy conda artefacts*:

```
++ ls 'dist/conda/gpf_web-*.conda'
+ test -n ''
+ echo 'ERROR: no gpf_web-*.conda in dist/conda/'
+ exit 1
```

## Diagnosis

`web_api/conda-recipe/recipe.yaml` declares `name: gpf-web` (dash), so the on-disk artefact is `gpf-web-2026.5.0.post1.dev40+g80f5ecd38.d20260527-pyh4616a5c_0.conda`. My Jenkinsfile + conftest globbed for `gpf_web-*.conda` (underscore — the Python *module* name) and matched nothing.

Conda normalizes between dash and underscore for command-line install (`mamba install gpf_web` works against the dash-named package), so the install step itself is fine — but a literal filename glob has to match the dashed on-disk name.

## Fix

| File | Change |
|---|---|
| `docs_e2e/Jenkinsfile.docs-e2e` (Copy conda artefacts) | `gpf_web-*.conda` → `gpf-web-*.conda` |
| `docs_e2e/conftest.py` (conda_channel fixture) | `path.glob("gpf_web-*.conda")` → `path.glob("gpf-web-*.conda")` |

Both spots now have a comment explaining the name-vs-module asymmetry so the next person doesn't trip.

## Test plan

- [ ] Merge → next master build triggers `gpf-docs-e2e` build 3.
- [ ] Build 3 should pass Copy conda artefacts, then Build driver image, then start the long Run pytest stage (~15 min cold for hg38 demand-pull).
- [ ] Either the suite goes green (no strict-mode prose drift) or it fails per-test with the RST file:line + triage hint — both are useful outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)