### PR TITLE
docs-e2e: validate getting_started_with_gene_sets.rst (#879)

### DIFF
--- a/docs/source/administration/getting_started/getting_started_with_gene_sets.rst
+++ b/docs/source/administration/getting_started/getting_started_with_gene_sets.rst
@@ -57,21 +57,17 @@ public GRR:
   <https://grr.iossifovlab.com/gene_properties/gene_sets/autism/index.html>`_ -
   autism gene sets derived from publications;
 
-* `gene_properties/gene_sets/relevant
-  <https://grr.iossifovlab.com/gene_properties/gene_sets/relevant/index.html>`_ -
-  variety of gene sets with potential relevance to autism;
-
 * `gene_properties/gene_sets/GO_2024-06-17_release
   <https://grr.iossifovlab.com/gene_properties/gene_sets/GO_2024-06-17_release/index.html>`_ -
   this gene set collection contains genes associated with Gene Ontology
   (GO) terms.
 
-To do this, you need to add lines 14-18 to the GPF instance configuration file
+To do this, you need to add lines 14-17 to the GPF instance configuration file
 (``minimal_instance/gpf_instance.yaml``):
 
 .. code-block:: yaml
     :linenos:
-    :emphasize-lines: 14-18
+    :emphasize-lines: 14-17
 
     instance_id: minimal_instance
 
@@ -89,7 +85,6 @@ To do this, you need to add lines 14-18 to the GPF instance configuration file
     gene_sets_db:
       gene_set_collections:
       - gene_properties/gene_sets/autism
-      - gene_properties/gene_sets/relevant
       - gene_properties/gene_sets/GO_2024-06-17_release
 
 When you restart the GPF instance, the configured gene set collections will be
@@ -134,12 +129,12 @@ public GRR:
   Degree of intolerance to predicted Loss-of-Function (pLoF) variation
 
 
-To do this, you need to add lines 20-26 to the GPF instance configuration file
+To do this, you need to add lines 19-25 to the GPF instance configuration file
 (``minimal_instance/gpf_instance.yaml``):
 
 .. code-block:: yaml
     :linenos:
-    :emphasize-lines: 20-26
+    :emphasize-lines: 19-25
 
     instance_id: minimal_instance
 
@@ -157,7 +152,6 @@ To do this, you need to add lines 20-26 to the GPF instance configuration file
     gene_sets_db:
       gene_set_collections:
       - gene_properties/gene_sets/autism
-      - gene_properties/gene_sets/relevant
       - gene_properties/gene_sets/GO_2024-06-17_release
 
     gene_scores_db:

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -1042,6 +1042,78 @@ def pheno_import_instance(cnv_instance, getting_started_clone, gpf_env):
     )
 
 
+# The gene_sets_db + gene_scores_db blocks getting_started_with_gene_sets.rst
+# tells the user to append to minimal_instance/gpf_instance.yaml (the
+# emphasized lines of the guide's two config code-blocks — RST lines 89-92
+# and 157-169). Kept byte-for-byte in sync with the guide; a drift here is
+# itself a guide-accuracy bug this suite is meant to catch.
+#
+# NOTE: the guide also listed `gene_properties/gene_sets/relevant`, but that
+# resource 404s in the public GRR (its config and its guide index.html link
+# are both gone) — guide drift fixed in the RST in the same PR (#879), so it
+# is absent here too. autism + GO are the surviving collections.
+_GENE_SETS_BLOCK = (
+    "\n"
+    "gene_sets_db:\n"
+    "  gene_set_collections:\n"
+    "  - gene_properties/gene_sets/autism\n"
+    "  - gene_properties/gene_sets/GO_2024-06-17_release\n"
+    "\n"
+    "gene_scores_db:\n"
+    "  gene_scores:\n"
+    "  - gene_properties/gene_scores/Satterstrom_Buxbaum_Cell_2020\n"
+    "  - gene_properties/gene_scores/Iossifov_Wigler_PNAS_2015\n"
+    "  - gene_properties/gene_scores/LGD\n"
+    "  - gene_properties/gene_scores/RVIS\n"
+    "  - gene_properties/gene_scores/LOEUF\n"
+)
+
+
+@dataclass
+class GeneSetsInstance:
+    """The instance after getting_started_with_gene_sets.rst: the
+    ``gene_sets_db`` (autism + GO collections) and ``gene_scores_db`` (five
+    gene scores) blocks added to gpf_instance.yaml."""
+
+    instance_dir: Path
+    clone_path: Path
+    config_path: Path
+
+
+@pytest.fixture(scope="session")
+def gene_sets_instance(pheno_import_instance):
+    """Apply getting_started_with_gene_sets.rst: append the
+    ``gene_sets_db`` + ``gene_scores_db`` blocks to
+    minimal_instance/gpf_instance.yaml (RST lines 89-92 + 157-169).
+
+    The de Novo gene sets the guide's first section describes need no
+    config — the GPF system generates them for any study with de Novo
+    variants (``ssc_denovo``), so they are exercised against the existing
+    instance with no edit here. This fixture only adds the two config
+    blocks the guide's later sections tell the user to type.
+
+    Chained after ``pheno_import_instance`` (the prior tail) to keep the
+    suite's single ``wgpf run`` ordering: ``wgpf_server`` depends on this
+    fixture, so the shared server boots with the gene set collections and
+    gene scores configured on top of everything else.
+
+    Strict mode (#871): the only thing done here is the yaml edit a real
+    user types. The configured collections/scores are GRR resources the
+    server demand-pulls on first access (gene_sets_db / gene_scores_db are
+    lazy ``@cached_property``); they are NOT in the prewarmed cache (the
+    prewarm runs against the base config), so the first request that
+    touches them pays a cold GRR pull — the gene-set/score tests allow for
+    that with a generous per-request timeout.
+    """
+    config_path = pheno_import_instance.instance_dir / "gpf_instance.yaml"
+    config_path.write_text(config_path.read_text() + _GENE_SETS_BLOCK)
+    return GeneSetsInstance(
+        instance_dir=pheno_import_instance.instance_dir,
+        clone_path=pheno_import_instance.clone_path,
+        config_path=config_path,
+    )
+
+
 def _pick_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -1049,25 +1121,27 @@ def _pick_free_port():
 
 
 @pytest.fixture(scope="session")
-def wgpf_server(pheno_import_instance, gpf_env):
+def wgpf_server(gene_sets_instance, gpf_env):
     """Start ``wgpf run`` in a background subprocess against the
     prepared instance; yield a SimpleNamespace with the base URL,
     httpx client, and the underlying Popen for log access.
 
-    Depends on ``pheno_import_instance`` — the last stage of the guide's
+    Depends on ``gene_sets_instance`` — the last stage of the guide's
     linear narrative (imports → annotation edit → pheno import + pheno
     attach → preview-column config → ssc_denovo import + study-column
-    config → ssc_cnv import → ssc_pheno import + ssc_denovo pheno-attach).
-    ``pheno_import_instance`` transitively pulls the whole prior chain, so
-    the single shared server starts after every config edit the guide
-    describes: it serves the annotated, pheno-enabled example_dataset with
-    its extended preview columns, the ssc_denovo study (now with the
-    ssc_pheno phenotype study attached), the ssc_cnv study, AND the
-    ssc_pheno phenotype study. Keeping the suite to one wgpf process per
-    session avoids two ``wgpf run``s racing on the same ``DAE_DB_DIR``
-    parquet during re-annotation. Every earlier claim (datasets visible,
-    annotation download columns, pheno browser) holds equally in this
-    final state, so sharing one server across all stages is sound.
+    config → ssc_cnv import → ssc_pheno import + ssc_denovo pheno-attach →
+    gene_sets_db + gene_scores_db config). ``gene_sets_instance``
+    transitively pulls the whole prior chain, so the single shared server
+    starts after every config edit the guide describes: it serves the
+    annotated, pheno-enabled example_dataset with its extended preview
+    columns, the ssc_denovo study (with the ssc_pheno phenotype study
+    attached), the ssc_cnv study, the ssc_pheno phenotype study, AND the
+    configured gene set collections + gene scores. Keeping the suite to one
+    wgpf process per session avoids two ``wgpf run``s racing on the same
+    ``DAE_DB_DIR`` parquet during re-annotation. Every earlier claim
+    (datasets visible, annotation download columns, pheno browser) holds
+    equally in this final state, so sharing one server across all stages is
+    sound.
 
     wgpf's combined stdout/stderr is redirected to a temp FILE rather
     than ``subprocess.PIPE``. This matters: the readiness poll below does
@@ -1086,7 +1160,7 @@ def wgpf_server(pheno_import_instance, gpf_env):
     import httpx  # lazy — see top-of-file note.
 
     env = dict(gpf_env)
-    env["DAE_DB_DIR"] = str(pheno_import_instance.instance_dir)
+    env["DAE_DB_DIR"] = str(gene_sets_instance.instance_dir)
 
     port = _pick_free_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -1112,7 +1186,7 @@ def wgpf_server(pheno_import_instance, gpf_env):
 
     proc = subprocess.Popen(
         ["wgpf", "run", "--port", str(port), "--host", "127.0.0.1"],
-        cwd=pheno_import_instance.instance_dir,
+        cwd=gene_sets_instance.instance_dir,
         env=env,
         stdout=log_fh,
         stderr=subprocess.STDOUT,

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -666,3 +666,145 @@ def assert_preview_table_column_group(
         "name", expected_column_names, actual_names,
         group_name=group_name, rst_ref=rst_ref, expectation=expectation,
     )
+
+
+def assert_gene_set_collections_available(
+        response, collections, *, rst_ref, expectation,
+):
+    """Assert each of ``collections`` is listed by the gene-sets collections
+    endpoint (``/api/v3/gene_sets/gene_sets_collections``).
+
+    Backs the gene-sets guide's claim that, after adding ``gene_sets_db`` to
+    the instance config, the configured gene set collections become
+    available. The response is a JSON list of collection dicts each carrying
+    a ``name`` (collection id) — note the id is the collection's configured
+    ``id``, which may differ from its GRR resource path (e.g. the
+    ``gene_properties/gene_sets/GO_2024-06-17_release`` resource has id
+    ``GO``). A non-200 status fails with HTTP-error triage; a missing
+    collection fails with a hint pointing at the config edit / GRR resource.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with gene set collections {collections} listed"
+            ),
+        ))
+    listed = [
+        c.get("name") for c in response.json() if isinstance(c, dict)
+    ]
+    missing = [c for c in collections if c not in listed]
+    if not missing:
+        return
+    available = ", ".join(repr(c) for c in listed) or "(none)"
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected gene set collections: {', '.join(collections)}\n"
+        f"  missing:                       {', '.join(missing)}\n"
+        f"  available:                     [{available}]\n"
+        f"\n"
+        f"  Triage hint: The collections endpoint responded but an expected "
+        f"collection is absent. Most likely either (a) the gene_sets_db "
+        f"block was not added to gpf_instance.yaml (or the server did not "
+        f"pick it up — check the wgpf log dump), (b) the configured GRR "
+        f"resource is missing/renamed in the public GRR (a 404 there is "
+        f"skipped at load), or (c) the collection's configured id drifted "
+        f"from the guide. If the new id is correct, update the guide."
+    )
+    raise AssertionError(message)
+
+
+def assert_gene_scores_available(response, scores, *, rst_ref, expectation):
+    """Assert each of ``scores`` is listed by the gene-scores endpoint
+    (``/api/v3/gene_scores/``).
+
+    Backs the gene-sets guide's claim that, after adding ``gene_scores_db``
+    to the instance config, the configured gene scores become available. The
+    response is a JSON list of score dicts each carrying a ``score`` (score
+    id) — note a single ``gene_score`` GRR resource can expose several scored
+    columns, each with its own id (e.g. the ``LGD`` resource exposes
+    ``LGD_score`` + ``LGD_rank``), so the ids may differ from the resource
+    name. A non-200 status fails with HTTP-error triage; a missing score
+    fails with a hint pointing at the config edit / GRR resource.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with gene scores {scores} listed"
+            ),
+        ))
+    listed = [
+        s.get("score") for s in response.json() if isinstance(s, dict)
+    ]
+    missing = [s for s in scores if s not in listed]
+    if not missing:
+        return
+    available = ", ".join(repr(s) for s in listed) or "(none)"
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected gene scores: {', '.join(scores)}\n"
+        f"  missing:              {', '.join(missing)}\n"
+        f"  available:            [{available}]\n"
+        f"\n"
+        f"  Triage hint: The gene-scores endpoint responded but an expected "
+        f"score is absent. Most likely either (a) the gene_scores_db block "
+        f"was not added to gpf_instance.yaml (or the server did not pick it "
+        f"up — check the wgpf log dump), (b) the configured GRR resource is "
+        f"missing/renamed, or (c) the score's id drifted from the guide. If "
+        f"the new id is correct, update the guide."
+    )
+    raise AssertionError(message)
+
+
+def assert_denovo_gene_sets_for_dataset(
+        response, dataset_id, *, rst_ref, expectation,
+):
+    """Assert ``dataset_id`` is listed by the de Novo gene sets types
+    endpoint (``/api/v3/gene_sets/denovo_gene_sets_types``).
+
+    Backs the gene-sets guide's claim that the GPF system generates a
+    collection of de Novo gene sets for each genotype study with de Novo
+    variants (e.g. ``ssc_denovo``). The response is a JSON list of dicts each
+    carrying a ``datasetId``; a study appearing there means its de Novo gene
+    sets were generated and are available in the Genotype Browser's
+    ``Genes > Gene Sets`` tab. A non-200 status fails with HTTP-error triage;
+    a missing dataset fails with a hint pointing at the study's de Novo data
+    / denovo_gene_sets config.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with dataset '{dataset_id}' among the de Novo "
+                f"gene set types"
+            ),
+        ))
+    listed = [
+        d.get("datasetId") for d in response.json() if isinstance(d, dict)
+    ]
+    if dataset_id in listed:
+        return
+    available = ", ".join(repr(d) for d in listed) or "(none)"
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected dataset with de Novo gene sets: {dataset_id!r}\n"
+        f"  available datasets:                      [{available}]\n"
+        f"\n"
+        f"  Triage hint: The de Novo gene sets endpoint responded but "
+        f"{dataset_id!r} is not among the studies with generated de Novo "
+        f"gene sets. Most likely either (a) the study has no de Novo "
+        f"variants / its import did not load them (re-check the import), or "
+        f"(b) denovo_gene_sets is disabled in the study config. If the study "
+        f"id in the guide drifted, update the guide."
+    )
+    raise AssertionError(message)

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -13,9 +13,12 @@ from docs_e2e.guide_assertions import (
     assert_command_succeeds,
     assert_dataset_description_flag,
     assert_dataset_visible,
+    assert_denovo_gene_sets_for_dataset,
     assert_download_has_columns,
     assert_download_trailing_columns,
     assert_file_created,
+    assert_gene_scores_available,
+    assert_gene_set_collections_available,
     assert_genomic_score_available,
     assert_image_response_ok,
     assert_pheno_instruments_available,
@@ -768,3 +771,137 @@ class TestAssertPreviewTableColumnGroup:
         message = str(exc_info.value)
         assert "404" in message
         assert "Triage" in message
+
+
+_GS_RST = "getting_started_with_gene_sets.rst"
+
+
+class TestAssertGeneSetCollectionsAvailable:
+    def test_passes_when_all_collections_present(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[
+                {"name": "autism"}, {"name": "denovo"}, {"name": "GO"},
+            ],
+        )
+        assert_gene_set_collections_available(
+            resp, ["autism", "GO"],
+            rst_ref=f"{_GS_RST}:95",
+            expectation="configured gene set collections are available",
+        )
+
+    def test_raises_when_collection_missing(self):
+        # Models the relevant-404 drift: a configured collection that did
+        # not load is absent from the list.
+        resp = _FakeResponse(
+            200,
+            json_body=[{"name": "autism"}, {"name": "GO"}],
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_set_collections_available(
+                resp, ["autism", "relevant", "GO"],
+                rst_ref=f"{_GS_RST}:95",
+                expectation="configured gene set collections are available",
+            )
+        message = str(exc_info.value)
+        assert f"{_GS_RST}:95" in message
+        assert "relevant" in message
+        # Lists what IS available so the operator can spot the gap.
+        assert "autism" in message
+        assert "Triage" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(500, text="Internal Server Error")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_set_collections_available(
+                resp, ["autism"],
+                rst_ref=f"{_GS_RST}:95",
+                expectation="configured gene set collections are available",
+            )
+        assert "500" in str(exc_info.value)
+
+
+class TestAssertGeneScoresAvailable:
+    def test_passes_when_all_scores_present(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[
+                {"score": "LGD_score"}, {"score": "RVIS score"},
+                {"score": "LOEUF"},
+            ],
+        )
+        assert_gene_scores_available(
+            resp, ["LGD_score", "LOEUF"],
+            rst_ref=f"{_GS_RST}:171",
+            expectation="configured gene scores are available",
+        )
+
+    def test_raises_when_score_missing(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[{"score": "LGD_score"}],
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_scores_available(
+                resp, ["LGD_score", "LOEUF"],
+                rst_ref=f"{_GS_RST}:171",
+                expectation="configured gene scores are available",
+            )
+        message = str(exc_info.value)
+        assert f"{_GS_RST}:171" in message
+        assert "LOEUF" in message
+        assert "LGD_score" in message
+        assert "Triage" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(503, text="Service Unavailable")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_scores_available(
+                resp, ["LOEUF"],
+                rst_ref=f"{_GS_RST}:171",
+                expectation="configured gene scores are available",
+            )
+        assert "503" in str(exc_info.value)
+
+
+class TestAssertDenovoGeneSetsForDataset:
+    def test_passes_when_dataset_present(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[
+                {"datasetId": "denovo_example"},
+                {"datasetId": "ssc_denovo"},
+            ],
+        )
+        assert_denovo_gene_sets_for_dataset(
+            resp, "ssc_denovo",
+            rst_ref=f"{_GS_RST}:37",
+            expectation="de Novo gene sets are generated for ssc_denovo",
+        )
+
+    def test_raises_when_dataset_missing(self):
+        resp = _FakeResponse(
+            200,
+            json_body=[{"datasetId": "denovo_example"}],
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_denovo_gene_sets_for_dataset(
+                resp, "ssc_denovo",
+                rst_ref=f"{_GS_RST}:37",
+                expectation="de Novo gene sets are generated for ssc_denovo",
+            )
+        message = str(exc_info.value)
+        assert f"{_GS_RST}:37" in message
+        assert "ssc_denovo" in message
+        assert "denovo_example" in message
+        assert "Triage" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(500, text="Internal Server Error")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_denovo_gene_sets_for_dataset(
+                resp, "ssc_denovo",
+                rst_ref=f"{_GS_RST}:37",
+                expectation="de Novo gene sets are generated for ssc_denovo",
+            )
+        assert "500" in str(exc_info.value)

--- a/docs_e2e/tests/test_gene_sets.py
+++ b/docs_e2e/tests/test_gene_sets.py
@@ -1,0 +1,136 @@
+"""Guide-claim tests for getting_started_with_gene_sets.rst.
+
+The gene-sets sub-guide covers three things, all against the same
+``minimal_instance`` the earlier guides built:
+
+1. **de Novo gene sets** — the GPF system auto-generates a collection of
+   de Novo gene sets (LGDs, LGDs.Male, Missense, ...) for every genotype
+   study with de Novo variants (``ssc_denovo``); no config needed. They
+   show up in the study's Genotype Browser ``Genes > Gene Sets`` tab.
+2. **pre-defined gene set collections** — adding a ``gene_sets_db`` block
+   to gpf_instance.yaml makes the configured GRR gene set collections
+   (``autism``, ``GO``) available.
+3. **pre-defined gene scores** — adding a ``gene_scores_db`` block makes
+   the configured GRR gene scores available.
+
+The two config edits live in the session-scoped ``gene_sets_instance``
+fixture (conftest.py); ``wgpf_server`` depends on it, so the single shared
+server serves the gene-set/score-enabled instance. The de Novo gene sets
+need no edit — they are generated for ``ssc_denovo`` (imported earlier in
+the chain).
+
+Strict mode (#871): the fixture only does what the guide tells the user to
+do — the two yaml edits. The configured collections/scores are GRR
+resources the server demand-pulls on first access; they are not in the
+prewarmed cache, so the collection/score tests use a generous per-request
+timeout to absorb that one-time cold pull.
+
+Guide-drift fix shipped in the same PR (#879): the guide also listed
+``gene_properties/gene_sets/relevant``, but that resource 404s in the
+public GRR (resource + guide index.html link both gone), so it was removed
+from the RST and is absent from the fixture config — these tests assert the
+surviving ``autism`` + ``GO`` collections.
+
+Each test maps to one discrete prose claim. ``rst_ref`` points at the line
+in the guide source so a failure localizes the drift.
+"""
+
+from docs_e2e.guide_assertions import (
+    assert_denovo_gene_sets_for_dataset,
+    assert_gene_scores_available,
+    assert_gene_set_collections_available,
+)
+
+RST = "getting_started_with_gene_sets.rst"
+
+# The gene set collection ids the configured gene_sets_db resolves to.
+# NB: the id is the collection's configured `id`, which differs from the
+# GRR resource path — `gene_properties/gene_sets/GO_2024-06-17_release` has
+# id `GO` (see the resource's genomic_resource.yaml).
+GENE_SET_COLLECTIONS = ["autism", "GO"]
+
+# The gene score ids the configured gene_scores_db resolves to — one stable
+# id per configured GRR gene_score resource. A single resource can expose
+# several scored columns (e.g. LGD -> LGD_score + LGD_rank); we assert one
+# representative id per resource.
+GENE_SCORES = [
+    "Satterstrom Buxbaum Cell 2020 qval",   # Satterstrom_Buxbaum_Cell_2020
+    "Iossifov Wigler PNAS 2015 post noaut",  # Iossifov_Wigler_PNAS_2015
+    "LGD_score",                             # LGD
+    "RVIS score",                            # RVIS
+    "LOEUF",                                 # LOEUF
+]
+
+# Cold demand-pull budget: the gene_sets_db / gene_scores_db GRR resources
+# are not in the prewarmed cache, so the first request that touches each
+# lazy collection pays a one-time GRR fetch. Well above the shared client's
+# default 60s, comfortably under the build wall.
+_COLD_PULL_TIMEOUT = 300
+
+
+class TestDenovoGeneSets:
+    """RST lines 19-44: the GPF system auto-generates de Novo gene sets for
+    each genotype study with de Novo variants (``ssc_denovo``)."""
+
+    def test_ssc_denovo_has_denovo_gene_sets(self, wgpf_server):
+        # RST lines 34-37: navigating to the ssc_denovo Genotype Browser
+        # `Genes > Gene Sets` tab shows the de Novo gene sets generated for
+        # the study. The denovo_gene_sets_types endpoint backs that listing;
+        # building the per-study cache here pays the (capped) de Novo query.
+        resp = wgpf_server.client.get(
+            "/api/v3/gene_sets/denovo_gene_sets_types",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_denovo_gene_sets_for_dataset(
+            resp, "ssc_denovo",
+            rst_ref=f"{RST}:37",
+            expectation=(
+                "the GPF system generates de Novo gene sets for the "
+                "ssc_denovo study (visible in its Genotype Browser "
+                "`Genes > Gene Sets` tab)"
+            ),
+        )
+
+
+class TestGeneSetCollections:
+    """RST lines 47-103: adding the ``gene_sets_db`` block makes the
+    configured pre-defined gene set collections available."""
+
+    def test_configured_collections_available(self, wgpf_server):
+        # RST lines 91-94: after restart the configured gene set collections
+        # are available (shown in the ssc_denovo Genotype Browser
+        # `Genes > Gene Sets` tab). First touch demand-pulls them from GRR.
+        resp = wgpf_server.client.get(
+            "/api/v3/gene_sets/gene_sets_collections",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_gene_set_collections_available(
+            resp, GENE_SET_COLLECTIONS,
+            rst_ref=f"{RST}:93",
+            expectation=(
+                "the configured gene set collections (autism, GO) are "
+                "available after adding the gene_sets_db block"
+            ),
+        )
+
+
+class TestGeneScores:
+    """RST lines 106-179: adding the ``gene_scores_db`` block makes the
+    configured pre-defined gene scores available."""
+
+    def test_configured_gene_scores_available(self, wgpf_server):
+        # RST lines 165-168: after restart the configured gene scores are
+        # available (shown in the ssc_denovo Genotype Browser
+        # `Genes > Gene Scores` tab). First touch demand-pulls them from GRR.
+        resp = wgpf_server.client.get(
+            "/api/v3/gene_scores/",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_gene_scores_available(
+            resp, GENE_SCORES,
+            rst_ref=f"{RST}:165",
+            expectation=(
+                "the configured gene scores are available after adding the "
+                "gene_scores_db block"
+            ),
+        )


### PR DESCRIPTION
Extends the `gpf-docs-e2e` guide-accuracy suite (epic #871) to `getting_started_with_gene_sets.rst` — the next open child (#879).

## What lands

- **`docs_e2e/tests/test_gene_sets.py`** — one test per discrete prose claim:
  - de Novo gene sets are auto-generated for `ssc_denovo` (`GET /api/v3/gene_sets/denovo_gene_sets_types` lists it);
  - the configured pre-defined gene set collections (`autism`, `GO`) are available (`GET /api/v3/gene_sets/gene_sets_collections`);
  - the configured pre-defined gene scores are available (`GET /api/v3/gene_scores/`).
- **`gene_sets_instance` fixture** — appends the `gene_sets_db` + `gene_scores_db` blocks to `gpf_instance.yaml` (the only thing the guide tells the user to do; no import). `wgpf_server` now depends on it.
- **Three reusable `guide_assertions` helpers** (+ unit tests): `assert_gene_set_collections_available`, `assert_gene_scores_available`, `assert_denovo_gene_sets_for_dataset`.

These DBs are lazy `@cached_property`, so the configured GRR collections/scores **demand-pull on first request** — they are not in the prewarmed cache (built from the base config). The tests use a 300s per-request timeout to absorb that one-time cold pull; verified locally it fits comfortably (the run took ~2 min longer than a warm run, all within budget).

## ⚠️ Guide-drift fix (same PR)

The guide listed `gene_properties/gene_sets/relevant`, but **that resource 404s in the public GRR** — both its `genomic_resource.yaml` and the guide's own `index.html` link are gone, while the sibling `autism` / `GO` collections resolve fine. I removed the dead `relevant` reference from the RST (prose bullet + both config code blocks, with the `emphasize-lines` / "add lines N-M" prose corrected to match).

If a renamed `relevant` collection should be restored instead, that's a follow-up for the GRR/guide owners — I removed it rather than guess a replacement.

Two non-obvious facts the tests encode (verified against the live GRR resource configs): the `GO_2024-06-17_release` collection's **id is `GO`** (not the resource-path basename), and gene-score ids are the resources' configured **score ids** (e.g. `LGD_score`, `RVIS score`, `LOEUF`), not the resource names.

## Verification

Full suite in the docs-e2e driver container (warm `gpf-grr-cache`, conda artefacts from gpf master #5807): **119 passed in 291s** (was 107) — the cold GRR pull of the gene-set/score resources included, 0 failures.

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
