### PR TITLE
Jenkinsfile: stop accumulating stale conda packages in dist/conda/

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -883,6 +883,22 @@ pipeline {
                             # fails the stage — we just stop blocking the other
                             # three artefacts on a SPA-side regression.
                             for proj in core federation rest_client web_api; do
+                                # Wipe the rattler-build output dir for this
+                                # project first. `conda/` is NOT under `dist/`,
+                                # so the Prepare workspace `rm -rf dist` does
+                                # NOT clear it — on a reused agent workspace,
+                                # conda/$proj/noarch/ otherwise accumulates one
+                                # .conda per master build forever, and the `cp`
+                                # below copies that whole history into the
+                                # freshly-made dist/conda/. (Observed on
+                                # master #5791: ~25 stale versions per package
+                                # dating back ~18 days.) Wiping here keeps
+                                # dist/conda/ holding ONLY this build's
+                                # freshly-built packages — which is what the
+                                # comment on the cp already promised, and what
+                                # downstream consumers (gpf-release,
+                                # gpf-docs-e2e) assume.
+                                rm -rf conda/$proj
                                 mkdir -p conda/$proj
                                 docker run --rm \
                                     --user "$DOCKER_USER" \


### PR DESCRIPTION
## Background

The Conda packages stage builds each project with `rattler-build … --output-dir conda/$proj`, then `cp conda/$proj/noarch/*.conda dist/conda/`. But `conda/` lives **outside** `dist/`, so the Prepare workspace `rm -rf dist` doesn't clear it. On a reused agent workspace, `conda/$proj/noarch/` accumulates one `.conda` per master build forever, and the `cp` copies that whole history into the freshly-made `dist/conda/`.

Observed on [master 5791](https://nemo.seqpipe.org/job/iossifovlab/job/gpf/job/master/5791/artifact/dist/conda/): `dist/conda/` carried ~25 versions each of `gpf-core` / `gpf-federation` / `gpf-rest-client` / `gpf-web`, dating back to `dev7295` (2026-05-09, ~18 days). Only the latest (`dev42+g140cb7097`) is that build's. The wheel dirs (`dist/core/` etc.) are clean because `uv build --out-dir dist/...` writes under `dist/`, which *is* wiped.

Surfaced while wiring up `gpf-docs-e2e`, whose `copyArtifacts dist/conda/*.conda` pulls the entire pile (the suite copes by indexing + letting the solver pick the highest version, but the archive bloat is the real problem).

## Fix

`rm -rf conda/$proj` at the top of the build loop, before `mkdir` + `rattler-build`. Each build's output dir starts empty, so `dist/conda/` ends up holding only this build's freshly-built packages — exactly what the existing `cp` comment already promised ("dist/conda/ stays clean and holds only the published packages").

Chose the loop-level wipe over adding `conda` to Prepare workspace's `rm` so the cleanup survives a Jenkins "restart from stage" of just the Conda packages stage.

## Impact

- Smaller archives; faster `archiveArtifacts` + downstream `copyArtifacts`.
- **gpf-release**: its `Fetch upstream artefacts` copies `dist/conda/*.conda` from the tagged master build — today it would pull ~25 stale versions alongside the intended one. After this fix it gets exactly the tagged build's packages.
- **gpf-docs-e2e**: channel index step gets ~4 packages instead of ~100.

## Test plan

- [ ] Merge → next master build's `dist/conda/` artefacts contain exactly one version per package (4 `.conda` files total: core, federation, rest-client, web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)