### PR TITLE
docs-e2e: install conda-index in base env (fixes ModuleNotFoundError: conda)

### DIFF
--- a/docs_e2e/Dockerfile
+++ b/docs_e2e/Dockerfile
@@ -35,6 +35,20 @@ RUN apt-get update \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# conda-index in the BASE env. The upstream gpf master archive
+# ships `dist/conda/*.conda` as a flat directory of artefacts,
+# not as a proper conda channel layout. mamba cannot install from
+# it as `-c file://...` without `noarch/repodata.json`. The
+# conftest's `conda_channel` fixture invokes
+# `/opt/conda/bin/python -m conda_index` (BASE env's python) to
+# build that index in a tempdir before the install runs.
+#
+# conda-index has a runtime dep on the `conda` Python module —
+# easier to host it in the base env where conda already lives
+# than to pull conda into the driver env.
+RUN mamba install -y -n base -c conda-forge conda-index \
+    && mamba clean -afy
+
 # Driver env. python-version 3.12 matches gpf-monorepo's
 # requires-python so subprocess invocations of gpf-shipped CLIs
 # from this env don't hit a Python-version mismatch (they run
@@ -46,15 +60,7 @@ RUN mamba create -y -n driver python=3.12 \
         pytest-timeout \
         httpx \
         pyyaml \
-        conda-index \
     && mamba clean -afy
-
-# conda-index above: the upstream gpf master archive ships
-# `dist/conda/*.conda` as a flat directory of artefacts, not as a
-# proper conda channel layout. mamba cannot install from it as
-# `-c file://...` without `noarch/repodata.json`. The conftest's
-# `conda_channel` fixture uses `python -m conda_index` to build
-# that index in a tempdir before the install runs.
 
 # The Jenkinsfile mounts the gpf workspace at /workspace and
 # invokes pytest from there. Working dir set here so an ad-hoc

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -113,13 +113,20 @@ def conda_channel(tmp_path_factory):
             # Cross-filesystem or hardlink not permitted; fall back.
             shutil.copy2(conda_file, target)
 
+    # Invoke conda_index via the BASE env's python — that env has
+    # both `conda_index` (installed via the Dockerfile's
+    # `mamba install -n base conda-index`) and the `conda` python
+    # module conda_index depends on at runtime. The driver env's
+    # python (which is the one running pytest right now) has
+    # neither; the explicit absolute path is the cleanest cross-env
+    # invocation.
     result = _run(
-        ["python", "-m", "conda_index", str(channel)],
+        ["/opt/conda/bin/python", "-m", "conda_index", str(channel)],
         timeout=300,
     )
     if result.returncode != 0:
         pytest.fail(
-            "python -m conda_index failed:\n"
+            "conda_index failed:\n"
             f"  stdout: {result.stdout.decode(errors='replace')[-2000:]}\n"
             f"  stderr: {result.stderr.decode(errors='replace')[-2000:]}",
             pytrace=False,


### PR DESCRIPTION
Hot-fix 5. gpf-docs-e2e build 6 cleared the conda glob (#887) and the driver image, ran 14 unit tests green, then failed at the new `conda_index` invocation:

```
File "/opt/conda/envs/driver/lib/python3.12/site-packages/
     conda_index/index/__init__.py", line 23, in <module>
  from conda.models.version import VersionOrder
ModuleNotFoundError: No module named 'conda'
```

## Diagnosis

`conda-index` (pulled via pip into the driver env in #888) has a runtime dep on the `conda` Python module, which the minimal driver env doesn't have. Pulling `conda` itself into the driver env via pip isn't really a thing — conda is conda-installed.

## Fix

- Install `conda-index` in the BASE env (where `conda` already lives — it IS the miniforge3 installation), via `mamba install -y -n base -c conda-forge conda-index`.
- Drop `conda-index` from the driver env's pip install.
- In the `conda_channel` fixture, invoke via the base python's absolute path: `/opt/conda/bin/python -m conda_index <channel>`.

That sidesteps the missing-`conda` issue and keeps the driver env minimal (only `pytest` + `httpx` + `pyyaml`). The conftest runs inside the driver env so a bare `python` would resolve there; the explicit `/opt/conda/bin/python` is the cleanest cross-env invocation.

## Test plan

- [ ] Merge → master rebuild → gpf-docs-e2e build 7 should pass `python -m conda_index` and proceed into the actual install (cold path then exercises hg38 demand-pull + the import flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)