### PR TITLE
docs-e2e: make the suite run green (gpf-web name, mamba 2.x, readiness, response shape)

### DIFF
--- a/docs/source/administration/getting_started/getting_started.rst
+++ b/docs/source/administration/getting_started/getting_started.rst
@@ -39,7 +39,7 @@ To use this environment, you need to activate it using the following command:
 
     mamba activate gpf
 
-Afterwards, install the `gpf_web` conda package:
+Afterwards, install the `gpf-web` conda package:
 
 .. code-block:: bash
 
@@ -47,7 +47,7 @@ Afterwards, install the `gpf_web` conda package:
         -c conda-forge \
         -c bioconda \
         -c iossifovlab \
-        gpf_web
+        gpf-web
 
 This command is going to install GPF and all of its dependencies.
 

--- a/docs_e2e/Dockerfile
+++ b/docs_e2e/Dockerfile
@@ -69,5 +69,10 @@ WORKDIR /workspace
 
 # Default cmd is the canonical local-run invocation. CI overrides
 # with explicit pytest args.
-CMD ["mamba", "run", "--no-capture-output", "-n", "driver", \
+# Note: no `--no-capture-output` — mamba 2.x (shipped in the
+# current condaforge/miniforge3 base) removed that flag (streaming
+# is the default now) and chokes on it with
+# `exec: --: invalid option`. Plain `mamba run -n driver` streams
+# fine on both mamba 1.x and 2.x.
+CMD ["mamba", "run", "-n", "driver", \
      "pytest", "-v", "docs_e2e/"]

--- a/docs_e2e/Jenkinsfile.docs-e2e
+++ b/docs_e2e/Jenkinsfile.docs-e2e
@@ -217,7 +217,7 @@ pipeline {
                                 -e DOCS_E2E_GRR_CACHE=/grr-cache \\
                                 -w /workspace \\
                                 "\$DRIVER_IMAGE" \\
-                                mamba run --no-capture-output -n driver \\
+                                mamba run -n driver \\
                                     pytest -v ${pytest_k} \\
                                         --junitxml=/workspace/reports/docs_e2e/pytest.xml \\
                                         docs_e2e/

--- a/docs_e2e/README.md
+++ b/docs_e2e/README.md
@@ -2,7 +2,7 @@
 
 Guide-accuracy regression for the [GPF Getting Started
 Guide][published-guide]. Drives the guide's setup → import → query
-flow as written, against the freshly-built `gpf_web` conda
+flow as written, against the freshly-built `gpf-web` conda
 package, and asserts each prose claim. Failures cite the RST
 file:line so drift surfaces directly to the line that needs
 updating (or to the regression that broke the claim).
@@ -21,11 +21,11 @@ Per build:
 1. **Test driver image** — `docs_e2e/Dockerfile` (base:
    `condaforge/miniforge3`) starts with `pytest + httpx` in a
    tiny `driver` mamba env.
-2. **Install** — `install_gpf_web` conftest fixture creates a
-   *fresh* gpf_web env from this build's `dist/conda/*.conda`
+2. **Install** — the `gpf_env_prefix` conftest fixture creates a
+   *fresh* gpf-web env from this build's `dist/conda/*.conda`
    artefacts (mounted at `/workspace/dist/conda`), layered on
    the upstream `iossifovlab`/`bioconda`/`conda-forge` channels.
-   Mirrors what `mamba install gpf_web` does for an end user.
+   Mirrors what `mamba install gpf-web` does for an end user.
 3. **Clone demo data** — `getting_started_clone` fixture
    shallow-clones `iossifovlab/gpf-getting-started` master.
    Same source `docs/build_docs.sh` uses.
@@ -58,7 +58,7 @@ Anything else is drift, not infrastructure. Fix the guide.
 ## Local iteration
 
 You need the same artefacts CI uses: a directory of
-`gpf_web-*.conda` files. Easiest path is to copy them from a
+`gpf-web-*.conda` files. Easiest path is to copy them from a
 recent green CI build. Then:
 
 ```bash
@@ -119,7 +119,7 @@ docs_e2e/
 ├── Jenkinsfile.docs-e2e     # downstream pipeline
 ├── jenkins-jobs/
 │   └── docs_e2e.groovy      # pipelineJob DSL, seeded by main gpf Jenkinsfile
-├── conftest.py              # fixtures: install_gpf_web, getting_started_clone, …
+├── conftest.py              # fixtures: conda_channel, gpf_env_prefix, getting_started_clone, prepared_instance, wgpf_server
 ├── guide_assertions.py      # deep module — uniform failure-message helpers
 ├── test_guide_assertions.py # unit tests for the module (pure Python)
 ├── __init__.py

--- a/docs_e2e/README.md
+++ b/docs_e2e/README.md
@@ -82,7 +82,7 @@ docker run --rm \
     -e DOCS_E2E_CHANNEL=/workspace/dist/conda \
     -e DOCS_E2E_GRR_CACHE=/grr-cache \
     gpf-docs-e2e:dev \
-    mamba run --no-capture-output -n driver \
+    mamba run -n driver \
         pytest -v docs_e2e/tests/test_main_body.py::TestDenovoImport
 ```
 

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -1,6 +1,6 @@
 """Session fixtures for docs_e2e/tests/.
 
-Builds the system-under-test once per pytest run: install gpf_web
+Builds the system-under-test once per pytest run: install gpf-web
 from the local conda channel, clone gpf-getting-started, import
 the guide's demo data, configure the example dataset, then start
 ``wgpf run`` in a background subprocess and yield an httpx client.
@@ -14,7 +14,7 @@ transparent to the user's command path.
 Run requirements (set by the docs-e2e Jenkinsfile, or by the
 local-iteration command in docs_e2e/README.md):
 
-* ``DOCS_E2E_CHANNEL`` — directory of ``gpf_web-*.conda`` files.
+* ``DOCS_E2E_CHANNEL`` — directory of ``gpf-web-*.conda`` files.
 * ``DOCS_E2E_GRR_CACHE`` — directory persisted as the GRR cache.
 """
 
@@ -89,11 +89,12 @@ def conda_channel(tmp_path_factory):
             f"a directory of gpf-web-*.conda files.",
             pytrace=False,
         )
-    # The conda package name (per web_api/conda-recipe/recipe.yaml
-    # `name: gpf-web`) uses a dash. The Python module name
-    # `gpf_web` uses an underscore — conda normalizes between the
-    # two so `mamba install gpf_web` resolves to the dash-named
-    # package, but the on-disk artefact is always `gpf-web-*.conda`.
+    # The conda package is named `gpf-web` (dash) — per
+    # web_api/conda-recipe/recipe.yaml. Both the `mamba install`
+    # target and the on-disk artefact use the dash form; the guide
+    # is kept in sync (it says `mamba install gpf-web`). The Python
+    # *module* inside the package is still `gpf_web` (underscore),
+    # but that name never appears on a conda command line.
     if not any(src.glob("gpf-web-*.conda")):
         pytest.fail(
             f"No gpf-web-*.conda found in {src}. The freshly-built "
@@ -160,12 +161,12 @@ def gpf_env_prefix(tmp_path_factory, conda_channel):
         "-c", "iossifovlab",
         "-c", "bioconda",
         "-c", "conda-forge",
-        "gpf_web",
+        "gpf-web",
     ]
     result = _run(cmd, timeout=_INSTALL_TIMEOUT)
     if result.returncode != 0:
         pytest.fail(
-            "mamba create gpf_web failed:\n"
+            "mamba create gpf-web failed:\n"
             f"  stdout: {result.stdout.decode(errors='replace')[-4000:]}\n"
             f"  stderr: {result.stderr.decode(errors='replace')[-4000:]}",
             pytrace=False,

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -153,7 +153,12 @@ def grr_cache_dir():
 def gpf_env_prefix(tmp_path_factory, conda_channel):
     """Create a fresh gpf-web conda env from the local channel +
     the upstream channels the guide tells users to add."""
-    prefix = tmp_path_factory.mktemp("gpf-env-prefix", numbered=False)
+    # mamba create --prefix refuses to write into a directory that
+    # already exists as a non-conda folder ("Non-conda folder
+    # exists at prefix"). tmp_path_factory.mktemp() *creates* the
+    # dir, so point --prefix at a not-yet-existing subpath of it
+    # and let mamba create the leaf.
+    prefix = tmp_path_factory.mktemp("gpf-env", numbered=False) / "prefix"
     cmd = [
         "mamba", "create", "-y",
         "--prefix", str(prefix),
@@ -308,8 +313,19 @@ def wgpf_server(prepared_instance, gpf_env):
     )
     client = httpx.Client(base_url=base_url, timeout=60.0)
 
-    # Poll for readiness. /api/v3/instance is a cheap, public
-    # endpoint that exists once the Django app starts answering.
+    # Poll for readiness against /api/v3/datasets/ — the same
+    # endpoint the production compose healthcheck uses
+    # (web_infra/compose-jenkins-split.yaml). It returns 200 only
+    # once WGPFInstance.studies_db is fully populated, i.e. after
+    # the instance has finished building (loading reference genome
+    # + gene models from the GRR, which takes several seconds).
+    #
+    # Earlier this polled /api/v3/instance and accepted any
+    # status < 500 — but /api/v3/instance is NOT a route (it 404s),
+    # and 404 < 500 made the fixture report "ready" the instant
+    # Django started answering, long before studies loaded. Tests
+    # then saw an empty /datasets/visible. Require == 200 on
+    # /datasets/ so we wait for the instance, not just for Django.
     deadline = time.monotonic() + _WGPF_READY_TIMEOUT
     last_err = None
     while time.monotonic() < deadline:
@@ -321,8 +337,8 @@ def wgpf_server(prepared_instance, gpf_env):
                 pytrace=False,
             )
         try:
-            r = client.get("/api/v3/instance")
-            if r.status_code < 500:
+            r = client.get("/api/v3/datasets/")
+            if r.status_code == 200:
                 break
             last_err = f"HTTP {r.status_code}"
         except httpx.RequestError as exc:

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -102,7 +102,16 @@ def assert_dataset_visible(response, dataset_id, *, rst_ref, expectation):
             ),
         ))
     data = response.json()
-    visible_ids = [item.get("id") for item in data if isinstance(item, dict)]
+    # /api/v3/datasets/visible returns a JSON list of dataset-id
+    # *strings* (e.g. ["denovo_example", "vcf_example"]). Tolerate
+    # a list of {"id": ...} dicts too, in case a caller passes a
+    # response from a richer datasets endpoint.
+    visible_ids = [
+        item if isinstance(item, str)
+        else item.get("id") if isinstance(item, dict)
+        else None
+        for item in data
+    ]
     if dataset_id in visible_ids:
         return
     visible_list = ", ".join(repr(i) for i in visible_ids) or "(none)"

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -162,6 +162,21 @@ class TestAssertFileCreated:
 
 class TestAssertDatasetVisible:
     def test_passes_when_dataset_id_present(self):
+        # /api/v3/datasets/visible returns a list of dataset-id
+        # STRINGS — this is the real on-the-wire shape.
+        resp = _FakeResponse(
+            200,
+            json_body=["denovo_example", "vcf_example"],
+        )
+        assert_dataset_visible(
+            resp, "denovo_example",
+            rst_ref="getting_started.rst:213",
+            expectation="home page lists denovo_example",
+        )
+
+    def test_passes_when_response_is_list_of_dicts(self):
+        # Tolerate a richer {"id": ...} shape too, for callers that
+        # pass a response from a different datasets endpoint.
         resp = _FakeResponse(
             200,
             json_body=[
@@ -178,7 +193,7 @@ class TestAssertDatasetVisible:
     def test_raises_when_dataset_id_missing(self):
         resp = _FakeResponse(
             200,
-            json_body=[{"id": "vcf_example", "name": "VCF example"}],
+            json_body=["vcf_example"],
         )
         with pytest.raises(AssertionError) as exc_info:
             assert_dataset_visible(


### PR DESCRIPTION
Makes the `gpf-docs-e2e` suite actually pass end-to-end. **Validated locally — 25 passed** — by reproducing the full pipeline against the real `dev42` conda artefacts (downloaded from master CI), which let me find and fix these in minutes instead of one ~20-min CI round-trip each.

## Fixes

1. **gpf-web (dash) install target + guide prose** — the conda artefact is `gpf-web`; the guide said `mamba install gpf_web`. Updated `getting_started.rst`, `conftest.py`, and the README. (First strict-mode guide-drift fix.)

2. **mamba 2.x dropped `--no-capture-output`** — the current `condaforge/miniforge3` base ships mamba 2.0.5, where the flag is gone (streaming is default) and its presence aborts with `exec: --: invalid option`. Removed from the Dockerfile CMD, the Jenkinsfile Run-pytest stage, and the README. (CI build 6 only worked because its cached base had mamba 1.x.)

3. **`mamba create --prefix` into a pre-existing dir** — `tmp_path_factory.mktemp()` pre-creates the dir, so mamba aborted with "Non-conda folder exists at prefix". Point `--prefix` at a not-yet-existing subpath.

4. **Wrong wgpf readiness probe** — it polled `/api/v3/instance` (not a real route — 404s) and accepted any `status < 500`, so a 404 marked the server "ready" before the GPF instance finished loading studies. Now polls `/api/v3/datasets/` for `== 200`, matching the production compose healthcheck (that route requires `WGPFInstance.studies_db` populated).

5. **`assert_dataset_visible` parsed the wrong shape** — `/api/v3/datasets/visible` returns a list of dataset-id **strings**, not `{"id": ...}` dicts. The helper extracted nothing and every visibility assertion failed with "(none)". Now handles strings (tolerates dicts); the unit test had seeded fiction — corrected + a list-of-strings case added.

## Local reproduction (for the record)

```bash
# 4 latest conda artefacts pulled from master CI into dist/conda/
docker build -f docs_e2e/Dockerfile -t gpf-docs-e2e-driver:local docs_e2e/
docker run --rm -v "$PWD:/workspace" -v gpf-grr-cache:/grr-cache \
    -e DOCS_E2E_CHANNEL=/workspace/dist/conda -e DOCS_E2E_GRR_CACHE=/grr-cache \
    gpf-docs-e2e-driver:local \
    mamba run -n driver pytest -v docs_e2e/
# => 25 passed
```

## Test plan

- [x] Local full-suite run: **25 passed** (15 unit + 10 integration) against dev42 artefacts, warm GRR cache.
- [ ] Merge (with #891 conda-cleanup) → next master build's `gpf-docs-e2e` should go green for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)