### PR TITLE
docs-e2e: validate getting_started_with_python_interface.rst (#883)

### DIFF
--- a/docs/source/administration/getting_started/getting_started_with_python_interface.rst
+++ b/docs/source/administration/getting_started/getting_started_with_python_interface.rst
@@ -6,7 +6,7 @@ The simplest way to start using GPF's Python API is to import the
 
 .. code-block:: python3
 
-    from dae.gpf_instance.gpf_instance import GPFInstance
+    from gpf.gpf_instance.gpf_instance import GPFInstance
     gpf_instance = GPFInstance.build()
 
 This ``gpf_instance`` object groups several interfaces, each dedicated
@@ -53,9 +53,9 @@ will produce the following output:
 
     chr14:21391016 A->AT f2
     chr14:21393484 TCTTC->T f2
-    chr14:21402010 G->A f1
     chr14:21403019 G->A f2
     chr14:21403214 T->C f1
+    chr14:21409849 A->G f1
     chr14:21431459 G->C f1
     chr14:21385738 C->T f1
     chr14:21385738 C->T f2
@@ -73,6 +73,8 @@ will produce the following output:
     chr14:21431306 G->A f1
     chr14:21431623 A->C f2
     chr14:21393540 GGAA->G f1
+    chr14:21431499 T->C f2
+    chr14:21402010 G->A f1
 
 The ``query_variants`` interface allows you to specify what kind of variants
 you are interested in. For example, if you only need "synonymous" variants, you
@@ -152,7 +154,7 @@ We can then get specific measure values for specific individuals:
 
 .. code-block:: python3
 
-    from dae.variants.attributes import Role
+    from gpf.variants.attributes import Role
 
     list(pd.get_people_measure_values(["iq.non-verbal-iq"], roles=[Role.prb], family_ids=["f1", "f2", "f3"]))
 

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -18,6 +18,7 @@ local-iteration command in docs_e2e/README.md):
 * ``DOCS_E2E_GRR_CACHE`` — directory persisted as the GRR cache.
 """
 
+import json
 import os
 import shutil
 import socket
@@ -1280,6 +1281,173 @@ def gene_profiles_instance(gene_sets_instance, gpf_env):
         generate=generate,
         gpdb_path=instance_dir / "gpdb.duckdb",
     )
+
+
+# getting_started_with_python_interface.rst drives the GPF Python API
+# directly (no REST, no wgpf): it is a REPL-style narrative that builds one
+# ``GPFInstance`` and runs a sequence of query snippets, each annotated with
+# the value it "will produce". docs-e2e runs those snippets faithfully — in a
+# single python process in the gpf-web conda env, against the fully-built
+# instance the earlier guides produced — and emits a JSON summary of each
+# snippet's result under a ``@@DOCS_E2E::<key>::<json>`` marker. The
+# per-claim tests then assert one captured value each via
+# ``assert_python_snippet_output``.
+#
+# The driver uses the SAME imports the guide tells the user to type
+# (``from gpf.gpf_instance.gpf_instance import GPFInstance`` /
+# ``from gpf.variants.attributes import Role``). A namespace drift in the
+# guide (e.g. the historical ``dae`` -> ``gpf`` rename) is caught separately
+# by test_python_interface's static RST-import check; here the driver must
+# run, so it uses the current namespace. Each emit() line cites the RST
+# lines of the snippet it backs.
+_PY_MARKER = "@@DOCS_E2E::"
+_PYTHON_INTERFACE_DRIVER = """\
+import json
+import sys
+
+from gpf.gpf_instance.gpf_instance import GPFInstance
+
+
+def emit(key, value):
+    line = "@@DOCS_E2E::" + key + "::" + json.dumps(value) + "\\n"
+    sys.stdout.write(line)
+
+
+def main():
+    # RST 7-10: import GPFInstance and build it from the startup instance.
+    gpf_instance = GPFInstance.build()
+
+    # RST 21-29: list all configured genotype-study ids.
+    emit("genotype_data_ids", sorted(gpf_instance.get_genotype_data_ids()))
+
+    # RST 33-75: query all variants of example_dataset; the guide prints each
+    # alt allele (str(aa) -> "chr14:21391016 A->AT f2"). Capture them all.
+    st = gpf_instance.get_genotype_data("example_dataset")
+    vs = list(st.query_variants())
+    emit(
+        "example_dataset_alt_alleles",
+        sorted(str(aa) for v in vs for aa in v.alt_alleles),
+    )
+
+    # RST 81-90: only "synonymous" variants.
+    st = gpf_instance.get_genotype_data("example_dataset")
+    vs = list(st.query_variants(effect_types=["synonymous"]))
+    emit("synonymous_count", len(vs))
+
+    # RST 95-103: "synonymous" variants only in people with the "prb" role.
+    vs = list(st.query_variants(effect_types=["synonymous"], roles="prb"))
+    emit("synonymous_prb_count", len(vs))
+
+    # RST 110-118: list all configured phenotype-data ids.
+    emit("phenotype_data_ids", sorted(gpf_instance.get_phenotype_data_ids()))
+
+    # RST 124-134: mini_pheno instruments and their measure counts
+    # ("Instrument(basic_medical, 4)" -> {"basic_medical": 4, "iq": 3}).
+    pd = gpf_instance.get_phenotype_data("mini_pheno")
+    emit(
+        "instruments",
+        {name: len(instr.measures) for name, instr in pd.instruments.items()},
+    )
+
+    # RST 137-149: mini_pheno measures (the measure ids).
+    emit("measures", sorted(pd.measures.keys()))
+
+    # RST 153-178: non-verbal IQ for the probands of families f1, f2, f3.
+    from gpf.variants.attributes import Role
+    rows = list(pd.get_people_measure_values(
+        ["iq.non-verbal-iq"],
+        roles=[Role.prb],
+        family_ids=["f1", "f2", "f3"],
+    ))
+    emit("people_measure_values", sorted(
+        (
+            {
+                "person_id": r["person_id"],
+                "iq.non-verbal-iq": r["iq.non-verbal-iq"],
+            }
+            for r in rows
+        ),
+        key=lambda d: d["person_id"],
+    ))
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+# 10 min: building the GPFInstance loads the reference genome + gene models
+# from the warm GRR cache, then the snippets run small queries against the
+# demo example_dataset + mini_pheno. No re-import, no server.
+_PYTHON_INTERFACE_TIMEOUT = 600
+
+
+def _parse_py_markers(stdout):
+    """Parse ``@@DOCS_E2E::<key>::<json>`` marker lines from the driver's
+    stdout into a ``{key: value}`` dict. Non-marker output (logging the
+    GPFInstance build emits) is ignored; a malformed payload is skipped."""
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", errors="replace")
+    values = {}
+    for line in stdout.splitlines():
+        if not line.startswith(_PY_MARKER):
+            continue
+        body = line[len(_PY_MARKER):]
+        key, sep, payload = body.partition("::")
+        if not sep:
+            continue
+        try:
+            values[key] = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+    return values
+
+
+@dataclass
+class PythonInterfaceSession:
+    """The result of running getting_started_with_python_interface.rst's
+    snippets in one python process against the built instance.
+
+    ``process`` is the driver subprocess result (so a per-test assertion can
+    feed it into ``assert_command_succeeds`` for the GPFInstance.build claim,
+    and ``assert_python_snippet_output`` can surface its stderr on failure).
+    ``values`` maps each snippet's marker key to its captured JSON value.
+    """
+
+    process: subprocess.CompletedProcess
+    values: dict
+
+
+@pytest.fixture(scope="session")
+def python_interface_session(gene_profiles_instance, gpf_env, tmp_path_factory):
+    """Apply getting_started_with_python_interface.rst: run the guide's
+    Python-API snippets against the fully-built instance.
+
+    Depends on ``gene_profiles_instance`` — the tail of the guide's linear
+    narrative — so the instance the driver builds is the same fully-prepared
+    one the rest of the suite uses (example_dataset + mini_pheno are the demo
+    data the guide queries; the full genotype/phenotype id lists the guide
+    documents need every imported study present). The driver runs in the
+    gpf-web conda env (``gpf_env`` puts it first on PATH) with ``DAE_DB_DIR``
+    pointed at the instance dir, exactly as ``GPFInstance.build()`` expects.
+
+    Strict mode (#871): the driver runs only the read-only query snippets the
+    guide tells the user to type — no imports, no config edits, no server. It
+    is pure GPF Python API against the already-built instance.
+    """
+    instance_dir = gene_profiles_instance.instance_dir
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(instance_dir)
+
+    script_dir = tmp_path_factory.mktemp("python-interface", numbered=False)
+    script_path = script_dir / "driver.py"
+    script_path.write_text(_PYTHON_INTERFACE_DRIVER)
+
+    result = _run(
+        ["python", str(script_path)],
+        cwd=instance_dir, env=env, timeout=_PYTHON_INTERFACE_TIMEOUT,
+    )
+    values = _parse_py_markers(result.stdout) if result.returncode == 0 else {}
+    return PythonInterfaceSession(process=result, values=values)
 
 
 def _pick_free_port():

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -1146,3 +1146,83 @@ def assert_gene_profile_for_gene(
         f"correct, update the test."
     )
     raise AssertionError(message)
+
+
+# Sentinel for a snippet the driver script never emitted (typically because
+# the whole script failed before reaching it). Distinct from any JSON value a
+# snippet could legitimately produce.
+_SNIPPET_MISSING = object()
+
+
+def assert_python_snippet_output(
+        values, key, expected, *, rst_ref, expectation, after_command=None,
+):
+    """Assert a guide Python snippet produced the documented output.
+
+    The python-interface guide is a REPL-style narrative: a single
+    ``GPFInstance`` is built once and a sequence of snippets query it, each
+    annotated with the value it "will produce". The docs-e2e driver runs those
+    snippets in one process and captures a JSON summary of each one's result
+    under a marker ``key``; this helper compares one captured value against the
+    value the guide documents.
+
+    ``values`` is the parsed ``{key: captured_value}`` mapping the
+    ``python_interface_session`` fixture produces; ``key`` selects the snippet.
+    A key absent from ``values`` means the driver never emitted it — almost
+    always because the script failed earlier. ``after_command`` is the driver's
+    ``subprocess.CompletedProcess``; when supplied and failed, its stderr
+    shapes the triage hint, mirroring ``assert_file_created``.
+    """
+    actual = values.get(key, _SNIPPET_MISSING)
+    if actual is not _SNIPPET_MISSING and actual == expected:
+        return
+
+    prior_failed = (
+        after_command is not None and after_command.returncode != 0
+    )
+
+    if actual is _SNIPPET_MISSING and prior_failed:
+        triage = (
+            f"Triage hint: The driver script exited non-zero (exit code "
+            f"{after_command.returncode}), so this snippet's output was "
+            f"never produced. Fix that failure first — most likely the "
+            f"GPFInstance build snippet or an earlier snippet raised (a "
+            f"renamed import or API). The script's stderr tail is below."
+        )
+        prior_block = (
+            f"\n  driver stderr (last {_TAIL_LINES} lines):\n"
+            f"{_tail(after_command.stderr)}\n"
+        )
+        actual_repr = "(not produced — driver script failed)"
+    elif actual is _SNIPPET_MISSING:
+        triage = (
+            "Triage hint: The driver script succeeded but emitted no value "
+            f"for {key!r} — the snippet's marker key drifted from what the "
+            "test expects, or the snippet was dropped from the driver. "
+            "Re-check the driver script and the test's marker key."
+        )
+        prior_block = ""
+        actual_repr = "(not produced)"
+    else:
+        triage = (
+            "Triage hint: The snippet ran but produced a different value than "
+            "the guide documents. Most likely either (a) the guide's shown "
+            "output drifted from current GPF behavior / the demo data (update "
+            "the guide's expected output), or (b) the Python API the snippet "
+            "calls changed its return shape. If the new value is correct, "
+            "update the guide."
+        )
+        prior_block = ""
+        actual_repr = repr(actual)
+
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  snippet output: {key}\n"
+        f"  expected:       {expected!r}\n"
+        f"  actual:         {actual_repr}"
+        f"{prior_block}"
+        f"\n"
+        f"  {triage}"
+    )
+    raise AssertionError(message)

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -29,6 +29,7 @@ from docs_e2e.guide_assertions import (
     assert_pheno_instruments_available,
     assert_pheno_measures_present,
     assert_preview_table_column_group,
+    assert_python_snippet_output,
     assert_query_returned_variants,
 )
 
@@ -1277,3 +1278,82 @@ class TestAssertGeneProfileForGene:
                 expectation="the CHD8 Gene Profile page opens",
             )
         assert "CHD8" in str(exc_info.value)
+
+
+_PI_RST = "getting_started_with_python_interface.rst"
+
+
+class TestAssertPythonSnippetOutput:
+    def test_passes_on_matching_value(self):
+        # No exception when the captured value equals the documented one.
+        assert_python_snippet_output(
+            {"synonymous_count": 4}, "synonymous_count", 4,
+            rst_ref=f"{_PI_RST}:90",
+            expectation="synonymous query yields 4",
+        )
+
+    def test_passes_on_matching_list_and_dict(self):
+        values = {
+            "ids": ["a", "b", "c"],
+            "instruments": {"basic_medical": 4, "iq": 3},
+        }
+        assert_python_snippet_output(
+            values, "ids", ["a", "b", "c"],
+            rst_ref=f"{_PI_RST}:29", expectation="ids match",
+        )
+        # dict equality is order-independent (json round-trips can reorder).
+        assert_python_snippet_output(
+            values, "instruments", {"iq": 3, "basic_medical": 4},
+            rst_ref=f"{_PI_RST}:134", expectation="instruments match",
+        )
+
+    def test_raises_on_value_mismatch(self):
+        with pytest.raises(AssertionError) as exc_info:
+            assert_python_snippet_output(
+                {"synonymous_count": 5}, "synonymous_count", 4,
+                rst_ref=f"{_PI_RST}:90",
+                expectation="synonymous query yields 4",
+            )
+        message = str(exc_info.value)
+        assert f"{_PI_RST}:90" in message
+        assert "synonymous query yields 4" in message
+        # both the expected and the actual value are surfaced
+        assert "4" in message
+        assert "5" in message
+        # mismatch triage points at guide-output / API drift
+        assert "update the guide" in message
+
+    def test_raises_on_missing_key_when_driver_succeeded(self):
+        # Driver exited 0 but never emitted the key — the marker key drifted.
+        with pytest.raises(AssertionError) as exc_info:
+            assert_python_snippet_output(
+                {}, "synonymous_count", 4,
+                rst_ref=f"{_PI_RST}:90",
+                expectation="synonymous query yields 4",
+                after_command=_ok_result(),
+            )
+        message = str(exc_info.value)
+        assert "marker key" in message
+        assert "not produced" in message
+
+    def test_raises_on_missing_key_when_driver_failed(self):
+        # Driver exited non-zero — the snippet output was never produced; the
+        # message redirects to the driver failure and surfaces its stderr.
+        failed = SimpleNamespace(
+            returncode=1,
+            args=["python", "driver.py"],
+            stdout=b"",
+            stderr=b"ModuleNotFoundError: No module named 'dae'\n",
+        )
+        with pytest.raises(AssertionError) as exc_info:
+            assert_python_snippet_output(
+                {}, "genotype_data_ids", ["example_dataset"],
+                rst_ref=f"{_PI_RST}:29",
+                expectation="study ids listed",
+                after_command=failed,
+            )
+        message = str(exc_info.value)
+        assert "exit code 1" in message
+        # the driver's traceback tail is surfaced for triage
+        assert "No module named 'dae'" in message
+        assert "Fix that failure first" in message

--- a/docs_e2e/tests/test_python_interface.py
+++ b/docs_e2e/tests/test_python_interface.py
@@ -1,0 +1,281 @@
+"""Guide-claim tests for getting_started_with_python_interface.rst.
+
+The python-interface sub-guide is the last of the Getting Started guides and
+the only REST-free one: a Jupyter-notebook-style narrative that drives the GPF
+Python API directly. It builds one ``GPFInstance`` from the startup instance
+the earlier guides produced, then runs a sequence of query snippets — listing
+studies, querying ``example_dataset`` variants, and reading ``mini_pheno``
+phenotype instruments/measures — each annotated with the value it "will
+produce".
+
+docs-e2e runs those snippets faithfully in a single python process in the
+gpf-web conda env (the ``python_interface_session`` fixture in conftest.py;
+see its docstring) and captures a JSON summary of each one's result. Each test
+here asserts one discrete documented claim against the captured value via
+``assert_python_snippet_output`` (which carries the rst_ref + a triage hint on
+failure). No ``wgpf run`` is involved — this is pure Python API.
+
+Import-namespace drift (the headline bug this sub-guide catches): the GPF
+Python package was renamed ``dae`` -> ``gpf``; the guide's ``import`` snippets
+must use the current ``gpf.`` namespace. That is a static property of the RST
+prose, not something the runtime driver re-derives (the driver hardcodes the
+working import so it can run), so ``test_guide_uses_current_import_namespace``
+guards it by reading the RST directly.
+
+Each test maps to one discrete prose claim. ``rst_ref`` points at the line in
+the guide source so a failure localizes the drift.
+"""
+
+from pathlib import Path
+
+from docs_e2e.guide_assertions import (
+    assert_command_succeeds,
+    assert_python_snippet_output,
+)
+
+RST = "getting_started_with_python_interface.rst"
+
+# The RST lives in the gpf docs tree (a path relative to this test file's repo
+# root) — the same root conftest reads the gene_profiles.yaml literalinclude
+# from. Used by the static import-namespace check.
+_GPF_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_RST_PATH = (
+    _GPF_REPO_ROOT
+    / "docs/source/administration/getting_started" / RST
+)
+
+# RST line 29: the ids of all configured genotype studies, in the order-
+# independent set the guide lists. Every study the earlier guides imported:
+# the two demo studies (denovo_example, vcf_example), their example_dataset
+# group, plus ssc_denovo + ssc_cnv.
+_GENOTYPE_DATA_IDS = sorted([
+    "ssc_denovo", "denovo_example", "vcf_example", "ssc_cnv", "example_dataset",
+])
+
+# RST lines 54-77: the alt alleles the guide prints for the full
+# example_dataset query — str(family_allele) is
+# "<chrom>:<pos> <ref>-><alt> <family_id>". Order-independent (the guide's
+# iteration order is not a documented claim); the driver sorts, so does this.
+_EXAMPLE_DATASET_ALT_ALLELES = sorted([
+    "chr14:21385738 C->T f1",
+    "chr14:21385738 C->T f2",
+    "chr14:21385954 A->C f2",
+    "chr14:21391016 A->AT f2",
+    "chr14:21393173 T->C f1",
+    "chr14:21393484 TCTTC->T f2",
+    "chr14:21393540 GGAA->G f1",
+    "chr14:21393702 C->T f2",
+    "chr14:21393860 G->A f1",
+    "chr14:21402010 G->A f1",
+    "chr14:21403019 G->A f2",
+    "chr14:21403023 G->A f1",
+    "chr14:21403023 G->A f2",
+    "chr14:21403214 T->C f1",
+    "chr14:21405222 T->C f2",
+    "chr14:21409849 A->G f1",
+    "chr14:21409888 T->C f1",
+    "chr14:21409888 T->C f2",
+    "chr14:21429019 C->T f1",
+    "chr14:21429019 C->T f2",
+    "chr14:21431306 G->A f1",
+    "chr14:21431459 G->C f1",
+    "chr14:21431499 T->C f2",
+    "chr14:21431623 A->C f2",
+])
+
+# RST line 90: synonymous variants in example_dataset.
+_SYNONYMOUS_COUNT = 4
+# RST line 103: synonymous variants in example_dataset, role prb only.
+_SYNONYMOUS_PRB_COUNT = 1
+
+# RST line 118: the ids of all configured phenotype data.
+_PHENOTYPE_DATA_IDS = sorted(["ssc_pheno", "mini_pheno"])
+
+# RST line 134: mini_pheno instruments and the number of measures in each
+# ("Instrument(basic_medical, 4)" / "Instrument(iq, 3)").
+_INSTRUMENTS = {"basic_medical": 4, "iq": 3}
+
+# RST lines 143-149: the seven mini_pheno measure ids.
+_MEASURES = sorted([
+    "basic_medical.age",
+    "basic_medical.weight",
+    "basic_medical.height",
+    "basic_medical.race",
+    "iq.diagnosis-notes",
+    "iq.verbal-iq",
+    "iq.non-verbal-iq",
+])
+
+# RST lines 161-178: non-verbal IQ for the probands of f1, f2, f3.
+_PEOPLE_MEASURE_VALUES = [
+    {"person_id": "f1.p1", "iq.non-verbal-iq": 70},
+    {"person_id": "f2.p1", "iq.non-verbal-iq": 45},
+    {"person_id": "f3.p1", "iq.non-verbal-iq": 93},
+]
+
+
+class TestGpfInstance:
+    """RST lines 4-14: build a ``GPFInstance`` from the startup instance."""
+
+    def test_guide_uses_current_import_namespace(self):
+        # RST lines 9 + 155: the guide imports from the GPF Python package.
+        # The package was renamed `dae` -> `gpf`; a guide still importing
+        # `from dae.…` is the canonical drift this sub-guide catches. Guard it
+        # statically against the RST source — the runtime driver hardcodes the
+        # working import so it cannot re-derive this.
+        assert _RST_PATH.is_file(), (
+            f'DRIFT at {RST}:1 — "the python-interface guide exists"\n\n'
+            f"  expected guide file: {_RST_PATH}\n"
+            f"  actual:              does not exist\n"
+        )
+        text = _RST_PATH.read_text()
+        # The GPF Python package was renamed `dae` -> `gpf`; the guide must
+        # not import from the old namespace, and must import GPFInstance from
+        # its current module path. Drift here is the headline bug this
+        # sub-guide catches.
+        stale_dae = (
+            f'DRIFT at {RST}:9 — "import GPFInstance from the gpf package"\n\n'
+            f"  expected: imports use the current `gpf.` namespace\n"
+            f"  actual:   the guide still imports from the `dae` package\n\n"
+            f"  Triage hint: the GPF Python package was renamed `dae` -> "
+            f"`gpf`. Update the guide's `from dae.` import lines to "
+            f"`from gpf.`. This is guide drift, not a code regression."
+        )
+        assert "from dae." not in text, stale_dae
+        assert "import dae" not in text, stale_dae
+        expected_import = (
+            "from gpf.gpf_instance.gpf_instance import GPFInstance"
+        )
+        assert expected_import in text, (
+            f'DRIFT at {RST}:9 — "import GPFInstance from the gpf package"\n\n'
+            f"  expected: {expected_import!r} present in the guide\n"
+            f"  actual:   not found\n\n"
+            f"  Triage hint: the guide's GPFInstance import drifted from the "
+            f"current module path. If the module moved, update the guide."
+        )
+
+    def test_gpf_instance_builds(self, python_interface_session):
+        # RST lines 7-10: GPFInstance.build() instantiates the interface. The
+        # driver script's first action is exactly that; a non-zero exit means
+        # the build (or an import) raised — assert_command_succeeds surfaces
+        # the traceback.
+        assert_command_succeeds(
+            python_interface_session.process,
+            rst_ref=f"{RST}:10",
+            expectation=(
+                "GPFInstance.build() instantiates the GPF Python interface"
+            ),
+        )
+
+
+class TestQueryingGenotypeData:
+    """RST lines 16-103: list studies and query example_dataset variants."""
+
+    def test_get_genotype_data_ids(self, python_interface_session):
+        # RST lines 21-29: get_genotype_data_ids() returns the ids of all
+        # configured studies.
+        assert_python_snippet_output(
+            python_interface_session.values, "genotype_data_ids",
+            _GENOTYPE_DATA_IDS,
+            rst_ref=f"{RST}:29",
+            expectation=(
+                "get_genotype_data_ids() lists every configured study"
+            ),
+            after_command=python_interface_session.process,
+        )
+
+    def test_query_variants_all(self, python_interface_session):
+        # RST lines 33-75: querying example_dataset and printing each alt
+        # allele produces the documented list of variants.
+        assert_python_snippet_output(
+            python_interface_session.values, "example_dataset_alt_alleles",
+            _EXAMPLE_DATASET_ALT_ALLELES,
+            rst_ref=f"{RST}:54",
+            expectation=(
+                "query_variants() over example_dataset yields the documented "
+                "alt alleles"
+            ),
+            after_command=python_interface_session.process,
+        )
+
+    def test_query_variants_synonymous(self, python_interface_session):
+        # RST lines 81-90: filtering by effect_types=['synonymous'] yields 4
+        # variants.
+        assert_python_snippet_output(
+            python_interface_session.values, "synonymous_count",
+            _SYNONYMOUS_COUNT,
+            rst_ref=f"{RST}:90",
+            expectation=(
+                "query_variants(effect_types=['synonymous']) yields 4 variants"
+            ),
+            after_command=python_interface_session.process,
+        )
+
+    def test_query_variants_synonymous_prb(self, python_interface_session):
+        # RST lines 95-103: adding roles='prb' narrows the synonymous query to
+        # 1 variant.
+        assert_python_snippet_output(
+            python_interface_session.values, "synonymous_prb_count",
+            _SYNONYMOUS_PRB_COUNT,
+            rst_ref=f"{RST}:103",
+            expectation=(
+                "query_variants(effect_types=['synonymous'], roles='prb') "
+                "yields 1 variant"
+            ),
+            after_command=python_interface_session.process,
+        )
+
+
+class TestQueryingPhenotypeData:
+    """RST lines 105-178: list phenotype data and read mini_pheno
+    instruments, measures, and per-person measure values."""
+
+    def test_get_phenotype_data_ids(self, python_interface_session):
+        # RST lines 110-118: get_phenotype_data_ids() returns the ids of all
+        # configured phenotype data.
+        assert_python_snippet_output(
+            python_interface_session.values, "phenotype_data_ids",
+            _PHENOTYPE_DATA_IDS,
+            rst_ref=f"{RST}:118",
+            expectation=(
+                "get_phenotype_data_ids() lists every configured phenotype "
+                "study"
+            ),
+            after_command=python_interface_session.process,
+        )
+
+    def test_instruments(self, python_interface_session):
+        # RST lines 124-134: mini_pheno exposes the basic_medical (4 measures)
+        # and iq (3 measures) instruments.
+        assert_python_snippet_output(
+            python_interface_session.values, "instruments",
+            _INSTRUMENTS,
+            rst_ref=f"{RST}:134",
+            expectation=(
+                "mini_pheno exposes the basic_medical and iq instruments"
+            ),
+            after_command=python_interface_session.process,
+        )
+
+    def test_measures(self, python_interface_session):
+        # RST lines 137-149: mini_pheno exposes the seven documented measures.
+        assert_python_snippet_output(
+            python_interface_session.values, "measures",
+            _MEASURES,
+            rst_ref=f"{RST}:149",
+            expectation="mini_pheno exposes the seven documented measures",
+            after_command=python_interface_session.process,
+        )
+
+    def test_people_measure_values(self, python_interface_session):
+        # RST lines 153-178: non-verbal IQ for the probands of f1, f2, f3.
+        assert_python_snippet_output(
+            python_interface_session.values, "people_measure_values",
+            _PEOPLE_MEASURE_VALUES,
+            rst_ref=f"{RST}:178",
+            expectation=(
+                "get_people_measure_values() returns the probands' non-verbal "
+                "IQ for f1, f2, f3"
+            ),
+            after_command=python_interface_session.process,
+        )


### PR DESCRIPTION
Implements **#883** — the final child of epic #871 (docs-e2e guide-accuracy regression for the GPF Getting Started Guide).

## What this adds
`docs_e2e/tests/test_python_interface.py` — guide-claim tests for `getting_started_with_python_interface.rst`, the last sub-guide and the only REST-free one. The guide is a REPL-style narrative driving the GPF Python API directly, so the suite:

- adds a session-scoped `python_interface_session` fixture (conftest) that runs the guide's query snippets **faithfully in one python process** in the gpf-web conda env — one `GPFInstance.build()` against the fully-prepared instance the earlier guides produced — and captures a JSON summary of each snippet's result;
- adds an `assert_python_snippet_output` helper (with unit tests in `test_guide_assertions.py`) carrying the `rst_ref` + a triage hint, and surfacing the driver's stderr when the whole script fails (e.g. a renamed import);
- asserts each discrete documented claim: `get_genotype_data_ids` / `get_phenotype_data_ids` lists, `example_dataset` variant queries (all / synonymous / synonymous+prb), and `mini_pheno` instruments / measures / per-person measure values.

## Guide drift fixed in the same PR (strict mode)
1. **Import namespace** — the GPF Python package was renamed `dae` → `gpf`; the guide still imported `from dae.gpf_instance…` / `from dae.variants.attributes…`, which now fails with `ModuleNotFoundError`. Both import snippets updated to `gpf.`, and guarded going forward by a static RST check (`test_guide_uses_current_import_namespace`).
2. **Demo-data drift** — the `example_dataset` query now yields **24** alt alleles, not the 22 the guide printed (gpf-getting-started master added `chr14:21409849 A->G` and `chr14:21431499 T->C`). Refreshed the guide's output block to the current 24 in iteration order.

## Validation
Run locally in the docs-e2e driver container against the prewarmed GRR cache: **10/10 green**. The full session-fixture chain (denovo/cnv/pheno imports → gene-sets/profiles config) is exercised, so fixture-wiring breaks are caught. No Jenkinsfile change — `gpf-docs-e2e` collects the new `tests/test_*.py` automatically.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)