### PR TITLE
gpf-web image: serve under a runtime URL prefix (GPF_PREFIX) — Closes #903

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -62,9 +62,14 @@ COPY --from=backend /opt/gpf /opt/gpf
 # the document root in our config to that path.
 COPY --from=frontend /usr/local/apache2/htdocs/ /var/www/html/
 
-# Apache + supervisord configs.
+# Apache + supervisord configs. The .template is the prefixed
+# variant rendered by the entrypoint when GPF_PREFIX is set; the
+# plain .conf is the root variant used as-is when it's unset.
 COPY httpd-combined.conf /etc/apache2/apache2.conf
+COPY httpd-combined.conf.template /etc/apache2/httpd-combined.conf.template
 COPY supervisord.conf /etc/supervisor/supervisord.conf
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV PATH=/opt/gpf/bin:$PATH \
     PYTHONUNBUFFERED=1 \
@@ -73,7 +78,10 @@ ENV PATH=/opt/gpf/bin:$PATH \
 
 EXPOSE 80
 
-# supervisord runs as PID 1; it forks gunicorn (loopback
+# The entrypoint applies GPF_PREFIX (renders the prefixed Apache
+# vhost + repoints the SPA <base href>) when set, then exec's the
+# CMD. supervisord runs as PID 1; it forks gunicorn (loopback
 # :9001) and apache2 (:80) and forwards their stdio to the
 # container's stdio.
-ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -999,6 +999,27 @@ pipeline {
                             docker tag "$BUNDLE_REPO:$BUILD_NUMBER" \
                                        "$BUNDLE_REPO:$GIT_SHORT"
 
+                            # URL-prefix support smoke (gpf#903). The
+                            # entrypoint renders the prefixed Apache
+                            # vhost + repoints the SPA <base href> when
+                            # GPF_PREFIX is set, and Django derives
+                            # FORCE_SCRIPT_NAME/STATIC_URL from
+                            # WDAE_PREFIX. Verify the real image:
+                            #   - root Apache config parses,
+                            #   - prefixed Apache config parses,
+                            #   - the SPA base href is rewritten,
+                            #   - Django produces the prefixed settings.
+                            IMG="$BUNDLE_REPO:$BUILD_NUMBER"
+                            docker run --rm "$IMG" apache2ctl configtest
+                            docker run --rm -e GPF_PREFIX=gpf "$IMG" apache2ctl configtest
+                            docker run --rm -e GPF_PREFIX=gpf "$IMG" \
+                                grep -q '<base href="/gpf/"' /var/www/html/index.html
+                            docker run --rm -e WDAE_PREFIX=gpf "$IMG" python -c "\
+from django.conf import settings; \
+assert settings.FORCE_SCRIPT_NAME == '/gpf', settings.FORCE_SCRIPT_NAME; \
+assert settings.STATIC_URL == '/gpf/static/', settings.STATIC_URL; \
+print('gpf-web prefix settings OK')"
+
                             # Resolve and record the base-image digests
                             # this build used, so a future release
                             # pipeline can rebuild from a tagged commit

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Entrypoint for the combined gpf-web image.
+#
+# When GPF_PREFIX is set, serve the app under /<prefix>/ instead of
+# the document root: render the prefixed Apache vhost from
+# httpd-combined.conf.template and repoint the SPA <base href>. When
+# GPF_PREFIX is empty, do nothing — the image ships the root-serving
+# httpd-combined.conf and <base href="/"> verbatim, so root
+# deployments (and web_e2e / compose) are byte-for-byte unchanged.
+#
+# Then hand off (exec) to the image's CMD — supervisord, which
+# foreground-runs gunicorn + apache2. apache2 reads the conf we
+# render here, so this MUST run before supervisord starts it (it
+# does: this is the ENTRYPOINT, supervisord is the CMD).
+#
+# Apache strips the prefix when proxying to gunicorn; Django carries
+# it back via FORCE_SCRIPT_NAME (set from WDAE_PREFIX). gpf-infra
+# sets GPF_PREFIX and WDAE_PREFIX to the same value.
+set -euo pipefail
+
+TEMPLATE=/etc/apache2/httpd-combined.conf.template
+APACHE_CONF=/etc/apache2/apache2.conf
+SPA_INDEX=/var/www/html/index.html
+
+# Normalise: "/gpf/" | "gpf" | "/gpf" -> "gpf"; unset/"" -> "".
+prefix="${GPF_PREFIX:-}"
+prefix="${prefix#/}"
+prefix="${prefix%/}"
+
+if [[ -n "$prefix" ]]; then
+    echo "gpf-web entrypoint: serving under /${prefix}/ (GPF_PREFIX=${prefix})"
+
+    # Render the prefixed vhost (token -> prefix path segment),
+    # overwriting the shipped root config.
+    sed "s|__GPF_PREFIX__|${prefix}|g" "$TEMPLATE" > "$APACHE_CONF"
+
+    # Repoint the SPA. The new SPA is fully relative, so rewriting
+    # this single line relocates assets + API + client-side routing
+    # under the prefix. The generic match on the current value makes
+    # it idempotent (safe across container restarts / re-renders).
+    if [[ -f "$SPA_INDEX" ]]; then
+        sed -i -E "s#<base href=\"[^\"]*\"#<base href=\"/${prefix}/\"#" "$SPA_INDEX"
+    fi
+else
+    echo "gpf-web entrypoint: serving at document root (GPF_PREFIX unset)"
+fi
+
+exec "$@"

--- a/httpd-combined.conf.template
+++ b/httpd-combined.conf.template
@@ -1,0 +1,132 @@
+## Apache config for the combined gpf-web image — PREFIXED variant.
+##
+## Rendered by docker-entrypoint.sh to /etc/apache2/apache2.conf when
+## GPF_PREFIX is set: the token __GPF_PREFIX__ is replaced with the
+## prefix path segment (e.g. "gpf"), so the app is served under
+## /gpf/ instead of /. When GPF_PREFIX is empty the entrypoint does
+## NOT use this file — it leaves the shipped httpd-combined.conf
+## (root variant) in place, so root deployments are byte-for-byte
+## unchanged.
+##
+## Prefix model: Apache STRIPS the prefix when proxying to gunicorn
+## (so Django resolves urlpatterns at root, ^api/ etc.), and Django
+## carries the prefix back into generated URLs / redirects / the
+## password-reset form's {% url %} via FORCE_SCRIPT_NAME (set from
+## WDAE_PREFIX). STATIC_URL is made /__GPF_PREFIX__/static/ in
+## default_settings.py so server-rendered static resolves here too.
+##
+## KEEP THE SHARED BITS IN SYNC WITH httpd-combined.conf (root
+## variant): module loads, the pheno-images alias, the cache rules,
+## the compression list, and the gunicorn proxy targets. Only the
+## URL-path layout (the /__GPF_PREFIX__ segment, the SPA fallback,
+## and the bare-root redirect) differs between the two files.
+
+ServerRoot "/etc/apache2"
+ServerName localhost
+Listen 80
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+PidFile ${APACHE_PID_FILE}
+
+LoadModule mpm_event_module       /usr/lib/apache2/modules/mod_mpm_event.so
+LoadModule authz_core_module      /usr/lib/apache2/modules/mod_authz_core.so
+LoadModule mime_module            /usr/lib/apache2/modules/mod_mime.so
+LoadModule dir_module             /usr/lib/apache2/modules/mod_dir.so
+LoadModule alias_module           /usr/lib/apache2/modules/mod_alias.so
+LoadModule headers_module         /usr/lib/apache2/modules/mod_headers.so
+LoadModule filter_module          /usr/lib/apache2/modules/mod_filter.so
+LoadModule deflate_module         /usr/lib/apache2/modules/mod_deflate.so
+LoadModule expires_module         /usr/lib/apache2/modules/mod_expires.so
+LoadModule rewrite_module         /usr/lib/apache2/modules/mod_rewrite.so
+LoadModule remoteip_module        /usr/lib/apache2/modules/mod_remoteip.so
+LoadModule proxy_module           /usr/lib/apache2/modules/mod_proxy.so
+LoadModule proxy_http_module      /usr/lib/apache2/modules/mod_proxy_http.so
+LoadModule proxy_wstunnel_module  /usr/lib/apache2/modules/mod_proxy_wstunnel.so
+LoadModule setenvif_module        /usr/lib/apache2/modules/mod_setenvif.so
+
+ErrorLog  /proc/self/fd/2
+CustomLog /proc/self/fd/1 common
+LogLevel  warn
+
+TypesConfig /etc/mime.types
+
+DocumentRoot "/var/www/html"
+
+# Bare root → the prefixed app.
+RedirectMatch ^/$ /__GPF_PREFIX__/
+
+# Reverse-proxy the dynamic paths to the in-container gunicorn,
+# STRIPPING the prefix (Django resolves at root; FORCE_SCRIPT_NAME
+# re-adds it to generated URLs). Declared before the Aliases below
+# so these win for the dynamic paths. /o/ + /accounts/ are the
+# OAuth login round-trip; /ws/ is websockets.
+ProxyPreserveHost On
+ProxyRequests Off
+RequestHeader set X-Forwarded-Proto "%{REQUEST_SCHEME}e"
+ProxyPass        /__GPF_PREFIX__/api/      http://127.0.0.1:9001/api/
+ProxyPassReverse /__GPF_PREFIX__/api/      http://127.0.0.1:9001/api/
+ProxyPass        /__GPF_PREFIX__/o/        http://127.0.0.1:9001/o/
+ProxyPassReverse /__GPF_PREFIX__/o/        http://127.0.0.1:9001/o/
+ProxyPass        /__GPF_PREFIX__/accounts/ http://127.0.0.1:9001/accounts/
+ProxyPassReverse /__GPF_PREFIX__/accounts/ http://127.0.0.1:9001/accounts/
+ProxyPass        /__GPF_PREFIX__/ws/ ws://127.0.0.1:9001/ws/
+ProxyPassReverse /__GPF_PREFIX__/ws/ ws://127.0.0.1:9001/ws/
+
+# Phenotype-browser images (parameterised container path; same as
+# the root variant). More specific than the /static/ alias, so it
+# is declared first.
+Alias /__GPF_PREFIX__/static/images/ "${PHENO_IMAGES_DIR}"
+<Directory "${PHENO_IMAGES_DIR}">
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+    <FilesMatch ".+">
+        ExpiresActive Off
+        Header unset Cache-Control
+        Header unset Expires
+    </FilesMatch>
+</Directory>
+
+# Django admin / DRF static + the SPA's own static assets, served
+# from the collected htdocs. STATIC_URL is /__GPF_PREFIX__/static/
+# (default_settings.py), so {% static %} in server-rendered pages
+# resolves here.
+Alias /__GPF_PREFIX__/static/ "/var/www/html/static/"
+<Directory "/var/www/html/static/">
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+    ExpiresActive On
+    ExpiresDefault "access plus 1 year"
+    Header set Cache-Control "public, immutable"
+</Directory>
+
+# The SPA, served under the prefix. The Alias maps /__GPF_PREFIX__
+# onto the document root; FallbackResource sends any path that
+# isn't a real file (i.e. client-side routes) to index.html. The
+# proxied + static paths above are handled in earlier phases, so
+# they never reach FallbackResource.
+Alias /__GPF_PREFIX__ "/var/www/html"
+<Directory "/var/www/html">
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+    DirectoryIndex index.html
+    FallbackResource /__GPF_PREFIX__/index.html
+</Directory>
+
+# Long cache on hashed Angular assets, no-cache on index.html so a
+# deploy is picked up immediately. Filename-based, prefix-agnostic.
+<Files "index.html">
+    Header set Cache-Control "no-store, no-cache, must-revalidate"
+</Files>
+<FilesMatch "\.(js|css|woff2?|svg|png|jpg|jpeg|gif|ico)$">
+    ExpiresActive On
+    ExpiresDefault "access plus 1 year"
+    Header set Cache-Control "public, immutable"
+</FilesMatch>
+
+# Compression for text types.
+AddOutputFilterByType DEFLATE \
+    text/plain text/html text/css text/xml \
+    application/javascript application/json image/svg+xml

--- a/web_api/gpf_web/gpf_web/default_settings.py
+++ b/web_api/gpf_web/gpf_web/default_settings.py
@@ -113,7 +113,16 @@ MEDIA_URL = ""
 
 STATIC_ROOT = ""
 
-STATIC_URL = "static/"
+# Server-rendered static (DRF, admin, and the password-reset /
+# set-password form's {% static %}). When serving under a URL
+# prefix, make STATIC_URL absolute + prefixed so it resolves at
+# /<prefix>/static/ — where the combined image's Apache aliases
+# it. Root keeps the relative "static/" it has always used.
+# WDAE_PREFIX is read above (next to LOGIN_URL/FORCE_SCRIPT_NAME).
+if WDAE_PREFIX:
+    STATIC_URL = f"/{WDAE_PREFIX}/static/"
+else:
+    STATIC_URL = "static/"
 
 APPEND_SLASH = False
 


### PR DESCRIPTION
Closes #903.

## Why
The combined `gpf-web` image is root-only: `httpd-combined.conf` hardcodes root routing and the SPA ships `<base href="/">`. `GPF_PREFIX`/`WDAE_PREFIX` had no effect — a `/gpf/api/...` request fell through to the SPA catch-all and returned `index.html` (a status-only healthcheck is fooled by this). That blocks the **SFARI cutover** (`gpf.sfari.org/gpf`) and serving GPF under `/gpf` on internal hosts (dory).

## What
Runtime, env-driven prefix; **root stays the default and is byte-for-byte unchanged**.

- **`httpd-combined.conf.template`** — prefixed vhost. Apache **strips** the prefix when proxying to gunicorn (Django resolves `urlpatterns` at root), and `FORCE_SCRIPT_NAME` re-adds it to generated URLs (login redirect, DRF, OAuth, the password-reset form's `{% url %}`). SPA served under `/<prefix>/` via `FallbackResource`; `/<prefix>/static{,/images}` aliased; bare `/` → `/<prefix>/`.
- **`docker-entrypoint.sh`** — if `GPF_PREFIX` set: render the template (token → prefix) over `apache2.conf` and idempotently repoint the **single** `<base href>` in `index.html` (the new SPA is fully relative, so one line relocates assets + API + routing). Empty → ship root config + `<base href="/">` verbatim. Then `exec` the CMD.
- **`Dockerfile.production`** — entrypoint becomes `ENTRYPOINT`; supervisord becomes `CMD`.
- **`default_settings.py`** — `STATIC_URL = /<WDAE_PREFIX>/static/` when prefixed (root unchanged) so server-rendered static resolves under the prefix.
- **`Jenkinsfile`** — smoke the built image: root + prefixed `apache2ctl configtest`, the SPA base-href rewrite, and Django's derived `FORCE_SCRIPT_NAME`/`STATIC_URL`.

## Scope
Combined `gpf-web` image only. Split `gpf-web-ui`/`gpf-web-api` images and the SPA build stay root → **web_e2e / compose / docs-e2e unaffected** (they never set `GPF_PREFIX`).

## Validation (local, against the rendered config + stub backend)
- `apache2 -t` → Syntax OK (root and prefixed).
- `/` → `302 → /gpf/`; `/gpf/api/v3/datasets/hierarchy` → backend receives **`/api/v3/datasets/hierarchy`** (prefix **stripped**); `/gpf/` + `/gpf/some/route` → SPA index (fallback); `/gpf/main.js` + `/gpf/static/styles.css` → served.

## Consumer / rollout
`gpf-infra` already passes `GPF_PREFIX`/`WDAE_PREFIX` and (in an open PR) fronts dory with a host Apache proxying `/gpf → :9038/gpf`. After this merges and CI publishes `registry.seqpipe.org/gpf-web`, dory deploys with `GPF_PREFIX=gpf` (pinned to this build for the cutover) and gpf-smoke-tests is pointed at `/gpf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)