### PR TITLE
docs-e2e: validate getting_started_with_annotation.rst

### DIFF
--- a/docs_e2e/README.md
+++ b/docs_e2e/README.md
@@ -119,11 +119,12 @@ docs_e2e/
 ├── Jenkinsfile.docs-e2e     # downstream pipeline
 ├── jenkins-jobs/
 │   └── docs_e2e.groovy      # pipelineJob DSL, seeded by main gpf Jenkinsfile
-├── conftest.py              # fixtures: conda_channel, gpf_env_prefix, getting_started_clone, prepared_instance, wgpf_server
+├── conftest.py              # fixtures: conda_channel, gpf_env_prefix, getting_started_clone, prepared_instance, annotated_instance, wgpf_server
 ├── guide_assertions.py      # deep module — uniform failure-message helpers
 ├── test_guide_assertions.py # unit tests for the module (pure Python)
 ├── __init__.py
 └── tests/
     ├── __init__.py
-    └── test_main_body.py    # v1: main getting_started.rst body claims
+    ├── test_main_body.py    # v1: main getting_started.rst body claims
+    └── test_annotation.py   # getting_started_with_annotation.rst claims
 ```

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -281,6 +281,53 @@ def prepared_instance(getting_started_clone, gpf_env):
     )
 
 
+# The gnomAD + ClinVar annotation block the annotation guide tells
+# the user to append to gpf_instance.yaml — the emphasized lines
+# 9-12 of the config code-block in
+# getting_started_with_annotation.rst (RST lines 44-55). Kept
+# byte-for-byte in sync with the guide; a drift here is itself a
+# guide-accuracy bug the annotation suite is meant to catch.
+_ANNOTATION_BLOCK = (
+    "\n"
+    "annotation:\n"
+    "  config:\n"
+    "    - allele_score: hg38/variant_frequencies/gnomAD_4.1.0/genomes/ALL\n"
+    "    - allele_score: hg38/scores/ClinVar_20240730\n"
+)
+
+
+@dataclass
+class AnnotatedInstance:
+    """The instance after the annotation guide's config edit."""
+
+    instance_dir: Path
+    config_path: Path
+
+
+@pytest.fixture(scope="session")
+def annotated_instance(prepared_instance):
+    """Apply getting_started_with_annotation.rst: append the gnomAD +
+    ClinVar annotation block to minimal_instance/gpf_instance.yaml.
+
+    Mirrors exactly the edit the guide tells the user to make. The
+    re-annotation itself is NOT run here — per the guide it is
+    triggered by ``wgpf run`` ("When you start the GPF instance using
+    the wgpf tool, it will automatically re-annotate any genotype data
+    that is not up to date"). The shared ``wgpf_server`` fixture
+    depends on this fixture, so the single server starts against the
+    annotated config and re-annotates on startup.
+
+    Strict mode: the only thing done here is the yaml edit a real user
+    types. No hidden re-annotation CLI, no pre-warming.
+    """
+    config_path = prepared_instance.instance_dir / "gpf_instance.yaml"
+    config_path.write_text(config_path.read_text() + _ANNOTATION_BLOCK)
+    return AnnotatedInstance(
+        instance_dir=prepared_instance.instance_dir,
+        config_path=config_path,
+    )
+
+
 def _pick_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -288,10 +335,20 @@ def _pick_free_port():
 
 
 @pytest.fixture(scope="session")
-def wgpf_server(prepared_instance, gpf_env):
+def wgpf_server(annotated_instance, gpf_env):
     """Start ``wgpf run`` in a background subprocess against the
     prepared instance; yield a SimpleNamespace with the base URL,
     httpx client, and the underlying Popen for log access.
+
+    Depends on ``annotated_instance`` so the single shared server
+    starts *after* the annotation guide's config edit and re-annotates
+    on startup. This keeps the suite to one wgpf process per session —
+    two ``wgpf run``s against the same ``DAE_DB_DIR`` would race on the
+    genotype-storage parquet during re-annotation. The main-body claims
+    (datasets visible) hold equally before and after annotation, so
+    sharing one annotated server across both stages is sound; the
+    guide is a linear narrative and by the annotation section the
+    instance genuinely is annotated.
 
     On teardown, terminates wgpf and dumps the last few hundred
     lines of its combined stdout/stderr if any test in the
@@ -299,14 +356,14 @@ def wgpf_server(prepared_instance, gpf_env):
     import httpx  # lazy — see top-of-file note.
 
     env = dict(gpf_env)
-    env["DAE_DB_DIR"] = str(prepared_instance.instance_dir)
+    env["DAE_DB_DIR"] = str(annotated_instance.instance_dir)
 
     port = _pick_free_port()
     base_url = f"http://127.0.0.1:{port}"
 
     proc = subprocess.Popen(
         ["wgpf", "run", "--port", str(port), "--host", "127.0.0.1"],
-        cwd=prepared_instance.instance_dir,
+        cwd=annotated_instance.instance_dir,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -228,3 +228,143 @@ def assert_file_created(path, *, rst_ref, expectation, after_command=None):
         f"  {triage}"
     )
     raise AssertionError(message)
+
+
+def _parse_tsv_header(response):
+    """Return the tab-separated header fields of a download response."""
+    text = getattr(response, "text", "") or ""
+    lines = text.splitlines()
+    if not lines:
+        return []
+    return lines[0].split("\t")
+
+
+def assert_download_has_columns(response, columns, *, rst_ref, expectation):
+    """Assert the genotype-browser download TSV header contains each
+    of ``columns``.
+
+    Backs the annotation guide's claim that the additional attributes
+    produced by annotation (``gnomad_v4_genome_ALL_af``, ``CLNSIG``,
+    ``CLNDN``) are included in the downloaded variants file. A non-200
+    status fails with HTTP-error triage; a missing column fails with a
+    hint pointing at the annotation config / re-annotation step.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with a TSV header containing {columns}"
+            ),
+        ))
+    header = _parse_tsv_header(response)
+    missing = [c for c in columns if c not in header]
+    if not missing:
+        return
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected columns: {', '.join(columns)}\n"
+        f"  missing:          {', '.join(missing)}\n"
+        f"  actual header:    {', '.join(header)}\n"
+        f"\n"
+        f"  Triage hint: The download succeeded but an expected "
+        f"annotation column is absent. Most likely either (a) the "
+        f"annotation config in gpf_instance.yaml did not take effect "
+        f"(re-check that `wgpf run` re-annotated — the wgpf log dump "
+        f"in the artefacts shows the configured annotators), or (b) "
+        f"the annotator's output attribute was renamed. If the new "
+        f"column name is correct, update the guide."
+    )
+    raise AssertionError(message)
+
+
+def assert_download_trailing_columns(
+        response, columns, *, rst_ref, expectation,
+):
+    """Assert the final columns of the download TSV header are exactly
+    ``columns`` (order-insensitive among themselves).
+
+    Backs the guide's claim that annotation attributes are appended
+    "as the last columns in the downloaded file". The inter-order of
+    the trailing columns is not asserted — the guide makes no claim
+    about it and it is cosmetic.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with {columns} as the trailing TSV columns"
+            ),
+        ))
+    header = _parse_tsv_header(response)
+    trailing = header[-len(columns):]
+    if set(trailing) == set(columns):
+        return
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected last {len(columns)} columns: "
+        f"{', '.join(sorted(columns))}\n"
+        f"  actual last {len(columns)} columns:   "
+        f"{', '.join(trailing)}\n"
+        f"  full header:    {', '.join(header)}\n"
+        f"\n"
+        f"  Triage hint: The annotation attributes are not the trailing "
+        f"block of the download. Either a column was appended after them "
+        f"(layout changed) or one of the expected attributes is missing. "
+        f"If the layout legitimately changed, update the guide's claim "
+        f"that they are the last columns."
+    )
+    raise AssertionError(message)
+
+
+def _score_id(item):
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return item.get("score") or item.get("id") or item.get("name")
+    return None
+
+
+def assert_genomic_score_available(
+        response, score_id, *, rst_ref, expectation,
+):
+    """Assert ``score_id`` appears in the instance's genomic-scores
+    registry (``/api/v3/genomic_scores/``).
+
+    Backs the guide's claim that annotation attributes are usable as
+    genomic-score query filters. The response is a JSON list of score
+    descriptor dicts each carrying a ``score`` field; a list of bare
+    id strings is tolerated too.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with '{score_id}' among the genomic scores"
+            ),
+        ))
+    score_ids = [_score_id(item) for item in response.json()]
+    if score_id in score_ids:
+        return
+    available = ", ".join(repr(s) for s in score_ids) or "(none)"
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected genomic score: {score_id!r}\n"
+        f"  available scores:       [{available}]\n"
+        f"\n"
+        f"  Triage hint: The score is not registered as a queryable "
+        f"genomic score. Most likely the annotation that produces it is "
+        f"not configured (re-check the annotation block in "
+        f"gpf_instance.yaml and that `wgpf run` re-annotated), or the "
+        f"score id in the guide drifted from the annotator's output "
+        f"attribute name."
+    )
+    raise AssertionError(message)

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -12,9 +12,26 @@ import pytest
 from docs_e2e.guide_assertions import (
     assert_command_succeeds,
     assert_dataset_visible,
+    assert_download_has_columns,
+    assert_download_trailing_columns,
     assert_file_created,
+    assert_genomic_score_available,
     assert_query_returned_variants,
 )
+
+
+def _tsv(*headers):
+    """A download response whose body is a TSV with these headers."""
+    return _FakeResponse(200, text="\t".join(headers) + "\nrow1\trow2\n")
+
+
+# A realistic example_dataset download header: the fixed genotype
+# columns followed by the three annotation attributes as trailing
+# columns (see getting_started_with_annotation.rst).
+_ANNOTATED_HEADER = [
+    "family id", "study", "location", "variant", "worst effect", "genes",
+    "gnomad_v4_genome_ALL_af", "CLNDN", "CLNSIG",
+]
 
 
 class _FakeResponse:
@@ -288,3 +305,132 @@ class TestAssertQueryReturnedVariants:
         message = str(exc_info.value)
         assert "at least 3" in message
         assert "1 variant" in message
+
+
+class TestAssertDownloadHasColumns:
+    def test_passes_when_all_columns_present(self):
+        resp = _tsv(*_ANNOTATED_HEADER)
+        assert_download_has_columns(
+            resp, ["gnomad_v4_genome_ALL_af", "CLNSIG", "CLNDN"],
+            rst_ref="getting_started_with_annotation.rst:67",
+            expectation="download includes annotation attributes",
+        )
+
+    def test_raises_when_a_column_missing(self):
+        # gnomAD attribute absent — annotation did not take effect.
+        resp = _tsv(
+            "family id", "study", "worst effect", "genes",
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_download_has_columns(
+                resp, ["gnomad_v4_genome_ALL_af"],
+                rst_ref="getting_started_with_annotation.rst:67",
+                expectation="download includes gnomad_v4_genome_ALL_af",
+            )
+        message = str(exc_info.value)
+        assert "getting_started_with_annotation.rst:67" in message
+        assert "gnomad_v4_genome_ALL_af" in message
+        # The actual header is surfaced so the operator can see what
+        # columns DID come through.
+        assert "worst effect" in message
+        assert "Triage" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(500, text="Internal Server Error")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_download_has_columns(
+                resp, ["gnomad_v4_genome_ALL_af"],
+                rst_ref="getting_started_with_annotation.rst:67",
+                expectation="download includes gnomad_v4_genome_ALL_af",
+            )
+        message = str(exc_info.value)
+        assert "500" in message
+        assert "server" in message.lower() or "backend" in message.lower()
+
+
+class TestAssertDownloadTrailingColumns:
+    def test_passes_when_columns_are_trailing_any_order(self):
+        # Live order is gnomad, CLNDN, CLNSIG — the helper is
+        # order-insensitive among the trailing columns, so passing
+        # the guide's prose order (CLNSIG before CLNDN) still passes.
+        resp = _tsv(*_ANNOTATED_HEADER)
+        assert_download_trailing_columns(
+            resp, ["gnomad_v4_genome_ALL_af", "CLNSIG", "CLNDN"],
+            rst_ref="getting_started_with_annotation.rst:91",
+            expectation="annotation attributes are the last columns",
+        )
+
+    def test_raises_when_a_column_trails_the_annotation_block(self):
+        # An extra column appended after the annotation block — the
+        # "last columns" claim no longer holds.
+        resp = _tsv(
+            "family id", "gnomad_v4_genome_ALL_af", "CLNDN", "CLNSIG",
+            "some_new_trailing_column",
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_download_trailing_columns(
+                resp, ["gnomad_v4_genome_ALL_af", "CLNSIG", "CLNDN"],
+                rst_ref="getting_started_with_annotation.rst:91",
+                expectation="annotation attributes are the last columns",
+            )
+        message = str(exc_info.value)
+        assert "getting_started_with_annotation.rst:91" in message
+        assert "some_new_trailing_column" in message
+        assert "Triage" in message
+
+
+class TestAssertGenomicScoreAvailable:
+    def test_passes_when_score_present_dict_shape(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[
+                {"score": "gnomad_v4_genome_ALL_af"},
+                {"score": "CLNDN"},
+                {"score": "CLNSIG"},
+            ],
+        )
+        assert_genomic_score_available(
+            resp, "CLNSIG",
+            rst_ref="getting_started_with_annotation.rst:77",
+            expectation="CLNSIG is queryable as a genomic score",
+        )
+
+    def test_passes_when_score_present_string_shape(self):
+        resp = _FakeResponse(
+            200,
+            json_body=["gnomad_v4_genome_ALL_af", "CLNDN", "CLNSIG"],
+        )
+        assert_genomic_score_available(
+            resp, "gnomad_v4_genome_ALL_af",
+            rst_ref="getting_started_with_annotation.rst:77",
+            expectation="gnomad score is queryable",
+        )
+
+    def test_raises_when_score_missing(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[{"score": "gnomad_v4_genome_ALL_af"}],
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_genomic_score_available(
+                resp, "CLNSIG",
+                rst_ref="getting_started_with_annotation.rst:77",
+                expectation="CLNSIG is queryable as a genomic score",
+            )
+        message = str(exc_info.value)
+        assert "getting_started_with_annotation.rst:77" in message
+        assert "CLNSIG" in message
+        # Lists what IS available so the operator can spot a rename.
+        assert "gnomad_v4_genome_ALL_af" in message
+        assert "Triage" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(503, text="Service Unavailable")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_genomic_score_available(
+                resp, "CLNSIG",
+                rst_ref="getting_started_with_annotation.rst:77",
+                expectation="CLNSIG is queryable as a genomic score",
+            )
+        message = str(exc_info.value)
+        assert "503" in message

--- a/docs_e2e/tests/test_annotation.py
+++ b/docs_e2e/tests/test_annotation.py
@@ -1,0 +1,144 @@
+"""Guide-claim tests for getting_started_with_annotation.rst.
+
+The annotation section tells the user to append a gnomAD + ClinVar
+annotation block to ``minimal_instance/gpf_instance.yaml`` and re-run
+``wgpf run`` — which re-annotates the already-imported genotype data.
+The variants then carry three additional attributes
+(``gnomad_v4_genome_ALL_af``, ``CLNSIG``, ``CLNDN``) that are included
+in genotype-browser downloads and usable as genomic-score filters.
+
+The config edit lives in the session-scoped ``annotated_instance``
+fixture (conftest.py); ``wgpf_server`` depends on it, so the single
+shared server reflects the annotated state. Strict mode (#871): the
+fixture only does what the guide tells the user to do — edit the yaml;
+re-annotation is triggered by wgpf itself.
+
+Each test maps to one discrete prose claim. ``rst_ref`` points at the
+line in the guide source so a failure localizes the drift.
+"""
+
+from docs_e2e.guide_assertions import (
+    assert_dataset_visible,
+    assert_download_has_columns,
+    assert_download_trailing_columns,
+    assert_genomic_score_available,
+)
+
+RST = "getting_started_with_annotation.rst"
+
+# The three attributes the annotation produces (RST lines 67-69).
+ANNOTATION_ATTRIBUTES = ["gnomad_v4_genome_ALL_af", "CLNSIG", "CLNDN"]
+
+
+class TestReannotation:
+    """RST lines 57-62: ``wgpf run`` re-annotates genotype data that is
+    not up to date and serves the annotated instance."""
+
+    def test_wgpf_run_serves_reannotated_instance(self, wgpf_server):
+        # The annotation block was appended to gpf_instance.yaml by the
+        # `annotated_instance` fixture; `wgpf_server` then started
+        # `wgpf run`, which re-annotated on startup. If re-annotation
+        # had failed, the server would not have become ready and this
+        # (and every server-backed test) would fail at fixture setup.
+        # Assert the instance still serves the example dataset.
+        resp = wgpf_server.client.get("/api/v3/datasets/visible")
+        assert_dataset_visible(
+            resp, "example_dataset",
+            rst_ref=f"{RST}:57",
+            expectation=(
+                "after the annotation block is added, `wgpf run` "
+                "re-annotates and serves the instance with example_dataset "
+                "still available"
+            ),
+        )
+
+
+class TestAnnotationDownloadColumns:
+    """RST lines 64-92: the re-annotated variants carry the gnomAD +
+    ClinVar attributes, included in the Genotype Browser download as
+    the last columns."""
+
+    def _download(self, wgpf_server):
+        # The guide's "Download" button (RST line 89) maps to the
+        # query-download endpoint. No filter — the whole Example
+        # Dataset, so every annotation column is exercised.
+        return wgpf_server.client.post(
+            "/api/v3/genotype_browser/query-download",
+            json={"datasetId": "example_dataset"},
+        )
+
+    def test_download_has_gnomad_attribute(self, wgpf_server):
+        assert_download_has_columns(
+            self._download(wgpf_server), ["gnomad_v4_genome_ALL_af"],
+            rst_ref=f"{RST}:67",
+            expectation=(
+                "the downloaded variants file includes the "
+                "`gnomad_v4_genome_ALL_af` attribute from gnomAD annotation"
+            ),
+        )
+
+    def test_download_has_clnsig_attribute(self, wgpf_server):
+        assert_download_has_columns(
+            self._download(wgpf_server), ["CLNSIG"],
+            rst_ref=f"{RST}:68",
+            expectation=(
+                "the downloaded variants file includes the `CLNSIG` "
+                "attribute from ClinVar annotation"
+            ),
+        )
+
+    def test_download_has_clndn_attribute(self, wgpf_server):
+        assert_download_has_columns(
+            self._download(wgpf_server), ["CLNDN"],
+            rst_ref=f"{RST}:69",
+            expectation=(
+                "the downloaded variants file includes the `CLNDN` "
+                "attribute from ClinVar annotation"
+            ),
+        )
+
+    def test_annotation_attributes_are_last_columns(self, wgpf_server):
+        assert_download_trailing_columns(
+            self._download(wgpf_server), ANNOTATION_ATTRIBUTES,
+            rst_ref=f"{RST}:91",
+            expectation=(
+                "attributes from the annotation are included as the last "
+                "columns in the downloaded file"
+            ),
+        )
+
+
+class TestAnnotationGenomicScores:
+    """RST lines 77-78: the annotation attributes are usable as genomic
+    score query filters (registered in the genomic-scores registry)."""
+
+    def _genomic_scores(self, wgpf_server):
+        return wgpf_server.client.get("/api/v3/genomic_scores/")
+
+    def test_gnomad_is_queryable_genomic_score(self, wgpf_server):
+        assert_genomic_score_available(
+            self._genomic_scores(wgpf_server), "gnomad_v4_genome_ALL_af",
+            rst_ref=f"{RST}:77",
+            expectation=(
+                "the variants can be queried using the "
+                "`gnomad_v4_genome_ALL_af` genomic score"
+            ),
+        )
+
+    def test_clnsig_is_queryable_genomic_score(self, wgpf_server):
+        assert_genomic_score_available(
+            self._genomic_scores(wgpf_server), "CLNSIG",
+            rst_ref=f"{RST}:77",
+            expectation=(
+                "the variants can be queried using the `CLNSIG` genomic score"
+            ),
+        )
+
+    def test_clndn_is_queryable_genomic_score(self, wgpf_server):
+        assert_genomic_score_available(
+            self._genomic_scores(wgpf_server), "CLNDN",
+            rst_ref=f"{RST}:78",
+            expectation=(
+                "the variants can be queried using the `CLNDN` genomic score"
+            ),
+        )


### PR DESCRIPTION
## Summary

Extends the docs-e2e suite (epic #871) with `docs_e2e/tests/test_annotation.py` — one pytest test per discrete prose claim in `getting_started_with_annotation.rst`:

- the gnomAD + ClinVar annotation block re-annotates on `wgpf run`;
- the three attributes (`gnomad_v4_genome_ALL_af`, `CLNSIG`, `CLNDN`) appear as the **trailing columns** of the Genotype Browser download;
- each is queryable as a genomic score.

The config edit lives in a new session-scoped `annotated_instance` fixture; the shared `wgpf_server` now depends on it so a single wgpf process serves the annotated instance (two `wgpf run`s against one `DAE_DB_DIR` would race during re-annotation). The main-body claims hold equally before and after annotation.

Adds three `guide_assertions` helpers — `assert_download_has_columns`, `assert_download_trailing_columns`, `assert_genomic_score_available` — with pure-Python unit tests.

No prose drift found: the annotation guide's testable claims are all accurate against current GPF.

## Test plan

- [x] `guide_assertions` unit tests (pure Python): 24 passed
- [x] Full docs-e2e suite locally (master build 5796 conda artefacts): 42 passed
- [x] `gpf-docs-e2e` CI on this branch: build #18 SUCCESS, 42 tests, 0 failures

Closes #873

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>