### PR TITLE
docs-e2e: validate getting_started_with_preview_columns.rst

### DIFF
--- a/docs_e2e/README.md
+++ b/docs_e2e/README.md
@@ -119,7 +119,7 @@ docs_e2e/
 ├── Jenkinsfile.docs-e2e     # downstream pipeline
 ├── jenkins-jobs/
 │   └── docs_e2e.groovy      # pipelineJob DSL, seeded by main gpf Jenkinsfile
-├── conftest.py              # fixtures: conda_channel, gpf_env_prefix, getting_started_clone, prepared_instance, annotated_instance, phenotype_instance, wgpf_server
+├── conftest.py              # fixtures: conda_channel, gpf_env_prefix, getting_started_clone, prepared_instance, annotated_instance, phenotype_instance, preview_columns_instance, wgpf_server
 ├── guide_assertions.py      # deep module — uniform failure-message helpers
 ├── test_guide_assertions.py # unit tests for the module (pure Python)
 ├── __init__.py
@@ -127,5 +127,6 @@ docs_e2e/
     ├── __init__.py
     ├── test_main_body.py    # v1: main getting_started.rst body claims
     ├── test_annotation.py   # getting_started_with_annotation.rst claims
-    └── test_phenotype_data.py  # getting_started_with_phenotype_data.rst claims
+    ├── test_phenotype_data.py  # getting_started_with_phenotype_data.rst claims
+    └── test_preview_columns.py # getting_started_with_preview_columns.rst claims
 ```

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -392,6 +392,89 @@ def phenotype_instance(annotated_instance, getting_started_clone, gpf_env):
     )
 
 
+# The genotype_browser config getting_started_with_preview_columns.rst
+# tells the user to add to the example_dataset config (the guide's second,
+# final code-block — RST lines 127-161): the phenotype IQ columns, the
+# redefined `frequency` group (now carrying gnomAD), the new `clinvar` and
+# `proband_iq` column groups, and the preview_columns_ext that surfaces the
+# two new groups in the preview table. Kept byte-for-byte in sync with the
+# guide; a drift here is itself the guide-accuracy bug this suite catches.
+_PREVIEW_COLUMNS_BLOCK = (
+    "\n"
+    "genotype_browser:\n"
+    "  columns:\n"
+    "    phenotype:\n"
+    "      prb_verbal_iq:\n"
+    "        role: prb\n"
+    "        name: Verbal IQ\n"
+    "        source: iq.verbal_iq\n"
+    "\n"
+    "      prb_non_verbal_iq:\n"
+    "        role: prb\n"
+    "        name: Non-Verbal IQ\n"
+    "        source: iq.non_verbal_iq\n"
+    "\n"
+    "  column_groups:\n"
+    "    frequency:\n"
+    "      name: frequency\n"
+    "      columns:\n"
+    "      - allele_freq\n"
+    "      - gnomad_v4_genome_ALL_af\n"
+    "\n"
+    "    clinvar:\n"
+    "      name: ClinVar\n"
+    "      columns:\n"
+    "      - CLNSIG\n"
+    "      - CLNDN\n"
+    "\n"
+    "    proband_iq:\n"
+    "      name: Proband IQ\n"
+    "      columns:\n"
+    "      - prb_verbal_iq\n"
+    "      - prb_non_verbal_iq\n"
+    "\n"
+    "  preview_columns_ext:\n"
+    "    - clinvar\n"
+    "    - proband_iq\n"
+)
+
+
+@dataclass
+class PreviewColumnsInstance:
+    """The instance after the preview-columns guide's example_dataset edit."""
+
+    instance_dir: Path
+    dataset_yaml_path: Path
+
+
+@pytest.fixture(scope="session")
+def preview_columns_instance(phenotype_instance):
+    """Apply getting_started_with_preview_columns.rst: append the
+    genotype_browser column-group + phenotype-column config to the
+    example_dataset config.
+
+    The guide walks two edits (first the gnomAD/ClinVar column groups, then
+    the phenotype IQ columns), each followed by a ``wgpf`` restart. With the
+    suite's single-shared-server invariant we apply the guide's *final*
+    config — the second code-block (RST lines 127-161), a strict superset
+    that keeps the ClinVar + redefined-frequency groups and adds the
+    ``proband_iq`` phenotype group — and boot once. Every claim from both
+    edits holds in that end state.
+
+    Strict mode (#871): the only thing done here is the yaml edit a real
+    user types. The phenotype columns reference the ``iq.*`` measures of the
+    ``mini_pheno`` study attached by ``phenotype_instance``; chaining after
+    it keeps the linear-narrative ordering and ensures those measures
+    resolve when the server builds the dataset description.
+    """
+    dataset_yaml = phenotype_instance.dataset_yaml_path
+    dataset_yaml.write_text(dataset_yaml.read_text() + _PREVIEW_COLUMNS_BLOCK)
+    return PreviewColumnsInstance(
+        instance_dir=phenotype_instance.instance_dir,
+        dataset_yaml_path=dataset_yaml,
+    )
+
+
 def _pick_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -399,19 +482,20 @@ def _pick_free_port():
 
 
 @pytest.fixture(scope="session")
-def wgpf_server(phenotype_instance, gpf_env):
+def wgpf_server(preview_columns_instance, gpf_env):
     """Start ``wgpf run`` in a background subprocess against the
     prepared instance; yield a SimpleNamespace with the base URL,
     httpx client, and the underlying Popen for log access.
 
-    Depends on ``phenotype_instance`` — the last stage of the guide's
-    linear narrative (imports → annotation edit → pheno import + pheno
-    attach). The single shared server therefore starts after every
-    config edit the guide describes: it re-annotates the genotype data
-    on startup and serves the pheno-enabled example_dataset. Keeping the
-    suite to one wgpf process per session avoids two ``wgpf run``s racing
-    on the same ``DAE_DB_DIR`` parquet during re-annotation. Every
-    earlier claim (datasets visible, annotation download columns) holds
+    Depends on ``preview_columns_instance`` — the last stage of the
+    guide's linear narrative (imports → annotation edit → pheno import +
+    pheno attach → preview-column config). The single shared server
+    therefore starts after every config edit the guide describes: it
+    re-annotates the genotype data on startup and serves the pheno-enabled
+    example_dataset with its extended preview columns. Keeping the suite to
+    one wgpf process per session avoids two ``wgpf run``s racing on the same
+    ``DAE_DB_DIR`` parquet during re-annotation. Every earlier claim
+    (datasets visible, annotation download columns, pheno browser) holds
     equally in this final state, so sharing one server across all stages
     is sound.
 
@@ -421,14 +505,14 @@ def wgpf_server(phenotype_instance, gpf_env):
     import httpx  # lazy — see top-of-file note.
 
     env = dict(gpf_env)
-    env["DAE_DB_DIR"] = str(phenotype_instance.instance_dir)
+    env["DAE_DB_DIR"] = str(preview_columns_instance.instance_dir)
 
     port = _pick_free_port()
     base_url = f"http://127.0.0.1:{port}"
 
     proc = subprocess.Popen(
         ["wgpf", "run", "--port", str(port), "--host", "127.0.0.1"],
-        cwd=phenotype_instance.instance_dir,
+        cwd=preview_columns_instance.instance_dir,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -555,3 +555,114 @@ def assert_image_response_ok(response, *, rst_ref, expectation):
         f"measure record drifted from the on-disk layout."
     )
     raise AssertionError(message)
+
+
+def _assert_group_members(
+        kind, expected, actual, *, group_name, rst_ref, expectation,
+):
+    """Assert ``expected`` is a subset of ``actual`` member values.
+
+    ``kind`` is "source" or "name" (used only in the message). Subset
+    semantics: a column group may carry members the guide does not
+    mention, so only the expected ones must be present.
+    """
+    if not expected:
+        return
+    missing = [e for e in expected if e not in actual]
+    if not missing:
+        return
+    available = ", ".join(repr(a) for a in actual) or "(none)"
+    raise AssertionError(
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  in preview column group {group_name!r}:\n"
+        f"  expected member {kind}s: {', '.join(map(str, expected))}\n"
+        f"  missing:               {', '.join(map(str, missing))}\n"
+        f"  actual member {kind}s:   [{available}]\n"
+        f"\n"
+        f"  Triage hint: The column group is present but a member column "
+        f"the guide names is absent. Most likely either (a) the column "
+        f"definition (the {kind}) in the guide drifted from the study "
+        f"config / annotation output, or (b) a referenced column was "
+        f"silently dropped because its underlying attribute/measure did "
+        f"not resolve (an unresolved column-group member is skipped at "
+        f"description-build time). If the new {kind} is correct, update "
+        f"the guide.",
+    )
+
+
+def assert_preview_table_column_group(
+        response, group_name, *,
+        expected_sources=None, expected_column_names=None,
+        rst_ref, expectation,
+):
+    """Assert a column group surfaces in a dataset's preview table.
+
+    Backs the preview-columns guide's claims that editing a study's
+    ``genotype_browser.column_groups`` + ``preview_columns_ext`` makes the
+    new/redefined column groups appear in the Genotype Browser preview
+    table. The single-dataset description endpoint
+    (``/api/v3/datasets/<id>``, shaped ``{"data": {...}}``) exposes the
+    resolved preview layout at
+    ``data.genotype_browser_config.table_columns`` — the same list the SPA
+    renders as the preview table. Each column group is shaped
+    ``{"name": <display name>, "columns": [{"source": ..., "name": ...}]}``.
+
+    ``group_name`` is matched against each entry's display ``name``. When
+    supplied, ``expected_sources`` / ``expected_column_names`` must each be
+    present (subset) among the group's resolved member columns — tolerating
+    extra members the guide does not mention.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with a '{group_name}' column group in the "
+                f"preview table"
+            ),
+        ))
+    data = response.json().get("data", {})
+    found, table_columns = _navigate(
+        data, "genotype_browser_config.table_columns")
+    table_columns = table_columns if (found and table_columns) else []
+    group = next(
+        (c for c in table_columns
+         if isinstance(c, dict) and c.get("name") == group_name),
+        None,
+    )
+    if group is None:
+        present = ", ".join(
+            repr(c.get("name")) for c in table_columns if isinstance(c, dict)
+        ) or "(none)"
+        raise AssertionError(
+            f'DRIFT at {rst_ref} — "{expectation}"\n'
+            f"\n"
+            f"  expected: a '{group_name}' column group in the preview "
+            f"table\n"
+            f"  actual:   preview column groups = [{present}]\n"
+            f"\n"
+            f"  Triage hint: The dataset description was returned but no "
+            f"preview column group is named {group_name!r}. Most likely "
+            f"either (a) the column_groups / preview_columns_ext edit was "
+            f"not applied to the example_dataset config (or the server did "
+            f"not pick it up — check the wgpf log dump), or (b) the group's "
+            f"display name in the guide drifted from the config. If the "
+            f"layout legitimately changed, update the guide.",
+        )
+    member_columns = group.get("columns") or []
+    actual_sources = [
+        col.get("source") for col in member_columns if isinstance(col, dict)
+    ]
+    actual_names = [
+        col.get("name") for col in member_columns if isinstance(col, dict)
+    ]
+    _assert_group_members(
+        "source", expected_sources, actual_sources,
+        group_name=group_name, rst_ref=rst_ref, expectation=expectation,
+    )
+    _assert_group_members(
+        "name", expected_column_names, actual_names,
+        group_name=group_name, rst_ref=rst_ref, expectation=expectation,
+    )

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -20,6 +20,7 @@ from docs_e2e.guide_assertions import (
     assert_image_response_ok,
     assert_pheno_instruments_available,
     assert_pheno_measures_present,
+    assert_preview_table_column_group,
     assert_query_returned_variants,
 )
 
@@ -633,4 +634,137 @@ class TestAssertImageResponseOk:
             )
         message = str(exc_info.value)
         assert "text/html" in message
+
+
+class TestAssertPreviewTableColumnGroup:
+    _RST = "getting_started_with_preview_columns.rst"
+
+    def _description(self, *table_columns):
+        # The single-dataset endpoint wraps the description in "data";
+        # the resolved preview layout is genotype_browser_config.table_columns.
+        return _FakeResponse(200, json_body={"data": {
+            "id": "example_dataset",
+            "genotype_browser_config": {"table_columns": list(table_columns)},
+        }})
+
+    def _group(self, name, *members):
+        # A column-group table_columns entry as build_genotype_data_description
+        # emits it: {"name": ..., "columns": [{"name", "source"}, ...]}.
+        return {
+            "name": name,
+            "columns": [
+                {"name": disp, "source": src} for disp, src in members
+            ],
+        }
+
+    def test_passes_when_group_present(self):
+        resp = self._description(
+            self._group("ClinVar", ("CLNSIG", "CLNSIG"), ("CLNDN", "CLNDN")),
+        )
+        assert_preview_table_column_group(
+            resp, "ClinVar",
+            rst_ref=f"{self._RST}:67",
+            expectation="ClinVar column group appears in the preview table",
+        )
+
+    def test_passes_when_expected_sources_present(self):
+        resp = self._description(
+            self._group("ClinVar", ("CLNSIG", "CLNSIG"), ("CLNDN", "CLNDN")),
+        )
+        assert_preview_table_column_group(
+            resp, "ClinVar",
+            expected_sources=["CLNSIG", "CLNDN"],
+            rst_ref=f"{self._RST}:73",
+            expectation="ClinVar group carries CLNSIG + CLNDN",
+        )
+
+    def test_passes_when_sources_a_subset(self):
+        # frequency carries allele_freq too; only gnomad is asserted.
+        resp = self._description(
+            self._group(
+                "frequency",
+                ("allele freq", "allele_freq"),
+                ("gnomad_v4_genome_ALL_af", "gnomad_v4_genome_ALL_af"),
+            ),
+        )
+        assert_preview_table_column_group(
+            resp, "frequency",
+            expected_sources=["gnomad_v4_genome_ALL_af"],
+            rst_ref=f"{self._RST}:69",
+            expectation="frequency group includes the gnomAD frequency",
+        )
+
+    def test_passes_when_expected_column_names_present(self):
+        resp = self._description(
+            self._group(
+                "Proband IQ",
+                ("Verbal IQ", "iq.verbal_iq"),
+                ("Non-Verbal IQ", "iq.non_verbal_iq"),
+            ),
+        )
+        assert_preview_table_column_group(
+            resp, "Proband IQ",
+            expected_sources=["iq.verbal_iq", "iq.non_verbal_iq"],
+            expected_column_names=["Verbal IQ", "Non-Verbal IQ"],
+            rst_ref=f"{self._RST}:159",
+            expectation="Proband IQ group carries both IQ measures",
+        )
+
+    def test_raises_when_group_absent(self):
+        resp = self._description(
+            self._group("frequency", ("allele freq", "allele_freq")),
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_preview_table_column_group(
+                resp, "ClinVar",
+                rst_ref=f"{self._RST}:67",
+                expectation="ClinVar column group appears in the preview table",
+            )
+        message = str(exc_info.value)
+        assert f"{self._RST}:67" in message
+        assert "ClinVar" in message
+        # Surfaces the groups that WERE present, to spot a rename.
+        assert "frequency" in message
+        assert "Triage" in message
+
+    def test_raises_when_a_source_missing(self):
+        resp = self._description(
+            self._group("ClinVar", ("CLNSIG", "CLNSIG")),
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_preview_table_column_group(
+                resp, "ClinVar",
+                expected_sources=["CLNSIG", "CLNDN"],
+                rst_ref=f"{self._RST}:73",
+                expectation="ClinVar group carries CLNSIG + CLNDN",
+            )
+        message = str(exc_info.value)
+        assert "CLNDN" in message
+        assert "missing" in message
+        assert "Triage" in message
+
+    def test_raises_when_a_column_name_missing(self):
+        resp = self._description(
+            self._group("Proband IQ", ("Verbal IQ", "iq.verbal_iq")),
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_preview_table_column_group(
+                resp, "Proband IQ",
+                expected_column_names=["Verbal IQ", "Non-Verbal IQ"],
+                rst_ref=f"{self._RST}:159",
+                expectation="Proband IQ group shows both IQ display names",
+            )
+        message = str(exc_info.value)
+        assert "Non-Verbal IQ" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(404, text="Dataset not found")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_preview_table_column_group(
+                resp, "ClinVar",
+                rst_ref=f"{self._RST}:67",
+                expectation="ClinVar column group appears in the preview table",
+            )
+        message = str(exc_info.value)
+        assert "404" in message
         assert "Triage" in message

--- a/docs_e2e/tests/test_preview_columns.py
+++ b/docs_e2e/tests/test_preview_columns.py
@@ -1,0 +1,116 @@
+"""Guide-claim tests for getting_started_with_preview_columns.rst.
+
+The preview-columns section tells the user to edit the
+``example_dataset`` config and, in the ``genotype_browser`` section:
+
+1. redefine the existing ``frequency`` column group to include the
+   gnomAD frequency ``gnomad_v4_genome_ALL_af`` (the attribute the
+   annotation guide added), and define a new ``clinvar`` column group
+   carrying the ClinVar attributes ``CLNSIG`` + ``CLNDN`` — then add
+   ``clinvar`` to ``preview_columns_ext`` so it shows in the preview
+   table;
+2. define two phenotype columns (``prb_verbal_iq`` /
+   ``prb_non_verbal_iq``, sourcing the ``iq.*`` measures of the
+   ``mini_pheno`` study attached in the phenotype guide), group them as
+   ``proband_iq``, and add that group to ``preview_columns_ext`` too.
+
+The config edit lives in the session-scoped ``preview_columns_instance``
+fixture (conftest.py); ``wgpf_server`` depends on it, so the single
+shared server serves the dataset with the extended preview layout.
+Strict mode (#871): the fixture only does what the guide tells the user
+to do — the one-block yaml edit (the guide's final code-block, which is
+a strict superset of its first edit).
+
+The resolved preview layout surfaces through the single-dataset
+description endpoint at
+``data.genotype_browser_config.table_columns`` — the same list the SPA
+renders as the preview table. Each test maps to one discrete prose
+claim; ``rst_ref`` points at the line in the guide source so a failure
+localizes the drift.
+"""
+
+from docs_e2e.guide_assertions import assert_preview_table_column_group
+
+RST = "getting_started_with_preview_columns.rst"
+
+
+def _description(wgpf_server):
+    return wgpf_server.client.get("/api/v3/datasets/example_dataset")
+
+
+class TestGenotypeColumnConfig:
+    """RST lines 5-95: redefining ``frequency`` and adding the ``clinvar``
+    column group surfaces the annotation attributes in the preview
+    table."""
+
+    def test_clinvar_column_group_in_preview_table(self, wgpf_server):
+        # RST lines 77-78: adding `clinvar` to preview_columns_ext makes
+        # the new column group appear in the preview table.
+        assert_preview_table_column_group(
+            _description(wgpf_server), "ClinVar",
+            rst_ref=f"{RST}:78",
+            expectation=(
+                "the new `clinvar` column group is added to the preview "
+                "table"
+            ),
+        )
+
+    def test_clinvar_group_has_clnsig_and_clndn(self, wgpf_server):
+        # RST lines 73-75: the `clinvar` group contains the ClinVar
+        # annotation attributes CLNSIG and CLNDN.
+        assert_preview_table_column_group(
+            _description(wgpf_server), "ClinVar",
+            expected_sources=["CLNSIG", "CLNDN"],
+            rst_ref=f"{RST}:73",
+            expectation=(
+                "the `clinvar` column group contains the CLNSIG and CLNDN "
+                "annotation attributes"
+            ),
+        )
+
+    def test_frequency_group_includes_gnomad(self, wgpf_server):
+        # RST lines 69-71: the redefined `frequency` group includes the
+        # gnomAD frequency. (allele_freq may also be present; only the
+        # gnomAD attribute is asserted — that is the guide's claim.)
+        assert_preview_table_column_group(
+            _description(wgpf_server), "frequency",
+            expected_sources=["gnomad_v4_genome_ALL_af"],
+            rst_ref=f"{RST}:69",
+            expectation=(
+                "the existing `frequency` column group is redefined to "
+                "include the gnomAD frequency gnomad_v4_genome_ALL_af"
+            ),
+        )
+
+
+class TestPhenotypeColumnConfig:
+    """RST lines 98-200: defining phenotype columns and grouping them as
+    ``proband_iq`` surfaces the pheno measures in the preview table."""
+
+    def test_proband_iq_column_group_in_preview_table(self, wgpf_server):
+        # RST lines 192-193: the new column group `proband_iq` appears in
+        # the preview table after adding it to preview_columns_ext.
+        assert_preview_table_column_group(
+            _description(wgpf_server), "Proband IQ",
+            rst_ref=f"{RST}:193",
+            expectation=(
+                "the new `proband_iq` column group appears in the preview "
+                "table"
+            ),
+        )
+
+    def test_proband_iq_group_has_both_iq_measures(self, wgpf_server):
+        # RST lines 164-178: the `proband_iq` group carries the two
+        # phenotype columns — sourcing iq.verbal_iq / iq.non_verbal_iq,
+        # displayed as `Verbal IQ` / `Non-Verbal IQ`.
+        assert_preview_table_column_group(
+            _description(wgpf_server), "Proband IQ",
+            expected_sources=["iq.verbal_iq", "iq.non_verbal_iq"],
+            expected_column_names=["Verbal IQ", "Non-Verbal IQ"],
+            rst_ref=f"{RST}:164",
+            expectation=(
+                "the `proband_iq` column group carries the Verbal IQ and "
+                "Non-Verbal IQ proband measures (iq.verbal_iq, "
+                "iq.non_verbal_iq)"
+            ),
+        )


### PR DESCRIPTION
## Summary

Covers the **preview-columns** sub-guide (#875, child of epic #871) in the `docs-e2e` guide-accuracy suite. One pytest test per discrete prose claim that configuring `genotype_browser` column groups + `preview_columns_ext` in the `example_dataset` config surfaces them in the Genotype Browser preview table.

- **guide_assertions**: new `assert_preview_table_column_group` — reads the resolved preview layout from `data.genotype_browser_config.table_columns` (the same list the SPA renders as the preview table), asserts a named column group is present, optionally checking member `source`s / display `name`s as present-subsets (tolerant of extra members the guide does not mention).
- **conftest**: new `preview_columns_instance` fixture — appends the guide's final `genotype_browser` config block to `example_dataset.yaml` (byte-for-byte from RST lines 127-161, a strict superset of the guide's first edit). `wgpf_server` now depends on it, so the single shared server serves the extended preview layout. Chained after `phenotype_instance` so the proband-IQ columns' `iq.*` measures resolve.
- **tests/test_preview_columns.py**: ClinVar group present + CLNSIG/CLNDN members; redefined `frequency` group includes the gnomAD frequency; Proband IQ group present + both IQ measures/display names.

No RST drift found — the guide is accurate; only test code + harness added.

Strict mode (#871): the fixture only does the one yaml edit a real user types. The two guide edits (gnomAD/ClinVar groups, then phenotype IQ columns) each call for a `wgpf` restart; with the suite's single-shared-server invariant we apply the guide's final (superset) config and boot once — every claim from both edits holds in that end state.

## Test plan

- [x] `guide_assertions` unit tests (pure Python): **46 passed** (8 new for the helper).
- [x] Full `docs-e2e` suite locally in the driver container against the build's conda artefacts (warm GRR cache): **79 passed** — including all 5 new `test_preview_columns.py` claims against a live `wgpf run`.
- [ ] `gpf-docs-e2e` GREEN on master after merge.

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)