### PR TITLE
docs-e2e: validate example_cnv_import.rst (#877)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,11 @@ Test markers in `core/pytest.ini`: genotype storage
 
 All tests run with `PYTHONHASHSEED=0`.
 
+The `docs_e2e/` guide-accuracy suite has its own agent guide —
+**`docs_e2e/CLAUDE.md`**. Key rule: it is container/runtime-only, so
+static checks miss fixture-wiring bugs — **always run it locally in the
+driver container before committing** (recipe there).
+
 ### Linting and Type Checking
 
 ```bash

--- a/docs/source/administration/getting_started/example_cnv_import.rst
+++ b/docs/source/administration/getting_started/example_cnv_import.rst
@@ -93,7 +93,7 @@ content:
     The resulting ``ssc_cnv.tsv`` file is available in the
     `gpf-getting-started <https://github.com/iossifovlab/gpf-getting-started.git>`_
     repository under the subdirectory
-    ``example_imports/denovo_and_cnv_import/input_data``.
+    ``example_imports/denovo_and_cnv_import``.
 
 
 Data Import of ``ssc_cnv``

--- a/docs_e2e/CLAUDE.md
+++ b/docs_e2e/CLAUDE.md
@@ -1,0 +1,63 @@
+# docs-e2e — Agent Guide
+
+Guide-accuracy regression suite for the GPF Getting Started Guide
+(epic iossifovlab/gpf#871). Each sub-guide RST has a
+`tests/test_<name>.py` whose tests assert the guide's discrete prose
+claims by running its commands and probing a backgrounded `wgpf run`.
+Full design + local-iteration details: `docs_e2e/README.md`.
+
+## ALWAYS run the suite locally before committing
+
+The Jenkins `gpf-docs-e2e` build is **not** your first test. Almost the
+entire suite is **session fixtures** (`conftest.py`) exercised only at
+**runtime**, so `py_compile`, `ruff`, and even `pytest --collect-only`
+do **not** catch the most common breakage: a fixture referenced by bare
+name instead of being injected as a parameter. That fails at fixture
+setup and cascades to **every** server-backed test as an ERROR (see
+build #35: a stray `denovo_instance` in `wgpf_server` → 63 passed, 33
+errors). Only actually running the suite catches it.
+
+Emulate the Jenkins run in the driver container (needs docker,
+`dist/conda/gpf-web-*.conda` artefacts, and a populated `gpf-grr-cache`
+volume — see README § Local iteration):
+
+```bash
+# from the gpf checkout, with dist/conda populated:
+docker build -f docs_e2e/Dockerfile -t gpf-docs-e2e:local docs_e2e/
+docker run --rm -v "$PWD:/workspace" -v gpf-grr-cache:/grr-cache \
+    -e DOCS_E2E_CHANNEL=/workspace/dist/conda \
+    -e DOCS_E2E_GRR_CACHE=/grr-cache -w /workspace \
+    gpf-docs-e2e:local mamba run -n driver pytest -v -s docs_e2e/
+```
+
+- No local `dist/conda`? Reuse a sibling worktree's
+  `dist/conda/*.conda` (any recent gpf build works — the GRR resources
+  are version-independent), or pull from a gpf build.
+- Local `gpf-grr-cache` populated but missing the `.docs-e2e-prewarmed`
+  sentinel? `touch` it once:
+  `docker run --rm -v gpf-grr-cache:/grr-cache alpine touch /grr-cache/.docs-e2e-prewarmed`
+- Iterating on one sub-guide? Running just its file still pulls the
+  **whole** session-fixture chain (so it catches wiring breaks):
+  `… pytest -v -s docs_e2e/tests/test_<name>.py`.
+
+## Strict mode (#871)
+
+Tests run **only** what the guide tells users to run — no silent
+`migrate`, no hidden user creation, no quietly-pre-imported study. If a
+step is missing, fix the **guide**, not the harness. The one sanctioned
+exception is invisible infrastructure no real user sees (the local conda
+channel, the persistent GRR cache). Documented data carve-outs (capping
+an import to N variants for the time budget) are allowed **only** when
+the guide's command still runs verbatim — see `_DENOVO_VARIANT_CAP` /
+`_CNV_VARIANT_CAP` in `conftest.py` (issues #876 / #877). Every test
+failure must carry the originating `RST file:line` (`rst_ref=`).
+
+## Per-agent GRR cache seeding
+
+The suite is pinned to one agent (`AGENT_LABEL`, default `eyoree`) and
+needs that agent's node-local `gpf-grr-cache` volume pre-seeded by the
+`gpf-docs-e2e-prewarm` job (it bulk-caches ~15 GB of instance resources
+out of band; the build then validates the warm cache fast). The
+`grr_cache_seeded` conftest guard fails fast on an unseeded agent. The
+prewarm currently uses `grr_cache_repo -j 1` to dodge a gain HTTP-timeout
+bug (iossifovlab/gain#43) — drop back to `-j 4` once that's fixed.

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -750,6 +750,115 @@ def denovo_instance(
     )
 
 
+# The awk pipeline example_cnv_import.rst (RST lines 76-83) tells the user
+# to run to build ssc_cnv.tsv from Supplementary_Data_4.tsv.gz, keeping
+# only the SSC-collection rows. Reproduced byte-for-byte from the guide;
+# a drift here is itself a guide-accuracy bug this suite is meant to catch.
+_CNV_AWK = r"""gunzip -c Supplementary_Data_4.tsv.gz | cut -f 2,5-7 | awk '
+    BEGIN{
+        OFS="\t"
+        print "location", "variant", "person_id"
+    }
+    $1 == "SSC" {
+        print $3, $4, $2
+    }' > ssc_cnv.tsv"""
+
+# example_cnv_import.rst imports the ssc_cnv study. STRICT-MODE EXCEPTION
+# (#877, mirroring the #876 denovo cap): docs-e2e guards command accuracy,
+# not full-scale import, so cnv_instance truncates the awk-produced
+# ssc_cnv.tsv to the guide's first _CNV_VARIANT_CAP variants (all chr1)
+# before import. import_genotypes still runs verbatim; only the row count
+# differs, and the warm GRR cache keeps the annotation fast.
+_CNV_VARIANT_CAP = 20
+
+
+@dataclass
+class CnvInstance:
+    """The instance after example_cnv_import.rst: ssc_cnv imported into
+    minimal_instance.
+
+    Captures each setup step's subprocess result so per-test assertions
+    can feed them into ``after_command=`` / ``assert_command_succeeds``
+    for triage.
+    """
+
+    instance_dir: Path
+    clone_path: Path
+    cnv_awk: subprocess.CompletedProcess
+    ssc_cnv_import: subprocess.CompletedProcess
+    study_config_path: Path
+
+
+@pytest.fixture(scope="session")
+def cnv_instance(denovo_instance, getting_started_clone, gpf_env):
+    """Apply example_cnv_import.rst: import the ``ssc_cnv`` study (SSC CNV
+    variants) into the same ``minimal_instance``.
+
+    Walks the guide's command path verbatim:
+
+    1. The SSC-filter awk (RST lines 76-83): reads
+       ``Supplementary_Data_4.tsv.gz`` and writes ``ssc_cnv.tsv``. The
+       pedigree ``ssc_denovo.ped`` is reused from the denovo guide
+       (created by ``denovo_instance``'s ped awk) — exactly as the guide
+       says ("we already discussed how to transform the list of children
+       into a pedigree file").
+    2. ``import_genotypes -v -j 1 .../ssc_cnv.yaml`` (RST line 125):
+       imports + annotates the CNV study using the instance annotation.
+
+    Chained after ``denovo_instance`` to keep the suite's single ``wgpf
+    run`` ordering: ``wgpf_server`` depends on this fixture, so the shared
+    server boots with ``ssc_cnv`` added alongside everything else.
+
+    Strict mode (#871): every step here is a CLI command the guide tells
+    the user to type. The only carve-out is the ``_CNV_VARIANT_CAP``
+    truncation of the awk output (#877) — see the constant's note;
+    ``import_genotypes`` itself still runs verbatim.
+    """
+    clone = getting_started_clone
+    instance_dir = denovo_instance.instance_dir
+    import_dir = clone / "example_imports" / "denovo_and_cnv_import"
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(instance_dir)
+
+    # Step 1: the SSC-filter awk, run from the import dir.
+    cnv_awk = _run(["bash", "-c", _CNV_AWK], cwd=import_dir, env=env)
+
+    # STRICT-MODE EXCEPTION (#877): cap the awk output to the guide's first
+    # _CNV_VARIANT_CAP SSC variants (all chr1) before import_genotypes —
+    # which still runs verbatim below. Mirrors the #876 denovo cap. The awk
+    # command's success and output file are asserted by test_example_cnv
+    # before this truncation mutates the file.
+    cnv_path = import_dir / "ssc_cnv.tsv"
+    if cnv_awk.returncode == 0 and cnv_path.exists():
+        rows = cnv_path.read_text().splitlines()
+        cnv_path.write_text(
+            "\n".join(rows[:_CNV_VARIANT_CAP + 1]) + "\n",
+        )
+
+    # Step 2: import + annotate the (capped) CNV study.
+    ssc_cnv_import = _run(
+        [
+            "import_genotypes", "-v", "-j", "1",
+            "example_imports/denovo_and_cnv_import/ssc_cnv.yaml",
+        ],
+        cwd=clone, env=env, timeout=_IMPORT_TIMEOUT,
+    )
+
+    # The study id is `ssc_cnv`, so the config lands under
+    # studies/<id>/<id>.yaml. The CNV guide makes no further config edit.
+    study_config = (
+        instance_dir / "studies" / "ssc_cnv" / "ssc_cnv.yaml"
+    )
+
+    return CnvInstance(
+        instance_dir=instance_dir,
+        clone_path=clone,
+        cnv_awk=cnv_awk,
+        ssc_cnv_import=ssc_cnv_import,
+        study_config_path=study_config,
+    )
+
+
 def _pick_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -757,23 +866,23 @@ def _pick_free_port():
 
 
 @pytest.fixture(scope="session")
-def wgpf_server(denovo_instance, gpf_env):
+def wgpf_server(cnv_instance, gpf_env):
     """Start ``wgpf run`` in a background subprocess against the
     prepared instance; yield a SimpleNamespace with the base URL,
     httpx client, and the underlying Popen for log access.
 
-    Depends on ``denovo_instance`` — the last stage of the guide's linear
+    Depends on ``cnv_instance`` — the last stage of the guide's linear
     narrative (imports → annotation edit → pheno import + pheno attach →
-    preview-column config → ssc_denovo import + study-column config).
-    ``denovo_instance`` transitively pulls the whole prior chain, so the
-    single shared server starts after every config edit the guide
-    describes: it serves the annotated, pheno-enabled example_dataset with
-    its extended preview columns AND the 255K-variant ssc_denovo study.
-    Keeping the suite to one wgpf process per session avoids two ``wgpf
-    run``s racing on the same ``DAE_DB_DIR`` parquet during re-annotation.
-    Every earlier claim (datasets visible, annotation download columns,
-    pheno browser) holds equally in this final state, so sharing one
-    server across all stages is sound.
+    preview-column config → ssc_denovo import + study-column config →
+    ssc_cnv import). ``cnv_instance`` transitively pulls the whole prior
+    chain, so the single shared server starts after every config edit the
+    guide describes: it serves the annotated, pheno-enabled example_dataset
+    with its extended preview columns, the ssc_denovo study, AND the
+    ssc_cnv study. Keeping the suite to one wgpf process per session avoids
+    two ``wgpf run``s racing on the same ``DAE_DB_DIR`` parquet during
+    re-annotation. Every earlier claim (datasets visible, annotation
+    download columns, pheno browser) holds equally in this final state, so
+    sharing one server across all stages is sound.
 
     On teardown, terminates wgpf and dumps the last few hundred
     lines of its combined stdout/stderr if any test in the
@@ -781,7 +890,7 @@ def wgpf_server(denovo_instance, gpf_env):
     import httpx  # lazy — see top-of-file note.
 
     env = dict(gpf_env)
-    env["DAE_DB_DIR"] = str(denovo_instance.instance_dir)
+    env["DAE_DB_DIR"] = str(cnv_instance.instance_dir)
 
     port = _pick_free_port()
     base_url = f"http://127.0.0.1:{port}"

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -897,7 +897,7 @@ def wgpf_server(cnv_instance, gpf_env):
 
     proc = subprocess.Popen(
         ["wgpf", "run", "--port", str(port), "--host", "127.0.0.1"],
-        cwd=denovo_instance.instance_dir,
+        cwd=cnv_instance.instance_dir,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -936,13 +936,18 @@ def wgpf_server(cnv_instance, gpf_env):
             last_err = repr(exc)
         time.sleep(1)
     else:
-        # Readiness timeout. Capture log for the failure message.
+        # Readiness timeout. Capture the wgpf log for the failure
+        # message. communicate() reads AND closes stdout, so we must use
+        # its return value — a second proc.stdout.read() here raises
+        # "read of closed file" and masks the real reason wgpf never
+        # became ready.
         proc.terminate()
         try:
-            proc.communicate(timeout=10)
+            out_b, _ = proc.communicate(timeout=10)
         except subprocess.TimeoutExpired:
             proc.kill()
-        out = proc.stdout.read().decode(errors="replace") if proc.stdout else ""
+            out_b, _ = proc.communicate()
+        out = out_b.decode(errors="replace") if out_b else ""
         pytest.fail(
             f"wgpf run did not become ready within "
             f"{_WGPF_READY_TIMEOUT}s (last error: {last_err}):\n"

--- a/docs_e2e/tests/test_example_cnv.py
+++ b/docs_e2e/tests/test_example_cnv.py
@@ -1,0 +1,136 @@
+"""Guide-claim tests for example_cnv_import.rst.
+
+The CNV import sub-guide imports a CNV study, ``ssc_cnv`` (SSC CNV
+variants from the Yoon et al. paper), into the same ``minimal_instance``
+the earlier guides built, reusing the ``ssc_denovo.ped`` pedigree. It
+walks the user through:
+
+1. preprocessing ``Supplementary_Data_4.tsv.gz`` with an awk pipeline
+   that filters the SSC collection into a CNV variants file
+   (``ssc_cnv.tsv``);
+2. importing the study with ``import_genotypes -v -j 1``;
+3. seeing ``ssc_cnv`` on the Home Page and querying its CNV variants in
+   the Genotype Browser.
+
+The awk + import live in the session-scoped ``cnv_instance`` fixture
+(conftest.py); ``wgpf_server`` depends on it, so the single shared server
+serves the ssc_cnv-enabled instance. Strict mode (#871): the fixture only
+does what the guide tells the user to do — the awk pipeline and the import
+CLI. The single carve-out is the ``_CNV_VARIANT_CAP`` truncation of the
+awk output (#877, mirroring the #876 denovo cap).
+
+Each test maps to one discrete prose claim. ``rst_ref`` points at the
+line in the guide source so a failure localizes the drift.
+"""
+
+from docs_e2e.guide_assertions import (
+    assert_command_succeeds,
+    assert_dataset_visible,
+    assert_file_created,
+    assert_query_returned_variants,
+)
+
+RST = "example_cnv_import.rst"
+
+
+class TestPreprocessCnv:
+    """RST lines 71-90: the SSC-filter awk reads
+    ``Supplementary_Data_4.tsv.gz`` and produces ``ssc_cnv.tsv``."""
+
+    def test_cnv_awk_command_succeeds(self, cnv_instance):
+        # RST lines 76-83: the awk pipeline that filters the SSC
+        # collection into the CNV variants file.
+        assert_command_succeeds(
+            cnv_instance.cnv_awk,
+            rst_ref=f"{RST}:83",
+            expectation=(
+                "the SSC-filter awk pipeline over "
+                "Supplementary_Data_4.tsv.gz succeeds"
+            ),
+        )
+
+    def test_ssc_cnv_tsv_created(self, cnv_instance):
+        # RST lines 85-90: the script produces the CNV variants file
+        # ssc_cnv.tsv.
+        path = (
+            cnv_instance.clone_path
+            / "example_imports" / "denovo_and_cnv_import" / "ssc_cnv.tsv"
+        )
+        assert_file_created(
+            path,
+            rst_ref=f"{RST}:85",
+            expectation=(
+                "the awk script produces the CNV variants file "
+                "ssc_cnv.tsv"
+            ),
+            after_command=cnv_instance.cnv_awk,
+        )
+
+
+class TestSscCnvImport:
+    """RST lines 99-143: importing the ssc_cnv study and seeing it on the
+    Home Page / querying it in the Genotype Browser."""
+
+    def test_import_genotypes_command_succeeds(self, cnv_instance):
+        # RST line 125: time import_genotypes -v -j 1 .../ssc_cnv.yaml.
+        # The guide imports the full SSC CNV set; the suite caps the input
+        # to the first 20 (conftest, #877 carve-out) but runs this command
+        # verbatim.
+        assert_command_succeeds(
+            cnv_instance.ssc_cnv_import,
+            rst_ref=f"{RST}:125",
+            expectation=(
+                "import_genotypes -v -j 1 example_imports/"
+                "denovo_and_cnv_import/ssc_cnv.yaml succeeds"
+            ),
+        )
+
+    def test_study_yaml_created(self, cnv_instance):
+        # RST lines 134-135: the import produces the study config under
+        # studies/ssc_cnv/ssc_cnv.yaml.
+        path = (
+            cnv_instance.instance_dir
+            / "studies" / "ssc_cnv" / "ssc_cnv.yaml"
+        )
+        assert_file_created(
+            path,
+            rst_ref=f"{RST}:135",
+            expectation=(
+                "minimal_instance/studies/ssc_cnv/ssc_cnv.yaml is "
+                "created after the ssc_cnv import"
+            ),
+            after_command=cnv_instance.ssc_cnv_import,
+        )
+
+    def test_ssc_cnv_visible_on_home_page(self, wgpf_server):
+        # RST lines 134-135: the Home page shows the new study ssc_cnv.
+        resp = wgpf_server.client.get("/api/v3/datasets/visible")
+        assert_dataset_visible(
+            resp, "ssc_cnv",
+            rst_ref=f"{RST}:135",
+            expectation=(
+                "in the Home page of the GPF instance, we should have "
+                "the new study `ssc_cnv`"
+            ),
+        )
+
+    def test_genotype_browser_returns_cnv_variants(self, wgpf_server):
+        # RST lines 141-143: following the study's Genotype Browser tab
+        # lets you query the imported CNV variants.
+        resp = wgpf_server.client.post(
+            "/api/v3/genotype_browser/query",
+            json={"datasetId": "ssc_cnv"},
+        )
+        # min_count=5: the import is capped to the guide's first 20 CNV
+        # variants (conftest, #877 carve-out), so requiring >=5 back proves
+        # the import substantively worked rather than one row squeaking
+        # through — without coupling to an exact post-import count.
+        assert_query_returned_variants(
+            resp,
+            min_count=5,
+            rst_ref=f"{RST}:143",
+            expectation=(
+                "the Genotype Browser of the ssc_cnv study returns the "
+                "imported CNV variants"
+            ),
+        )


### PR DESCRIPTION
Part of the docs-e2e epic iossifovlab/gpf#871. Adds the guide-accuracy suite for `example_cnv_import.rst` (the CNV import sub-guide), following the pattern established by #876 (denovo).

## What's added
- **`docs_e2e/tests/test_example_cnv.py`** — one test per discrete claim: the SSC-filter awk succeeds, `ssc_cnv.tsv` is produced, `import_genotypes -v -j 1 ssc_cnv.yaml` succeeds, the study yaml is created, `ssc_cnv` is visible on the home page, and the genotype browser returns its CNV variants.
- **`cnv_instance` conftest fixture** — chained after `denovo_instance` (reuses `ssc_denovo.ped`, exactly as the guide instructs). `wgpf_server` now depends on it, so the single shared server also serves `ssc_cnv`.

## Strict-mode carve-out (#877, mirrors #876)
The guide imports the full SSC CNV set; the suite truncates the awk output to the **first 20 SSC variants (all chr1)** before `import_genotypes` — which still runs verbatim. docs-e2e guards command accuracy, not full-scale import. The genotype-browser query asserts `min_count=5`.

## Prose fix
`example_cnv_import.rst` pointed at `example_imports/denovo_and_cnv_import/input_data` — no such subdir exists (the files live directly in `denovo_and_cnv_import`). Corrected; this is the same drift #876 fixed for the denovo guide.

## Notes
- No Jenkinsfile change — pytest collects `tests/test_*.py` automatically. The suite runs on the already-seeded `eyoree` agent; the in-build `grr_cache_repo` validates the warm cache and the 20-variant CNV import is fast.
- Ruff: no new findings (only the pre-existing conftest debt). `py_compile` clean.

Closes #877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)