### PR TITLE
ci: DOCS_ONLY carve-out for getting-started so docs-e2e fires on guide edits (#905)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,6 +229,20 @@ pipeline {
                     // commits since last build) → DOCS_ONLY='false' →
                     // full CI. Conservative default — only short-circuit
                     // when we positively know it's docs-only.
+                    //
+                    // Getting-Started carve-out (#905): the prose under
+                    // docs/source/administration/getting_started/** is the
+                    // system-under-test of the gpf-docs-e2e build, which is
+                    // gated on `not DOCS_ONLY` AND installs gpf-web from
+                    // THIS build's fresh dist/conda artefacts (themselves
+                    // produced by the `Conda packages` stage, also gated on
+                    // `not DOCS_ONLY`). So a change touching the guide must
+                    // NOT count as docs-only — otherwise the Conda stage is
+                    // skipped, there are no artefacts for docs-e2e to copy,
+                    // and the guide-accuracy suite never runs on the very
+                    // change meant to exercise it. A guide edit therefore
+                    // runs full CI; guide edits are infrequent and a guide
+                    // change is exactly when that validation should run.
                     steps {
                         script {
                             def changedFiles = []
@@ -237,11 +251,18 @@ pipeline {
                                     changedFiles.addAll(item.affectedPaths)
                                 }
                             }
+                            String gettingStartedPrefix =
+                                'docs/source/administration/getting_started/'
+                            boolean touchesGuide = changedFiles.any {
+                                it.startsWith(gettingStartedPrefix)
+                            }
                             boolean isDocsOnly =
                                 !changedFiles.isEmpty() &&
-                                changedFiles.every { it.startsWith('docs/') }
+                                changedFiles.every { it.startsWith('docs/') } &&
+                                !touchesGuide
                             env.DOCS_ONLY = isDocsOnly ? 'true' : 'false'
                             echo "Changeset: ${changedFiles.size()} file(s); " +
+                                 "touchesGuide=${touchesGuide}; " +
                                  "DOCS_ONLY=${env.DOCS_ONLY}"
                         }
                     }
@@ -1278,13 +1299,14 @@ print('gpf-web prefix settings OK')"
                     // branch before gpf-seed has re-run) from
                     // becoming fatal — parent stays UNSTABLE.
                     //
-                    // v1 docs-only-gap (see #871 § Triggering):
-                    // A pure prose edit to
-                    // docs/source/administration/getting_started/**
-                    // sets DOCS_ONLY=true and so skips this
-                    // stage; the next code commit catches drift.
-                    // A path-aware carve-out is filed as a
-                    // follow-up; defer until v1 (#872) settles.
+                    // Getting-Started carve-out (#905): a pure prose
+                    // edit to docs/source/administration/getting_started/**
+                    // is treated as NOT docs-only by the `Detect change
+                    // scope` stage (DOCS_ONLY=false), so this stage runs
+                    // and the guide-accuracy suite fires on guide-only
+                    // changes — see that stage's comment for why a guide
+                    // edit must run full CI (docs-e2e needs this build's
+                    // fresh conda artefacts).
                     steps {
                         catchError(
                             buildResult: 'UNSTABLE',


### PR DESCRIPTION
Implements **#905** — the deferred follow-up of epic #871.

## Problem
`Detect change scope` sets `DOCS_ONLY=true` when every changed file starts with `docs/`. Both the `Conda packages` stage and the `Trigger docs-e2e` stage gate on `not DOCS_ONLY`. So a **pure prose edit** to `docs/source/administration/getting_started/**` skipped docs-e2e — the guide-accuracy suite never ran on exactly the change it exists to guard. (The `Trigger docs-e2e` stage documented this gap as a deferred follow-up.)

## Fix
Treat a changeset that touches the Getting Started subtree as **not docs-only** → `DOCS_ONLY=false` → the Conda stage builds this commit's `dist/conda/*.conda` and `Trigger docs-e2e` installs gpf-web from them.

Un-gating *only* the trigger would not work: docs-e2e `copyArtifacts` **this build's** conda, which exist only when the Conda stage runs. Making the guide subtree not-docs-only keeps Conda + trigger coherent.

**Cost:** a prose-only guide edit runs full CI instead of the docs-fast-path. Acceptable — guide edits are infrequent, and a guide change is precisely when the full guide-accuracy validation should run. Other `docs/**` edits keep the fast-path.

## Validation
The predicate's decision table was checked against representative changesets — guide-only / guide+docs / other-docs-only / code+docs / empty:

| changeset | DOCS_ONLY |
|---|---|
| guide RST or literalinclude only | **false** (carve-out fires) |
| guide + other docs | **false** |
| other `docs/**` only | **true** (fast-path preserved) |
| code (± docs) | false |
| empty changeset | false (conservative) |

Note: this PR touches the `Jenkinsfile` (a non-docs file), so its **own** branch build runs full CI and can't exercise the getting-started-only path directly; the branch build does validate that the pipeline still parses. End-to-end confirmation is a trivial guide-only commit on master showing `DOCS_ONLY=false` + `gpf-docs-e2e` triggered.

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)