### PR TITLE
docs-e2e: validate getting_started_with_federation.rst — with auth (#882)

### DIFF
--- a/docs/source/administration/getting_started/getting_started_with_federation.rst
+++ b/docs/source/administration/getting_started/getting_started_with_federation.rst
@@ -16,7 +16,7 @@ Configure federation on your local GPF instance
 +++++++++++++++++++++++++++++++++++++++++++++++
 
 To use the GPF federation, you need to install the additional
-``gpf_federation`` conda package in your local conda environment. You can do
+``gpf-federation`` conda package in your local conda environment. You can do
 this by running the following command:
 
 .. code-block:: bash
@@ -25,7 +25,7 @@ this by running the following command:
         -c conda-forge \
         -c bioconda \
         -c iossifovlab \
-        gpf_federation
+        gpf-federation
 
 Once the package is installed, you need to configure the federation on your
 local GPF instance. You can do this by editing the
@@ -33,7 +33,7 @@ local GPF instance. You can do this by editing the
 
 .. code-block:: yaml
     :linenos:
-    :emphasize-lines: 30-32
+    :emphasize-lines: 29-31
 
     instance_id: minimal_instance
 
@@ -51,7 +51,6 @@ local GPF instance. You can do this by editing the
     gene_sets_db:
       gene_set_collections:
       - gene_properties/gene_sets/autism
-      - gene_properties/gene_sets/relevant
       - gene_properties/gene_sets/GO_2024-06-17_release
 
     gene_scores_db:

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -1591,3 +1591,387 @@ def wgpf_server(gene_profiles_instance, gpf_env):
             proc.kill()
         log_fh.close()
         log_path.unlink(missing_ok=True)
+
+
+# --- federation (getting_started_with_federation.rst, #882) --------------
+#
+# Federation needs a SECOND, remote GPF instance. The guide points the local
+# instance's `remotes:` block at the external SFARI instance; docs-e2e can't
+# depend on that, so we stand up a hermetic LOCAL stand-in remote and
+# federate local clients with it over HTTP.
+#
+# The remote runs as `wdaemanage runserver`, NOT `wgpf run`: wgpf forces
+# `settings.DISABLE_PERMISSIONS = True` (wgpf.py), bypassing ALL auth — a
+# federation test built on it would never exercise authentication. wdaemanage
+# uses `gpf_web.settings` (DISABLE_PERMISSIONS=False), so the remote ENFORCES
+# permissions, like SFARI. We set it up like the existing federation
+# integration backend (federation/scripts/backend/run_gpf.sh): migrate, a
+# federation user, and a client-credentials OAuth app — the CLI equivalent of
+# the guide's "create a federation token" UI step.
+#
+# The remote serves TWO demo studies so the test proves auth BOTH ways:
+#   - denovo_example -> PUBLIC (granted `any_user`): a token-free client can
+#     see it (the guide's public-access path, RST 67-76).
+#   - vcf_example -> PROTECTED (default `any_dataset`, not any_user): a
+#     token-free client must NOT see it, but a token client (configured with
+#     the OAuth client_id/secret) CAN (the Federation-tokens path, RST
+#     134-178).
+#
+# Carve-outs (documented): the remotes.url is local (vs SFARI), and the token
+# is created via `wdaemanage createapplication` rather than the SFARI UI —
+# both invisible infrastructure we substitute. Out of scope (non-hermetic,
+# like the screenshots): the literal token-panel UI steps.
+#
+# The clients stay on `wgpf run` (auth-disabled): gatekeeping happens on the
+# REMOTE; a client just displays what the remote returned for its
+# credentials, and disabling the client's own permissions lets the test's
+# plain httpx read the federated view without itself needing a token. This
+# subtree is INDEPENDENT of the main imports/annotation/gene-profiles chain.
+
+# A minimal GPF instance config: reference genome + gene models. The remote
+# adds studies; a client adds a `remotes:` block.
+_FEDERATION_BASE_CONFIG = (
+    "instance_id: {instance_id}\n"
+    "\n"
+    "reference_genome:\n"
+    '  resource_id: "hg38/genomes/GRCh38-hg38"\n'
+    "\n"
+    "gene_models:\n"
+    '  resource_id: "hg38/gene_models/MANE/1.3"\n'
+)
+
+# The remote-config id used in each client's `remotes:` block; the federation
+# extension prefixes remote study ids with it (<id>_<study>).
+_FEDERATION_REMOTE_ID = "fed_remote"
+
+# The OAuth client-credentials app created on the remote — the stand-in for a
+# SFARI federation token. The token client puts these in its `remotes:` block;
+# the secret is the plaintext the client authenticates with.
+_FEDERATION_CLIENT_ID = "docs_e2e_federation"
+_FEDERATION_CLIENT_SECRET = "docs-e2e-federation-secret"  # noqa: S105
+
+# The two demo studies the remote serves: one public, one protected.
+_FEDERATION_PUBLIC_STUDY = "denovo_example"
+_FEDERATION_PROTECTED_STUDY = "vcf_example"
+
+# Cap for each wdaemanage setup command (migrate/user_create/etc.).
+_FEDERATION_SETUP_TIMEOUT = 600
+
+
+def _wgpf_cmd(port):
+    return ["wgpf", "run", "--port", str(port), "--host", "127.0.0.1"]
+
+
+def _wdaemanage_runserver_cmd(port):
+    # `wdaemanage runserver` uses gpf_web.settings → DISABLE_PERMISSIONS=False,
+    # so the served instance ENFORCES dataset permissions (unlike `wgpf run`).
+    return [
+        "wdaemanage", "runserver", "--noreload", "--skip-checks",
+        f"127.0.0.1:{port}",
+    ]
+
+
+def _serve_instance(make_cmd, instance_dir, env, *,
+                    ready_timeout=_WGPF_READY_TIMEOUT):
+    """Start a GPF web server against ``instance_dir`` on a free port, poll for
+    readiness, and yield a handle; tear it down on generator close.
+    ``make_cmd(port)`` returns the argv to launch (``wgpf run`` for clients,
+    ``wdaemanage runserver`` for the authenticated remote).
+
+    Same robust shape as the shared ``wgpf_server`` fixture: combined
+    stdout/stderr go to a temp FILE (never a PIPE — an undrained pipe would
+    deadlock a verbose first boot before the port binds), readiness is a
+    ``== 200`` poll on ``/api/v3/datasets/`` (Django answering is not enough;
+    we wait for the instance to finish building — anonymous still gets 200 with
+    only the public datasets), and a failed boot ``pytest.fail``s with the
+    server log tail.
+    """
+    import httpx  # lazy — see top-of-file note.
+
+    port = _pick_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    log_fd, log_name = tempfile.mkstemp(prefix="docs-e2e-fed-", suffix=".log")
+    os.close(log_fd)
+    log_path = Path(log_name)
+    log_fh = log_path.open("wb")
+
+    def _log_tail(n_chars=4000):
+        try:
+            log_fh.flush()
+        except ValueError:
+            pass
+        try:
+            return log_path.read_text(errors="replace")[-n_chars:]
+        except OSError:
+            return ""
+
+    proc = subprocess.Popen(
+        make_cmd(port),
+        cwd=instance_dir, env=env, stdout=log_fh, stderr=subprocess.STDOUT,
+    )
+    client = httpx.Client(base_url=base_url, timeout=60.0)
+
+    deadline = time.monotonic() + ready_timeout
+    last_err = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            pytest.fail(
+                f"federation server exited early "
+                f"(returncode={proc.returncode}):\n{_log_tail()}",
+                pytrace=False,
+            )
+        try:
+            r = client.get("/api/v3/datasets/")
+            if r.status_code == 200:
+                break
+            last_err = f"HTTP {r.status_code}"
+        except httpx.RequestError as exc:
+            last_err = repr(exc)
+        time.sleep(1)
+    else:
+        tail = _log_tail()
+        proc.terminate()
+        try:
+            proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+        pytest.fail(
+            f"federation server did not become ready within {ready_timeout}s "
+            f"(last error: {last_err}):\n{tail}",
+            pytrace=False,
+        )
+
+    try:
+        yield SimpleNamespace(
+            url=base_url, client=client, process=proc, log_path=log_path,
+        )
+    finally:
+        client.close()
+        proc.terminate()
+        try:
+            proc.communicate(timeout=_WGPF_SHUTDOWN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        log_fh.close()
+        log_path.unlink(missing_ok=True)
+
+
+@dataclass
+class FederationInstall:
+    """The result of the guide's ``mamba install gpf-federation`` step."""
+
+    install: subprocess.CompletedProcess
+
+
+@pytest.fixture(scope="session")
+def federation_install(gpf_env_prefix, conda_channel):
+    """Apply getting_started_with_federation.rst's install step: install the
+    separate ``gpf-federation`` conda package into the gpf-web env.
+
+    The guide tells the user to ``mamba install gpf_federation`` as a step
+    distinct from the main ``gpf-web`` install; gpf-federation ships its own
+    conda artefact (built by the same Conda stage) and registers the
+    federation extension into WGPFInstance via an entry point. We install it
+    from the same local channel + upstream channels the conda_channel fixture
+    indexes. Installing it into the shared env is safe for the non-federation
+    tests: with no ``remotes:`` configured, the extension no-ops.
+
+    Captures the subprocess result so test_federation can feed it into
+    ``assert_command_succeeds`` for the install claim.
+    """
+    cmd = [
+        "mamba", "install", "-y",
+        "--prefix", str(gpf_env_prefix),
+        "-c", f"file://{conda_channel}",
+        "-c", "iossifovlab",
+        "-c", "bioconda",
+        "-c", "conda-forge",
+        "gpf-federation",
+    ]
+    result = _run(cmd, timeout=_INSTALL_TIMEOUT)
+    return FederationInstall(install=result)
+
+
+def _fed_step(cmd, *, env, what, cwd=None, timeout=_FEDERATION_SETUP_TIMEOUT):
+    """Run one remote-setup subprocess step; ``pytest.fail`` with output on a
+    non-zero exit. Returns the CompletedProcess."""
+    result = _run(cmd, cwd=cwd, env=env, timeout=timeout)
+    if result.returncode != 0:
+        pytest.fail(
+            f"federation remote setup — {what} failed "
+            f"(exit {result.returncode}):\n"
+            f"  cmd: {' '.join(str(a) for a in cmd)}\n"
+            f"  stdout: {result.stdout.decode(errors='replace')[-2000:]}\n"
+            f"  stderr: {result.stderr.decode(errors='replace')[-2000:]}",
+            pytrace=False,
+        )
+    return result
+
+
+@dataclass
+class FederationRemoteInstance:
+    """The authenticated stand-in remote: a minimal GPF instance with two demo
+    studies (one public, one protected), a wdae DB, a federation user, and a
+    client-credentials OAuth app — the local stand-in for SFARI."""
+
+    instance_dir: Path
+    client_id: str
+    client_secret: str
+
+
+@pytest.fixture(scope="session")
+def federation_remote_instance(
+        getting_started_clone, gpf_env, tmp_path_factory,
+        grr_cache_seeded,  # noqa: ARG001 — ordering dep: cold-cache guard
+):
+    """Build the authenticated stand-in remote, mirroring the federation
+    integration backend (federation/scripts/backend/run_gpf.sh) on the
+    getting-started demo data:
+
+    1. minimal instance config + import the two demo studies
+       (``denovo_example`` + ``vcf_example``);
+    2. ``wdaemanage migrate`` — create the wdae sqlite DB
+       (DEFAULT_WDAE_DIR = <DAE_DB_DIR>/wdae, gpf_web.settings);
+    3. ``wdaemanage user_create`` — a federation user in the ``any_dataset``
+       group (so a token authenticated as it sees the protected study);
+    4. ``wdaemanage createapplication confidential client-credentials`` — the
+       OAuth app the token client authenticates with (the CLI stand-in for the
+       guide's UI-created federation token);
+    5. grant the ``any_user`` group to ``denovo_example`` — making it PUBLIC (a
+       token-free client can see it); ``vcf_example`` keeps its default
+       ``any_dataset`` grant and stays PROTECTED.
+
+    wdaemanage uses gpf_web.settings (DISABLE_PERMISSIONS=False), so the served
+    remote ENFORCES these permissions — what makes the auth test meaningful
+    (``wgpf run`` would bypass all of it).
+    """
+    remote_dir = tmp_path_factory.mktemp("fed-remote", numbered=False)
+    (remote_dir / "gpf_instance.yaml").write_text(
+        _FEDERATION_BASE_CONFIG.format(instance_id="fed_remote_instance"))
+
+    # Copy ONLY the input files (not the dir) so each import's work_dir
+    # `.task-progress` cache is isolated from the shared clone — see the #882
+    # note: a shared base dir makes re-importing an already-imported study a
+    # silent no-op (the main chain imports both demo studies from the clone).
+    clone = getting_started_clone
+    remote_inputs = remote_dir / "input_genotype_data"
+    remote_inputs.mkdir()
+    src_inputs = clone / "input_genotype_data"
+    for fname in (
+        f"{_FEDERATION_PUBLIC_STUDY}.yaml",
+        f"{_FEDERATION_PROTECTED_STUDY}.yaml",
+        "example.ped", "example.tsv", "example.vcf",
+    ):
+        shutil.copy2(src_inputs / fname, remote_inputs / fname)
+
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(remote_dir)
+
+    for study in (_FEDERATION_PUBLIC_STUDY, _FEDERATION_PROTECTED_STUDY):
+        _fed_step(
+            ["import_genotypes", f"input_genotype_data/{study}.yaml"],
+            cwd=remote_dir, env=env, what=f"import {study}",
+            timeout=_IMPORT_TIMEOUT,
+        )
+
+    _fed_step(["wdaemanage", "migrate", "--noinput"],
+              cwd=remote_dir, env=env, what="migrate")
+    _fed_step(
+        ["wdaemanage", "user_create", "fed@docs-e2e.test",
+         "-p", _FEDERATION_CLIENT_SECRET, "-g", "any_dataset"],
+        cwd=remote_dir, env=env, what="user_create",
+    )
+    _fed_step(
+        ["wdaemanage", "createapplication",
+         "confidential", "client-credentials",
+         "--user", "1",
+         "--name", "docs-e2e federation app",
+         "--client-id", _FEDERATION_CLIENT_ID,
+         "--client-secret", _FEDERATION_CLIENT_SECRET],
+        cwd=remote_dir, env=env, what="createapplication",
+    )
+    # Make the public study public by granting `any_user`. The grant
+    # get_or_creates the Dataset row; recreate_dataset_perm (run on the
+    # server's instance build) is additive, so the any_user grant survives.
+    grant_code = (
+        "from datasets_api.permissions import add_group_perm_to_dataset; "
+        f"add_group_perm_to_dataset('any_user', '{_FEDERATION_PUBLIC_STUDY}')"
+    )
+    _fed_step(
+        ["wdaemanage", "shell", "-c", grant_code],
+        cwd=remote_dir, env=env, what="grant any_user to public study",
+    )
+
+    return FederationRemoteInstance(
+        instance_dir=remote_dir,
+        client_id=_FEDERATION_CLIENT_ID,
+        client_secret=_FEDERATION_CLIENT_SECRET,
+    )
+
+
+@pytest.fixture(scope="session")
+def federation_remote_server(federation_remote_instance, gpf_env):
+    """Start ``wdaemanage runserver`` (permissions ENFORCED) on the
+    authenticated stand-in remote. It exposes ``/api/v3/datasets/federation``
+    etc.; an anonymous client fetches only the public study, an OAuth client
+    (client-credentials) fetches the protected one too."""
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(federation_remote_instance.instance_dir)
+    yield from _serve_instance(
+        _wdaemanage_runserver_cmd, federation_remote_instance.instance_dir, env)
+
+
+def _write_federation_client(client_dir, remote_url, *, creds=None):
+    """Write a federation client's gpf_instance.yaml with a ``remotes:`` block
+    pointing at ``remote_url``. With ``creds=(client_id, client_secret)`` the
+    block carries the token fields (the guide's authenticated path); without
+    them it is the token-free public path."""
+    parts = [
+        _FEDERATION_BASE_CONFIG.format(instance_id="fed_client_instance"),
+        "\nremotes:\n",
+        f'  - id: "{_FEDERATION_REMOTE_ID}"\n',
+        f'    url: "{remote_url}"\n',
+    ]
+    if creds is not None:
+        client_id, client_secret = creds
+        parts.extend([
+            f'    client_id: "{client_id}"\n',
+            f'    client_secret: "{client_secret}"\n',
+        ])
+    (client_dir / "gpf_instance.yaml").write_text("".join(parts))
+
+
+@pytest.fixture(scope="session")
+def federation_anon_client_server(
+        federation_remote_server, gpf_env, tmp_path_factory,
+        federation_install,  # noqa: ARG001 — ordering dep: env needs federation
+):
+    """Token-free federation client: a ``remotes:`` block with NO
+    client_id/secret. The federation extension uses an anonymous REST session,
+    so the authenticated remote returns only its PUBLIC study — the guide's
+    public-access path (RST 67-76)."""
+    client_dir = tmp_path_factory.mktemp("fed-anon-client", numbered=False)
+    _write_federation_client(client_dir, federation_remote_server.url)
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(client_dir)
+    yield from _serve_instance(_wgpf_cmd, client_dir, env)
+
+
+@pytest.fixture(scope="session")
+def federation_auth_client_server(
+        federation_remote_server, gpf_env, tmp_path_factory,
+        federation_install,  # noqa: ARG001 — ordering dep: env needs federation
+):
+    """Token federation client: a ``remotes:`` block WITH the OAuth
+    client_id/secret. The federation extension authenticates via OAuth
+    client-credentials, so the remote returns the PROTECTED study too — the
+    guide's Federation-tokens path (RST 134-178)."""
+    client_dir = tmp_path_factory.mktemp("fed-auth-client", numbered=False)
+    _write_federation_client(
+        client_dir, federation_remote_server.url,
+        creds=(_FEDERATION_CLIENT_ID, _FEDERATION_CLIENT_SECRET))
+    env = dict(gpf_env)
+    env["DAE_DB_DIR"] = str(client_dir)
+    yield from _serve_instance(_wgpf_cmd, client_dir, env)

--- a/docs_e2e/guide_assertions.py
+++ b/docs_e2e/guide_assertions.py
@@ -1226,3 +1226,91 @@ def assert_python_snippet_output(
         f"  {triage}"
     )
     raise AssertionError(message)
+
+
+def assert_remote_dataset_resolves(
+        response, dataset_id, *, rst_ref, expectation,
+):
+    """Assert a federated (remote) dataset's details resolve through the
+    client (``GET /api/v3/datasets/<dataset_id>`` → HTTP 200 with a non-empty
+    ``data`` object).
+
+    Backs the federation guide's claim that studies from the remote instance
+    are usable through the local instance. Resolving a remote study's
+    description requires the client to proxy the request to the remote over
+    REST, so a 200 here proves the federation link works end-to-end — not just
+    that the remote id was listed. The single-dataset endpoint is shaped
+    ``{"data": {...}}``; a 404 means the client did not register/resolve the
+    remote study.
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response, rst_ref=rst_ref, expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 resolving remote dataset '{dataset_id}'"
+            ),
+        ))
+    body = response.json()
+    data = body.get("data") if isinstance(body, dict) else None
+    if data:
+        return
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected: a resolved description for remote dataset "
+        f"{dataset_id!r}\n"
+        f"  actual:   data = {data!r}\n"
+        f"\n"
+        f"  Triage hint: the dataset endpoint returned 200 but no description "
+        f"for the remote study. Most likely the federation extension listed "
+        f"the remote id but could not resolve its config from the remote "
+        f"(the stand-in remote server may have stopped, or the remote study "
+        f"id drifted). Check the federation client's wgpf log dump for a REST "
+        f"error against the remote."
+    )
+    raise AssertionError(message)
+
+
+def assert_dataset_not_visible(response, dataset_id, *, rst_ref, expectation):
+    """Assert ``dataset_id`` is ABSENT from ``/api/v3/datasets/visible``.
+
+    The negative counterpart of ``assert_dataset_visible``: backs the
+    federation guide's claim that a token-free client can access ONLY the
+    publicly available remote resources, so a PROTECTED remote study must NOT
+    appear. A non-200 status, or the id being present, raises AssertionError —
+    presence specifically means the remote leaked a protected study to an
+    unauthenticated federation session (auth not enforced).
+    """
+    if response.status_code != 200:
+        raise AssertionError(_http_failure_message(
+            response, rst_ref=rst_ref, expectation=expectation,
+            what_was_expected=(
+                f"HTTP 200 with dataset '{dataset_id}' ABSENT from the "
+                f"visible list"
+            ),
+        ))
+    data = response.json()
+    visible_ids = [
+        item if isinstance(item, str)
+        else item.get("id") if isinstance(item, dict)
+        else None
+        for item in data
+    ]
+    if dataset_id not in visible_ids:
+        return
+    visible_list = ", ".join(repr(i) for i in visible_ids) or "(none)"
+    message = (
+        f'DRIFT at {rst_ref} — "{expectation}"\n'
+        f"\n"
+        f"  expected: dataset id {dataset_id!r} ABSENT from the visible list\n"
+        f"  actual:   it is present; visible ids = [{visible_list}]\n"
+        f"\n"
+        f"  Triage hint: a protected remote study is visible to a token-free "
+        f"federation client — the remote is NOT enforcing authentication. Most "
+        f"likely the remote is running with permissions disabled (e.g. `wgpf "
+        f"run`, which sets DISABLE_PERMISSIONS=True) instead of an auth-"
+        f"enforcing server, or the study was inadvertently granted the "
+        f"`any_user` (public) group. A token-free client must see only public "
+        f"studies."
+    )
+    raise AssertionError(message)

--- a/docs_e2e/test_guide_assertions.py
+++ b/docs_e2e/test_guide_assertions.py
@@ -12,6 +12,7 @@ import pytest
 from docs_e2e.guide_assertions import (
     assert_command_succeeds,
     assert_dataset_description_flag,
+    assert_dataset_not_visible,
     assert_dataset_visible,
     assert_denovo_gene_sets_for_dataset,
     assert_download_has_columns,
@@ -31,6 +32,7 @@ from docs_e2e.guide_assertions import (
     assert_preview_table_column_group,
     assert_python_snippet_output,
     assert_query_returned_variants,
+    assert_remote_dataset_resolves,
 )
 
 
@@ -1357,3 +1359,82 @@ class TestAssertPythonSnippetOutput:
         # the driver's traceback tail is surfaced for triage
         assert "No module named 'dae'" in message
         assert "Fix that failure first" in message
+
+
+_FED_RST = "getting_started_with_federation.rst"
+
+
+class TestAssertRemoteDatasetResolves:
+    def test_passes_when_data_resolves(self):
+        resp = _FakeResponse(200, json_body={
+            "data": {"id": "fed_remote_denovo_example", "name": "denovo"},
+        })
+        assert_remote_dataset_resolves(
+            resp, "fed_remote_denovo_example",
+            rst_ref=f"{_FED_RST}:106",
+            expectation="the remote study resolves through the client",
+        )
+
+    def test_raises_on_404(self):
+        # 404 means the client never registered/resolved the remote study.
+        resp = _FakeResponse(404, text="Not Found")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_remote_dataset_resolves(
+                resp, "fed_remote_denovo_example",
+                rst_ref=f"{_FED_RST}:106",
+                expectation="the remote study resolves through the client",
+            )
+        message = str(exc_info.value)
+        assert f"{_FED_RST}:106" in message
+        assert "HTTP 404" in message
+
+    def test_raises_on_empty_data(self):
+        resp = _FakeResponse(200, json_body={"data": {}})
+        with pytest.raises(AssertionError) as exc_info:
+            assert_remote_dataset_resolves(
+                resp, "fed_remote_denovo_example",
+                rst_ref=f"{_FED_RST}:106",
+                expectation="the remote study resolves through the client",
+            )
+        message = str(exc_info.value)
+        assert "fed_remote_denovo_example" in message
+        # federation-aware triage
+        assert "remote" in message.lower()
+
+
+class TestAssertDatasetNotVisible:
+    def test_passes_when_protected_absent(self):
+        # token-free client sees only the public study, not the protected one
+        resp = _FakeResponse(200, json_body=["fed_remote_denovo_example"])
+        assert_dataset_not_visible(
+            resp, "fed_remote_vcf_example",
+            rst_ref=f"{_FED_RST}:74",
+            expectation="the protected study stays hidden without a token",
+        )
+
+    def test_raises_when_protected_present(self):
+        # a protected study leaking to a token-free client = auth not enforced
+        resp = _FakeResponse(200, json_body=[
+            "fed_remote_denovo_example", "fed_remote_vcf_example",
+        ])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_dataset_not_visible(
+                resp, "fed_remote_vcf_example",
+                rst_ref=f"{_FED_RST}:74",
+                expectation="the protected study stays hidden without a token",
+            )
+        message = str(exc_info.value)
+        assert f"{_FED_RST}:74" in message
+        assert "fed_remote_vcf_example" in message
+        # triage names the auth-enforcement failure mode
+        assert "DISABLE_PERMISSIONS" in message
+
+    def test_raises_on_non_200(self):
+        resp = _FakeResponse(500, text="boom")
+        with pytest.raises(AssertionError) as exc_info:
+            assert_dataset_not_visible(
+                resp, "fed_remote_vcf_example",
+                rst_ref=f"{_FED_RST}:74",
+                expectation="the protected study stays hidden without a token",
+            )
+        assert "HTTP 500" in str(exc_info.value)

--- a/docs_e2e/tests/test_federation.py
+++ b/docs_e2e/tests/test_federation.py
@@ -1,0 +1,158 @@
+"""Guide-claim tests for getting_started_with_federation.rst.
+
+Federation needs a SECOND, remote GPF instance. The guide points the local
+instance's ``remotes:`` block at the external SFARI instance; docs-e2e can't
+depend on that, so the fixtures (conftest.py) stand up a hermetic LOCAL
+stand-in remote and federate local clients with it over HTTP.
+
+Authentication is the point of this suite. The remote runs as ``wdaemanage
+runserver`` (NOT ``wgpf run`` — wgpf forces ``DISABLE_PERMISSIONS=True`` and
+bypasses all auth), so it ENFORCES dataset permissions like SFARI. It serves
+two demo studies — ``denovo_example`` made **public** (``any_user``) and
+``vcf_example`` left **protected** (default ``any_dataset``) — plus a
+client-credentials OAuth app standing in for a SFARI federation token. Two
+clients federate with it:
+
+* a **token-free** client (``remotes:`` without credentials) → the guide's
+  public-access path: sees the public study, NOT the protected one;
+* a **token** client (``remotes:`` with ``client_id``/``client_secret``) →
+  the guide's Federation-tokens path: also sees the protected study.
+
+Together the five tests prove our authentication works *as expected*: access
+is granted with a token, denied without one, and public resources are
+reachable token-free. (The old ``wgpf run`` remote silently faked all this by
+disabling permissions.)
+
+Carve-outs (documented in conftest): the ``remotes.url`` is local (vs SFARI),
+and the federation token is created via ``wdaemanage createapplication``
+rather than the SFARI UI — both invisible infrastructure we substitute. Out
+of scope (non-hermetic, like the screenshots): the literal token-panel UI
+steps. The remote-prefixing convention exposes a remote study on a client as
+``<remote_config_id>_<study_id>`` (the remote config id is ``fed_remote``).
+
+Each test maps to one discrete prose claim. ``rst_ref`` points at the line in
+the guide source so a failure localizes the drift.
+"""
+
+from docs_e2e.guide_assertions import (
+    assert_command_succeeds,
+    assert_dataset_not_visible,
+    assert_dataset_visible,
+    assert_remote_dataset_resolves,
+)
+
+RST = "getting_started_with_federation.rst"
+
+# Remote-prefixed study ids the clients expose (<remote_id>_<study>): the
+# remote serves denovo_example (public) + vcf_example (protected).
+_PUBLIC_REMOTE_STUDY = "fed_remote_denovo_example"
+_PROTECTED_REMOTE_STUDY = "fed_remote_vcf_example"
+
+# Cold budget: the client's first federated request resolves reference genome
+# / gene models from the warm GRR cache and makes a hop (token clients also do
+# the OAuth handshake) to the stand-in remote.
+_COLD_PULL_TIMEOUT = 300
+
+
+class TestFederationInstall:
+    """RST lines 15-28: install the separate ``gpf-federation`` conda
+    package into the local conda environment."""
+
+    def test_gpf_federation_installs(self, federation_install):
+        # RST lines 18-28: `mamba install ... gpf-federation` installs the
+        # federation package the local (client) instance needs.
+        assert_command_succeeds(
+            federation_install.install,
+            rst_ref=f"{RST}:19",
+            expectation=(
+                "installing the gpf-federation conda package succeeds"
+            ),
+        )
+
+
+class TestPublicAccess:
+    """RST lines 67-76: a token-free local instance accesses ONLY the publicly
+    available resources of the remote."""
+
+    def test_public_study_visible_without_token(
+        self, federation_anon_client_server,
+    ):
+        # RST lines 72-76: the token-free configuration lets the local
+        # instance access the remote's publicly available resources. The
+        # public study (granted any_user on the remote) appears in the
+        # token-free client's visible datasets.
+        resp = federation_anon_client_server.client.get(
+            "/api/v3/datasets/visible",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_dataset_visible(
+            resp, _PUBLIC_REMOTE_STUDY,
+            rst_ref=f"{RST}:74",
+            expectation=(
+                "a token-free local instance can access the remote's publicly "
+                "available study"
+            ),
+        )
+
+    def test_protected_study_hidden_without_token(
+        self, federation_anon_client_server,
+    ):
+        # RST lines 72-76 ("ONLY the publicly available resources"): a
+        # protected remote study must NOT appear to a token-free client. This
+        # is the negative that makes the auth test meaningful — an
+        # auth-bypassing remote (wgpf run) would leak it.
+        resp = federation_anon_client_server.client.get(
+            "/api/v3/datasets/visible",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_dataset_not_visible(
+            resp, _PROTECTED_REMOTE_STUDY,
+            rst_ref=f"{RST}:74",
+            expectation=(
+                "a token-free local instance accesses ONLY public resources — "
+                "the remote's protected study stays hidden (auth enforced)"
+            ),
+        )
+
+
+class TestTokenAccess:
+    """RST lines 134-178: with a federation token (client_id/secret) the local
+    instance accesses the resources it has access to on the remote."""
+
+    def test_protected_study_visible_with_token(
+        self, federation_auth_client_server,
+    ):
+        # RST lines 155-171: adding the federation client_id/client_secret to
+        # the remotes block grants access to the resources the account can see
+        # — including the protected study the token-free client could not.
+        resp = federation_auth_client_server.client.get(
+            "/api/v3/datasets/visible",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_dataset_visible(
+            resp, _PROTECTED_REMOTE_STUDY,
+            rst_ref=f"{RST}:170",
+            expectation=(
+                "a client configured with a federation token can access the "
+                "remote's protected study"
+            ),
+        )
+
+    def test_protected_study_resolves_with_token(
+        self, federation_auth_client_server,
+    ):
+        # RST lines 103-108 + 170: the authenticated client can actually use
+        # the remote study — resolving its details through the client proves
+        # the federation link works end-to-end (authenticated REST to the
+        # remote), not just that the id was listed.
+        resp = federation_auth_client_server.client.get(
+            f"/api/v3/datasets/{_PROTECTED_REMOTE_STUDY}",
+            timeout=_COLD_PULL_TIMEOUT,
+        )
+        assert_remote_dataset_resolves(
+            resp, _PROTECTED_REMOTE_STUDY,
+            rst_ref=f"{RST}:170",
+            expectation=(
+                "the protected remote study resolves through the token client"
+            ),
+        )


### PR DESCRIPTION
Implements **#882** — the last open child of epic #871. With this, **all 12 sub-guides** are covered.

Federation needs a **second, remote** GPF instance. The guide points `remotes:` at the external SFARI instance; docs-e2e can't use that, so the fixtures stand up a hermetic **local stand-in remote** and federate local clients with it.

## Authentication is the point (per review feedback)
The remote runs as **`wdaemanage runserver`**, *not* `wgpf run`: `wgpf` forces `settings.DISABLE_PERMISSIONS = True` (`wgpf.py:205`) and bypasses **all** auth — a federation test built on it would never exercise authentication. `wdaemanage` uses `gpf_web.settings` (`DISABLE_PERMISSIONS=False`), so the remote **enforces** dataset permissions like SFARI.

Setup mirrors the existing federation integration backend (`federation/scripts/backend/run_gpf.sh`) on the getting-started demo data: import two demo studies → `migrate` → `user_create` (in `any_dataset`) → `createapplication confidential client-credentials` (the CLI stand-in for the guide's UI-created federation token). `denovo_example` is granted `any_user` (**public**); `vcf_example` stays default `any_dataset` (**protected**).

**Two clients** (`wgpf run`) federate with that one remote:
- **token-free** → sees the public study, **not** the protected one
- **token** (`client_id`/`client_secret`) → sees the protected study too

## Five tests prove auth works *as expected*
1. `gpf-federation` installs
2. token-free client: **public** study visible *(guide public path, RST 67-76)*
3. token-free client: **protected** study **NOT** visible *(auth enforced — the negative the old `wgpf` approach silently faked)*
4. token client: **protected** study visible *(guide Federation-tokens path, RST 134-178)*
5. token client: protected study resolves end-to-end

New helpers: `assert_dataset_not_visible` (the negative) + a generalized `_serve_instance` (launches `wgpf run` **or** `wdaemanage runserver`); unit tests for both new assertions.

## Notes
- Each demo study is imported on the remote from a **private copy of just the input files** — `import_genotypes` keys its `.task-progress` cache on `work_dir=<import-yaml-dir>/<study_id>`, so re-importing a study the main chain already imported from the shared clone would be a silent no-op (only surfaces in the full-suite run).
- **Carve-outs (documented):** `remotes.url` is local (vs SFARI); the token is created via `createapplication` rather than the SFARI UI. **Out of scope** (non-hermetic, like screenshots): the literal token-panel UI steps.
- **Guide drift fixed:** `gpf_federation`→`gpf-federation` (command + prose); removed the 404'd `gene_properties/gene_sets/relevant`, adjusted `:emphasize-lines: 30-32`→`29-31`.

## Validation
Full docs-e2e suite locally in the driver container against the prewarmed GRR cache: **178 passed**, federation auth included. No Jenkinsfile change.

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)