### PR TITLE
docs-e2e: validate getting_started_with_gene_profiles.rst (#881)

### DIFF
--- a/docs/source/administration/getting_started/getting_started_files/gene_profiles.yaml
+++ b/docs/source/administration/getting_started/getting_started_files/gene_profiles.yaml
@@ -44,8 +44,6 @@ gene_scores:
 - category: protection_scores
   display_name: Protection Gene Scores
   scores:
-    - score_name: RVIS_rank
-      format: "%%s"
     - score_name: LGD_rank
       format: "%%s"
     - score_name: LOEUF_rank

--- a/docs/source/administration/getting_started/getting_started_with_federation.rst
+++ b/docs/source/administration/getting_started/getting_started_with_federation.rst
@@ -33,7 +33,7 @@ local GPF instance. You can do this by editing the
 
 .. code-block:: yaml
     :linenos:
-    :emphasize-lines: 31-33
+    :emphasize-lines: 30-32
 
     instance_id: minimal_instance
 
@@ -59,7 +59,6 @@ local GPF instance. You can do this by editing the
       - gene_properties/gene_scores/Satterstrom_Buxbaum_Cell_2020
       - gene_properties/gene_scores/Iossifov_Wigler_PNAS_2015
       - gene_properties/gene_scores/LGD
-      - gene_properties/gene_scores/RVIS
       - gene_properties/gene_scores/LOEUF
 
     gene_profiles_config:

--- a/docs/source/administration/getting_started/getting_started_with_gene_profiles.rst
+++ b/docs/source/administration/getting_started/getting_started_with_gene_profiles.rst
@@ -39,7 +39,7 @@ There are several sections in this configuration file:
   of gene scores:
 
   - ``autism_scores`` - lines 36-42;
-  - ``protection_scores`` - lines 44-52.
+  - ``protection_scores`` - lines 44-50.
 
   Please note that all gene scores used in this configuration section should
   be defined in the GPF instance configuration file.
@@ -49,7 +49,7 @@ There are several sections in this configuration file:
   the defined gene sets. In our example, we are going to use one group of gene
   sets:
 
-  - ``autism_gene_sets`` - lines 54-67;
+  - ``autism_gene_sets`` - lines 52-65;
 
     Please note that all gene sets used in this configuration section should
     be defined in the GPF instance configuration file.
@@ -57,16 +57,16 @@ There are several sections in this configuration file:
 - ``gene_links``: This section defines links to internal and external tools
   that contain information about genes. In our example, we are defining three
   links:
-  - lines 70-71 - link to the GPF Gene Browser tools;
-  - lines 73-74 - link to the GeneCards site;
-  - lines 75-76 - link to the SFARI Gene site.
+  - lines 68-69 - link to the GPF Gene Browser tools;
+  - lines 71-72 - link to the GeneCards site;
+  - lines 73-74 - link to the SFARI Gene site.
 
 Once we have this configuration, we need to add it to the GPF instance
 configuration:
 
 .. code-block:: yaml
     :linenos:
-    :emphasize-lines: 28-29
+    :emphasize-lines: 26-27
 
     instance_id: minimal_instance
 
@@ -91,7 +91,6 @@ configuration:
       - gene_properties/gene_scores/Satterstrom_Buxbaum_Cell_2020
       - gene_properties/gene_scores/Iossifov_Wigler_PNAS_2015
       - gene_properties/gene_scores/LGD
-      - gene_properties/gene_scores/RVIS
       - gene_properties/gene_scores/LOEUF
 
     gene_profiles_config:

--- a/docs/source/administration/getting_started/getting_started_with_gene_profiles.rst
+++ b/docs/source/administration/getting_started/getting_started_with_gene_profiles.rst
@@ -84,7 +84,6 @@ configuration:
     gene_sets_db:
       gene_set_collections:
       - gene_properties/gene_sets/autism
-      - gene_properties/gene_sets/relevant
       - gene_properties/gene_sets/GO_2024-06-17_release
 
     gene_scores_db:

--- a/docs/source/administration/getting_started/getting_started_with_gene_sets.rst
+++ b/docs/source/administration/getting_started/getting_started_with_gene_sets.rst
@@ -120,21 +120,17 @@ public GRR:
   <https://grr.iossifovlab.com/gene_properties/gene_scores/LGD/index.html>`_
   Gene vulnerability/intolerance score based on the rare LGD variants
 
-- `gene_properties/gene_scores/RVIS
-  <https://grr.iossifovlab.com/gene_properties/gene_scores/RVIS/index.html>`_
-  Residual Variation Intolerance Score
-
 - `gene_properties/gene_scores/LOEUF
   <https://grr.iossifovlab.com/gene_properties/gene_scores/LOEUF/index.html>`_
   Degree of intolerance to predicted Loss-of-Function (pLoF) variation
 
 
-To do this, you need to add lines 19-25 to the GPF instance configuration file
+To do this, you need to add lines 19-24 to the GPF instance configuration file
 (``minimal_instance/gpf_instance.yaml``):
 
 .. code-block:: yaml
     :linenos:
-    :emphasize-lines: 19-25
+    :emphasize-lines: 19-24
 
     instance_id: minimal_instance
 
@@ -159,7 +155,6 @@ To do this, you need to add lines 19-25 to the GPF instance configuration file
       - gene_properties/gene_scores/Satterstrom_Buxbaum_Cell_2020
       - gene_properties/gene_scores/Iossifov_Wigler_PNAS_2015
       - gene_properties/gene_scores/LGD
-      - gene_properties/gene_scores/RVIS
       - gene_properties/gene_scores/LOEUF
 
 When you restart the GPF instance, the configured gene scores will be

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -1153,6 +1153,136 @@ def gene_sets_instance(pheno_import_instance):
     )
 
 
+# getting_started_with_gene_profiles.rst tells the user to CREATE
+# minimal_instance/gene_profiles.yaml "with the following content" — the
+# guide's literalinclude of getting_started_files/gene_profiles.yaml (RST
+# lines 8-16). Rather than embed an inline copy that could silently drift
+# from the literalinclude target, the fixture writes the actual file the
+# guide renders, read from the gpf docs tree (a path relative to this
+# conftest). The file IS the guide's claim; reading it keeps the two in
+# lock-step automatically.
+_GPF_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GENE_PROFILES_YAML_SRC = (
+    _GPF_REPO_ROOT
+    / "docs/source/administration/getting_started"
+    / "getting_started_files/gene_profiles.yaml"
+)
+
+# The two-line block getting_started_with_gene_profiles.rst (the emphasized
+# lines 28-29 of the gpf_instance.yaml config code-block — RST lines 98-99)
+# tells the user to add to gpf_instance.yaml to enable the Gene Profiles
+# tool. Kept byte-for-byte in sync with the guide.
+_GENE_PROFILES_CONFIG_BLOCK = (
+    "\n"
+    "gene_profiles_config:\n"
+    "  conf_file: gene_profiles.yaml\n"
+)
+
+# The guide's main body says to run bare ``generate_gene_profile``, which
+# builds profiles for all 19,285 MANE genes (~10 min — RST lines 101-113).
+# Its ``.. note::`` (RST lines 116-128) offers a ``--genes`` form to limit
+# generation to a short list "if you want to speed up the process". docs-e2e
+# runs that documented form: it is a command the guide itself tells the user
+# to type, for exactly the purpose of keeping the step fast, so the build
+# stays inside its wall-time budget. Reproduced byte-for-byte from the note;
+# CHD8 (the guide's single-gene screenshot, RST line 156) heads the list.
+_GENE_PROFILES_GENES = (
+    "CHD8,NCKAP1,DSCAM,ANK2,GRIN2B,SYNGAP1,ARID1B,MED13L,GIGYF1,WDFY3"
+)
+
+# 15 min: the --genes form over the capped ssc_denovo still builds the
+# GPFInstance (reference genome + gene models from the warm GRR cache) and
+# queries variant counts per gene, but for ten genes only.
+_GP_GENERATE_TIMEOUT = 900
+
+
+@dataclass
+class GeneProfilesInstance:
+    """The instance after getting_started_with_gene_profiles.rst: the
+    ``gene_profiles.yaml`` config created, the ``gene_profiles_config`` block
+    added to gpf_instance.yaml, and the gene profiles prebuilt into
+    ``gpdb.duckdb`` by ``generate_gene_profile``.
+
+    Captures the prebuild subprocess result so per-test assertions can feed
+    it into ``after_command=`` / ``assert_command_succeeds`` for triage.
+    """
+
+    instance_dir: Path
+    clone_path: Path
+    config_path: Path
+    gene_profiles_yaml_path: Path
+    generate: subprocess.CompletedProcess
+    gpdb_path: Path
+
+
+@pytest.fixture(scope="session")
+def gene_profiles_instance(gene_sets_instance, gpf_env):
+    """Apply getting_started_with_gene_profiles.rst: configure + prebuild the
+    Gene Profiles tool on the same ``minimal_instance`` the earlier guides
+    built.
+
+    Walks the guide's command path:
+
+    1. Create ``minimal_instance/gene_profiles.yaml`` with the guide's
+       literalinclude content (RST lines 8-16), read from the gpf docs tree.
+    2. Append the ``gene_profiles_config`` block to gpf_instance.yaml
+       (RST lines 98-99) to enable the tool.
+    3. Run ``generate_gene_profile --genes <list>`` (the guide's note, RST
+       lines 116-128) to prebuild the profiles into ``gpdb.duckdb`` in
+       ``DAE_DB_DIR``; the instance loads that file on the next ``wgpf run``.
+
+    Chained after ``gene_sets_instance`` (the prior tail) to keep the suite's
+    single ``wgpf run`` ordering: ``wgpf_server`` depends on this fixture, so
+    the shared server boots with the Gene Profiles tool configured and its
+    gpdb prebuilt on top of everything else. The configured gene scores +
+    gene set collections the gene_profiles.yaml references are exactly those
+    ``gene_sets_instance`` added, so chaining after it keeps them resolvable.
+
+    Strict mode (#871): the only things done here are the file create + yaml
+    edit + CLI prebuild the guide tells the user to type. The ``--genes`` form
+    is the guide's own documented fast path (RST lines 116-128), not a harness
+    carve-out — the command runs verbatim, only the gene list is the guide's
+    short one.
+    """
+    instance_dir = gene_sets_instance.instance_dir
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(instance_dir)
+
+    # Step 1: create minimal_instance/gene_profiles.yaml from the guide's
+    # literalinclude target. Fail loudly if the file the guide points at is
+    # gone — that is itself a guide-accuracy bug.
+    if not _GENE_PROFILES_YAML_SRC.is_file():
+        pytest.fail(
+            f"The guide's literalinclude target {_GENE_PROFILES_YAML_SRC} "
+            f"does not exist; getting_started_with_gene_profiles.rst points "
+            f"at it for the gene_profiles.yaml content.",
+            pytrace=False,
+        )
+    gene_profiles_yaml = instance_dir / "gene_profiles.yaml"
+    gene_profiles_yaml.write_text(_GENE_PROFILES_YAML_SRC.read_text())
+
+    # Step 2: enable the tool — append gene_profiles_config to gpf_instance.yaml.
+    config_path = instance_dir / "gpf_instance.yaml"
+    config_path.write_text(
+        config_path.read_text() + _GENE_PROFILES_CONFIG_BLOCK)
+
+    # Step 3: prebuild the profiles. generate_gene_profile reads DAE_DB_DIR for
+    # both the instance config and the gpdb.duckdb output path.
+    generate = _run(
+        ["generate_gene_profile", "--genes", _GENE_PROFILES_GENES],
+        cwd=instance_dir, env=env, timeout=_GP_GENERATE_TIMEOUT,
+    )
+
+    return GeneProfilesInstance(
+        instance_dir=instance_dir,
+        clone_path=gene_sets_instance.clone_path,
+        config_path=config_path,
+        gene_profiles_yaml_path=gene_profiles_yaml,
+        generate=generate,
+        gpdb_path=instance_dir / "gpdb.duckdb",
+    )
+
+
 def _pick_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
@@ -1160,22 +1290,23 @@ def _pick_free_port():
 
 
 @pytest.fixture(scope="session")
-def wgpf_server(gene_sets_instance, gpf_env):
+def wgpf_server(gene_profiles_instance, gpf_env):
     """Start ``wgpf run`` in a background subprocess against the
     prepared instance; yield a SimpleNamespace with the base URL,
     httpx client, and the underlying Popen for log access.
 
-    Depends on ``gene_sets_instance`` — the last stage of the guide's
+    Depends on ``gene_profiles_instance`` — the last stage of the guide's
     linear narrative (imports → annotation edit → pheno import + pheno
     attach → preview-column config → ssc_denovo import + study-column
     config → ssc_cnv import → ssc_pheno import + ssc_denovo pheno-attach →
-    gene_sets_db + gene_scores_db config). ``gene_sets_instance``
-    transitively pulls the whole prior chain, so the single shared server
-    starts after every config edit the guide describes: it serves the
-    annotated, pheno-enabled example_dataset with its extended preview
-    columns, the ssc_denovo study (with the ssc_pheno phenotype study
-    attached), the ssc_cnv study, the ssc_pheno phenotype study, AND the
-    configured gene set collections + gene scores. Keeping the suite to one
+    gene_sets_db + gene_scores_db config → gene_profiles config + prebuild).
+    ``gene_profiles_instance`` transitively pulls the whole prior chain, so
+    the single shared server starts after every config edit the guide
+    describes: it serves the annotated, pheno-enabled example_dataset with
+    its extended preview columns, the ssc_denovo study (with the ssc_pheno
+    phenotype study attached), the ssc_cnv study, the ssc_pheno phenotype
+    study, the configured gene set collections + gene scores, AND the
+    prebuilt Gene Profiles tool (gpdb.duckdb). Keeping the suite to one
     wgpf process per session avoids two ``wgpf run``s racing on the same
     ``DAE_DB_DIR`` parquet during re-annotation. Every earlier claim
     (datasets visible, annotation download columns, pheno browser) holds
@@ -1199,7 +1330,7 @@ def wgpf_server(gene_sets_instance, gpf_env):
     import httpx  # lazy — see top-of-file note.
 
     env = dict(gpf_env)
-    env["DAE_DB_DIR"] = str(gene_sets_instance.instance_dir)
+    env["DAE_DB_DIR"] = str(gene_profiles_instance.instance_dir)
 
     port = _pick_free_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -1225,7 +1356,7 @@ def wgpf_server(gene_sets_instance, gpf_env):
 
     proc = subprocess.Popen(
         ["wgpf", "run", "--port", str(port), "--host", "127.0.0.1"],
-        cwd=gene_sets_instance.instance_dir,
+        cwd=gene_profiles_instance.instance_dir,
         env=env,
         stdout=log_fh,
         stderr=subprocess.STDOUT,

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -1103,7 +1103,6 @@ _GENE_SETS_BLOCK = (
     "  - gene_properties/gene_scores/Satterstrom_Buxbaum_Cell_2020\n"
     "  - gene_properties/gene_scores/Iossifov_Wigler_PNAS_2015\n"
     "  - gene_properties/gene_scores/LGD\n"
-    "  - gene_properties/gene_scores/RVIS\n"
     "  - gene_properties/gene_scores/LOEUF\n"
 )
 
@@ -1111,7 +1110,7 @@ _GENE_SETS_BLOCK = (
 @dataclass
 class GeneSetsInstance:
     """The instance after getting_started_with_gene_sets.rst: the
-    ``gene_sets_db`` (autism + GO collections) and ``gene_scores_db`` (five
+    ``gene_sets_db`` (autism + GO collections) and ``gene_scores_db`` (four
     gene scores) blocks added to gpf_instance.yaml."""
 
     instance_dir: Path

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -991,3 +991,158 @@ def assert_enrichment_test_result(
         f"underlying exception."
     )
     raise AssertionError(message)
+
+
+def assert_gene_profiles_configured(
+        response, *, default_dataset=None, rst_ref, expectation,
+):
+    """Assert the Gene Profiles tool is configured/enabled
+    (``GET /api/v3/gene_profiles/single-view/configuration``).
+
+    Backs the guide's claim that, after adding the ``gene_profiles_config``
+    block to gpf_instance.yaml and prebuilding the profiles with
+    ``generate_gene_profile``, the home page shows the Gene Profiles tool.
+
+    The configuration endpoint returns HTTP 200 with the (camelized) GP
+    configuration object when the tool is enabled, but ALSO returns 200 with
+    an EMPTY object ``{}`` when no GP config / no gpdb is present (the SPA
+    shows the Gene Profiles link only when the config is non-empty). So a 200
+    alone is not the signal — the config must be a non-empty object, and when
+    ``default_dataset`` is supplied its ``defaultDataset`` must match.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                "HTTP 200 with a non-empty Gene Profiles configuration"
+            ),
+        ))
+    config = response.json()
+    if not isinstance(config, dict) or not config:
+        message = (
+            f'DRIFT at {rst_ref} — "{expectation}"\n'
+            f"\n"
+            f"  expected: a non-empty Gene Profiles configuration object\n"
+            f"  actual:   {config!r}\n"
+            f"\n"
+            f"  Triage hint: The configuration endpoint returned 200 but an "
+            f"empty config, i.e. the Gene Profiles tool is NOT enabled — the "
+            f"SPA would not show its home-page link. Most likely either (a) "
+            f"the `gene_profiles_config` block was not added to "
+            f"gpf_instance.yaml (or the server did not pick it up — check the "
+            f"wgpf log dump), or (b) `generate_gene_profile` did not produce a "
+            f"gpdb.duckdb the instance could load. If the guide's claim no "
+            f"longer holds, update the guide."
+        )
+        raise AssertionError(message)
+    if default_dataset is not None and config.get("defaultDataset") != \
+            default_dataset:
+        message = (
+            f'DRIFT at {rst_ref} — "{expectation}"\n'
+            f"\n"
+            f"  expected: defaultDataset == {default_dataset!r}\n"
+            f"  actual:   defaultDataset == "
+            f"{config.get('defaultDataset')!r}\n"
+            f"\n"
+            f"  Triage hint: The Gene Profiles tool is configured but against "
+            f"a different default dataset than the guide describes. Either the "
+            f"gene_profiles.yaml `default_dataset` drifted from the guide, or "
+            f"the guide's dataset id changed. If the new id is correct, update "
+            f"the guide."
+        )
+        raise AssertionError(message)
+
+
+def assert_gene_profile_table_rows(
+        response, *, min_count=1, require_symbols=None, rst_ref, expectation,
+):
+    """Assert the Gene Profiles table returned profile rows
+    (``GET /api/v3/gene_profiles/table/rows``).
+
+    Backs the guide's claim that following the ``All Genes`` link opens the
+    Gene Profiles table with information about genes. The response is a JSON
+    list of profile-row objects each carrying a ``geneSymbol``. A non-200
+    status fails with HTTP-error triage; fewer than ``min_count`` rows — or a
+    required gene symbol missing — fails with a hint pointing at the
+    ``generate_gene_profile`` prebuild step.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with at least {min_count} gene profile row(s)"
+            ),
+        ))
+    rows = response.json()
+    count = len(rows)
+    symbols = [
+        r.get("geneSymbol") for r in rows if isinstance(r, dict)
+    ]
+    missing = [s for s in (require_symbols or []) if s not in symbols]
+    if count >= min_count and not missing:
+        return
+    detail = (
+        f"  expected: at least {min_count} row(s)"
+        + (f" including {require_symbols}" if require_symbols else "")
+        + "\n"
+        f"  actual:   {count} row(s)"
+        + (f", missing {missing}" if missing else "")
+        + "\n"
+    )
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"{detail}"
+        f"\n"
+        f"  Triage hint: The table endpoint responded but the rows are below "
+        f"expectation. Most likely either (a) `generate_gene_profile` did not "
+        f"populate the gpdb for the expected genes (re-check its exit code + "
+        f"the --genes list), or (b) the gpdb.duckdb the prebuild wrote is not "
+        f"the one the server loaded. If the guide's gene set legitimately "
+        f"changed, update the guide / the test's expected symbols."
+    )
+    raise AssertionError(message)
+
+
+def assert_gene_profile_for_gene(
+        response, gene_symbol, *, rst_ref, expectation,
+):
+    """Assert the single-gene Gene Profile page resolves for ``gene_symbol``
+    (``GET /api/v3/gene_profiles/single-view/gene/<gene_symbol>``).
+
+    Backs the guide's claim that selecting a gene from the table opens the
+    Gene Profile page for that gene (the guide's screenshot is CHD8). The
+    response is a JSON object carrying a ``geneSymbol`` matching the request.
+    The endpoint returns 404 when the gene has no generated profile, or when
+    the gene has no transcript models in the instance gene models — both are
+    treated as drift.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response,
+            rst_ref=rst_ref,
+            expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with a Gene Profile for {gene_symbol!r}"
+            ),
+        ))
+    data = response.json()
+    actual_symbol = data.get("geneSymbol") if isinstance(data, dict) else None
+    if actual_symbol == gene_symbol:
+        return
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected: a Gene Profile with geneSymbol {gene_symbol!r}\n"
+        f"  actual:   geneSymbol == {actual_symbol!r}\n"
+        f"\n"
+        f"  Triage hint: The profile endpoint returned 200 but for a "
+        f"different gene than requested. Most likely the response shape "
+        f"changed (the geneSymbol key moved/renamed). If the new shape is "
+        f"correct, update the test."
+    )
+    raise AssertionError(message)

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -19,6 +19,9 @@ from docs_e2e.guide_assertions import (
     assert_enrichment_models,
     assert_enrichment_test_result,
     assert_file_created,
+    assert_gene_profile_for_gene,
+    assert_gene_profile_table_rows,
+    assert_gene_profiles_configured,
     assert_gene_scores_available,
     assert_gene_set_collections_available,
     assert_genomic_score_available,
@@ -1135,4 +1138,142 @@ class TestAssertEnrichmentTestResult:
         message = str(exc_info.value)
         assert f"{_EN_RST}:26" in message
         assert "3" in message and "5" in message
-        assert "Triage" in message
+
+
+_GP_RST = "getting_started_with_gene_profiles.rst"
+
+
+class TestAssertGeneProfilesConfigured:
+    def test_passes_with_nonempty_config(self):
+        resp = _FakeResponse(
+            200, json_body={"defaultDataset": "ssc_denovo", "order": []},
+        )
+        assert_gene_profiles_configured(
+            resp, default_dataset="ssc_denovo",
+            rst_ref=f"{_GP_RST}:142",
+            expectation="the home page shows the Gene Profiles tool",
+        )
+
+    def test_passes_without_default_dataset_check(self):
+        resp = _FakeResponse(200, json_body={"defaultDataset": "anything"})
+        assert_gene_profiles_configured(
+            resp,
+            rst_ref=f"{_GP_RST}:142",
+            expectation="the Gene Profiles tool is enabled",
+        )
+
+    def test_raises_on_empty_config(self):
+        # 200 + {} is the tool-not-enabled case — must NOT pass.
+        resp = _FakeResponse(200, json_body={})
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profiles_configured(
+                resp,
+                rst_ref=f"{_GP_RST}:142",
+                expectation="the home page shows the Gene Profiles tool",
+            )
+        message = str(exc_info.value)
+        assert f"{_GP_RST}:142" in message
+        assert "not enabled" in message.lower()
+
+    def test_raises_on_default_dataset_mismatch(self):
+        resp = _FakeResponse(200, json_body={"defaultDataset": "other"})
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profiles_configured(
+                resp, default_dataset="ssc_denovo",
+                rst_ref=f"{_GP_RST}:142",
+                expectation="the Gene Profiles tool uses ssc_denovo",
+            )
+        message = str(exc_info.value)
+        assert "ssc_denovo" in message
+        assert "other" in message
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(500, text="Internal Server Error")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profiles_configured(
+                resp,
+                rst_ref=f"{_GP_RST}:142",
+                expectation="the Gene Profiles tool is enabled",
+            )
+        assert "HTTP 500" in str(exc_info.value)
+
+
+class TestAssertGeneProfileTableRows:
+    def test_passes_with_rows_and_required_symbol(self):
+        resp = _FakeResponse(200, json_body=[
+            {"geneSymbol": "CHD8"}, {"geneSymbol": "ANK2"},
+        ])
+        assert_gene_profile_table_rows(
+            resp, min_count=2, require_symbols=["CHD8"],
+            rst_ref=f"{_GP_RST}:147",
+            expectation="the All Genes table lists gene profiles",
+        )
+
+    def test_raises_when_too_few_rows(self):
+        resp = _FakeResponse(200, json_body=[{"geneSymbol": "CHD8"}])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profile_table_rows(
+                resp, min_count=10,
+                rst_ref=f"{_GP_RST}:147",
+                expectation="the All Genes table lists the prebuilt genes",
+            )
+        message = str(exc_info.value)
+        assert f"{_GP_RST}:147" in message
+        assert "10" in message
+
+    def test_raises_when_required_symbol_missing(self):
+        resp = _FakeResponse(200, json_body=[
+            {"geneSymbol": "ANK2"}, {"geneSymbol": "DSCAM"},
+        ])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profile_table_rows(
+                resp, min_count=1, require_symbols=["CHD8"],
+                rst_ref=f"{_GP_RST}:147",
+                expectation="CHD8 is in the gene profiles table",
+            )
+        assert "CHD8" in str(exc_info.value)
+
+    def test_raises_on_http_error(self):
+        resp = _FakeResponse(503, text="Service Unavailable")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profile_table_rows(
+                resp, min_count=1,
+                rst_ref=f"{_GP_RST}:147",
+                expectation="the All Genes table lists gene profiles",
+            )
+        assert "HTTP 503" in str(exc_info.value)
+
+
+class TestAssertGeneProfileForGene:
+    def test_passes_with_matching_gene(self):
+        resp = _FakeResponse(200, json_body={
+            "geneSymbol": "CHD8", "geneSets": [], "geneScores": [],
+        })
+        assert_gene_profile_for_gene(
+            resp, "CHD8",
+            rst_ref=f"{_GP_RST}:156",
+            expectation="the CHD8 Gene Profile page opens",
+        )
+
+    def test_raises_on_404(self):
+        # The endpoint 404s when the gene has no generated profile.
+        resp = _FakeResponse(404, text="Not Found")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profile_for_gene(
+                resp, "CHD8",
+                rst_ref=f"{_GP_RST}:156",
+                expectation="the CHD8 Gene Profile page opens",
+            )
+        message = str(exc_info.value)
+        assert f"{_GP_RST}:156" in message
+        assert "HTTP 404" in message
+
+    def test_raises_on_wrong_gene(self):
+        resp = _FakeResponse(200, json_body={"geneSymbol": "ANK2"})
+        with pytest.raises(AssertionError) as exc_info:
+            assert_gene_profile_for_gene(
+                resp, "CHD8",
+                rst_ref=f"{_GP_RST}:156",
+                expectation="the CHD8 Gene Profile page opens",
+            )
+        assert "CHD8" in str(exc_info.value)

--- a/docs_e2e/tests/test_gene_profiles.py
+++ b/docs_e2e/tests/test_gene_profiles.py
@@ -1,0 +1,147 @@
+"""Guide-claim tests for getting_started_with_gene_profiles.rst.
+
+The gene-profiles sub-guide configures and prebuilds the Gene Profile tool
+on the same ``minimal_instance`` the earlier guides built:
+
+1. **configure** — create ``minimal_instance/gene_profiles.yaml`` (which
+   statistics, gene scores, gene sets, and gene links to collect per gene)
+   and add a ``gene_profiles_config`` block to gpf_instance.yaml.
+2. **prebuild** — run ``generate_gene_profile`` to populate the gene
+   profiles DB (``gpdb.duckdb``). The guide's note offers a ``--genes`` form
+   to limit generation to a short gene list instead of all 19,285 MANE
+   genes; the suite runs that documented fast form.
+3. **serve** — ``wgpf run`` then shows the Gene Profiles tool on the home
+   page, an ``All Genes`` table of gene profiles, and a per-gene profile
+   page (the guide's screenshot is CHD8).
+
+The configure + prebuild steps live in the session-scoped
+``gene_profiles_instance`` fixture (conftest.py); ``wgpf_server`` depends on
+it, so the single shared server serves the profile-enabled instance.
+
+Strict mode (#871): the fixture only does what the guide tells the user to
+do — the file create, the one-block yaml edit, and the ``generate_gene_profile``
+prebuild. The ``--genes`` form is the guide's own documented fast path (RST
+lines 116-128), so the command runs verbatim with the guide's short gene list.
+
+Each test maps to one discrete prose claim. ``rst_ref`` points at the line
+in the guide source so a failure localizes the drift.
+"""
+
+from docs_e2e.guide_assertions import (
+    assert_command_succeeds,
+    assert_file_created,
+    assert_gene_profile_for_gene,
+    assert_gene_profile_table_rows,
+    assert_gene_profiles_configured,
+)
+
+RST = "getting_started_with_gene_profiles.rst"
+
+# The default dataset the gene_profiles.yaml configures (RST line 22 / the
+# config's `default_dataset`).
+_DEFAULT_DATASET = "ssc_denovo"
+
+# The gene the guide's single-profile screenshot shows (RST line 156); it
+# heads the --genes list the prebuild fixture runs.
+_PROFILE_GENE = "CHD8"
+
+# The ten genes the guide's note prebuilds (RST lines 125-127). PAGE_SIZE is
+# 50, so all ten land on the first table/rows page.
+_GENERATED_GENE_COUNT = 10
+
+# Cold demand-pull budget: building the GPFInstance for the profile endpoints
+# resolves the configured gene scores / gene set collections from the GRR on
+# first access. Well above the shared client's default 60s, under the build
+# wall.
+_COLD_PULL_TIMEOUT = 300
+
+
+class TestGenerateGeneProfile:
+    """RST lines 101-128: prebuild the gene profiles with
+    ``generate_gene_profile``."""
+
+    def test_generate_gene_profile_succeeds(self, gene_profiles_instance):
+        # RST lines 111-113 (+ the note's --genes form, 125-127): the
+        # generate_gene_profile command prebuilds the gene profiles.
+        assert_command_succeeds(
+            gene_profiles_instance.generate,
+            rst_ref=f"{RST}:112",
+            expectation=(
+                "generate_gene_profile prebuilds the gene profiles for the "
+                "configured genes"
+            ),
+        )
+
+    def test_generate_gene_profile_creates_gpdb(self, gene_profiles_instance):
+        # The prebuild writes the gene profiles DB (gpdb.duckdb) into the
+        # instance dir; wgpf loads it on startup to serve the tool. Backs the
+        # "prebuild the gene profiles" claim (RST lines 101-113) at the
+        # filesystem level, between command-success and server-serves.
+        assert_file_created(
+            gene_profiles_instance.gpdb_path,
+            rst_ref=f"{RST}:112",
+            expectation=(
+                "generating gene profiles produces the gene profiles DB the "
+                "instance serves"
+            ),
+            after_command=gene_profiles_instance.generate,
+        )
+
+
+class TestGeneProfilesTool:
+    """RST lines 130-156: ``wgpf run`` serves the Gene Profiles tool."""
+
+    def test_gene_profiles_tool_enabled(self, wgpf_server):
+        # RST lines 137-142: on the home page you can see the Gene Profiles
+        # tool. The single-view/configuration endpoint returns a non-empty
+        # config exactly when the tool is enabled (the SPA gates its home-page
+        # link on that); an empty {} would still be HTTP 200.
+        resp = wgpf_server.client.get(
+            "/api/v3/gene_profiles/single-view/configuration",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_gene_profiles_configured(
+            resp, default_dataset=_DEFAULT_DATASET,
+            rst_ref=f"{RST}:136",
+            expectation=(
+                "the home page shows the Gene Profiles tool after configuring "
+                "and prebuilding it"
+            ),
+        )
+
+    def test_all_genes_table_has_rows(self, wgpf_server):
+        # RST lines 144-149: following the `All Genes` link opens the Gene
+        # Profiles table with information about genes. table/rows backs that
+        # listing; the prebuilt ten genes all fit on page 1 (PAGE_SIZE 50),
+        # and CHD8 must be among them.
+        resp = wgpf_server.client.get(
+            "/api/v3/gene_profiles/table/rows",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_gene_profile_table_rows(
+            resp,
+            min_count=_GENERATED_GENE_COUNT,
+            require_symbols=[_PROFILE_GENE],
+            rst_ref=f"{RST}:143",
+            expectation=(
+                "the `All Genes` link opens the Gene Profiles table with "
+                "information about the prebuilt genes"
+            ),
+        )
+
+    def test_gene_profile_page_for_chd8(self, wgpf_server):
+        # RST lines 151-156: selecting a gene from the table opens the Gene
+        # Profile page for that gene (the screenshot is CHD8). The
+        # single-view/gene/<symbol> endpoint backs that page.
+        resp = wgpf_server.client.get(
+            f"/api/v3/gene_profiles/single-view/gene/{_PROFILE_GENE}",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_gene_profile_for_gene(
+            resp, _PROFILE_GENE,
+            rst_ref=f"{RST}:155",
+            expectation=(
+                "selecting a gene opens its Gene Profile page (CHD8 in the "
+                "guide screenshot)"
+            ),
+        )

--- a/docs_e2e/tests/test_gene_sets.py
+++ b/docs_e2e/tests/test_gene_sets.py
@@ -57,7 +57,6 @@ GENE_SCORES = [
     "Satterstrom Buxbaum Cell 2020 qval",   # Satterstrom_Buxbaum_Cell_2020
     "Iossifov Wigler PNAS 2015 post noaut",  # Iossifov_Wigler_PNAS_2015
     "LGD_score",                             # LGD
-    "RVIS score",                            # RVIS
     "LOEUF",                                 # LOEUF
 ]
 


### PR DESCRIPTION
## Summary

Extends `docs_e2e/` with a guide-claim suite for the **Gene Profiles** sub-guide — the next stage after gene_sets in epic #871's linear narrative. Closes #881.

The suite configures + prebuilds the Gene Profile tool on the same `minimal_instance` the earlier guides built, then asserts each discrete prose claim against a backgrounded `wgpf run`.

## What's here

- **`conftest.py` → `gene_profiles_instance`** (chained after `gene_sets_instance`): walks the guide verbatim —
  1. create `minimal_instance/gene_profiles.yaml` from the guide's literalinclude target (read from the docs tree, so it can never drift from what the guide renders);
  2. append the `gene_profiles_config` block to `gpf_instance.yaml`;
  3. prebuild with `generate_gene_profile --genes <list>`.
  `wgpf_server` now depends on this fixture, so the single shared server boots with the prebuilt `gpdb.duckdb`.
- **`tests/test_gene_profiles.py`** — one test per claim: `generate_gene_profile` succeeds + writes `gpdb.duckdb`; the tool is enabled (non-empty config — a bare `{}` is still HTTP 200, so 200 alone isn't the signal); the *All Genes* table returns the prebuilt rows incl. CHD8; the per-gene profile page resolves for CHD8 (the guide's screenshot).
- **`guide_assertions.py`** — three new helpers (`assert_gene_profiles_configured`, `assert_gene_profile_table_rows`, `assert_gene_profile_for_gene`), each with the `rst_ref` + triage-hint format from #872, unit-tested in `test_guide_assertions.py`.

## Strict mode (#871)

Only the file-create + one-block yaml edit + CLI prebuild the guide tells the user to type. The `--genes` form is the **guide's own documented fast path** (the RST note), not a harness carve-out — the command runs verbatim with the guide's short ten-gene list instead of all 19,285 MANE genes, keeping the step inside the build wall.

## Same-PR prose fix

Dropped `gene_properties/gene_sets/relevant` from the illustrative `gpf_instance.yaml` block — that resource 404s in the public GRR and #879 already removed it from the gene_sets guide + conftest.

## Verification

Local (what's runnable without the conda/wgpf/GRR container):
- ✅ `py_compile` all changed files
- ✅ `ruff` — no new findings in changed code
- ✅ `pytest docs_e2e/test_guide_assertions.py` — **80 passed** (incl. 12 new helper unit tests)
- ✅ `pytest --setup-plan` — fixture graph resolves: `… → gene_sets_instance → gene_profiles_instance → wgpf_server`, correct teardown order

The full install → configure → prebuild → probe path runs in the **`gpf-docs-e2e`** pipeline this branch triggers (the suite's true integration test — not reproducible in this checkout without the GRR-seeded driver container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)