### PR TITLE
gpf-release: create a GitHub Release for each CalVer tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -855,6 +855,60 @@ pipeline {
                     }
                 }
 
+                stage('Sync GitHub release notes') {
+                    when {
+                        allOf {
+                            branch 'master'
+                            changeset 'docs/source/development/changes.rst'
+                        }
+                    }
+                    // When the curated changelog changes on master,
+                    // reconcile every existing GitHub Release's body
+                    // against it — backfilling notes for releases that
+                    // were tagged BEFORE their changes.rst section was
+                    // written (the normal flow: tag first, write notes
+                    // after). The release-pipeline stage that creates a
+                    // release at tag time gets the minimal body; this is
+                    // what fills in the real notes later.
+                    //
+                    // Non-fatal (UNSTABLE on failure) and idempotent
+                    // (the helper PATCHes only when a body actually
+                    // changed), so it is safe on every changes.rst
+                    // commit. Runs the stdlib-only helper in a throwaway
+                    // python:3.12-slim because it must run on docs-only
+                    // commits too, where the conda-builder image is not
+                    // built. Token is stage-scoped via withCredentials —
+                    // same `github-token-iossifovlab` credential the
+                    // release pipeline uses; a missing credential just
+                    // marks the build UNSTABLE.
+                    steps {
+                        catchError(
+                            buildResult: 'UNSTABLE',
+                            stageResult: 'UNSTABLE',
+                            message:
+                                'GitHub release-notes sync failed ' +
+                                '(non-fatal).',
+                        ) {
+                            withCredentials([string(
+                                credentialsId: 'github-token-iossifovlab',
+                                variable: 'GH_TOKEN',
+                            )]) {
+                                sh '''
+                                    docker run --rm \
+                                        -e HOME=/tmp \
+                                        -e GH_TOKEN \
+                                        -v "$PWD:/workspace" \
+                                        -w /workspace \
+                                        python:3.12-slim \
+                                        python \
+                                          scripts/make_github_release.py \
+                                          --sync-existing
+                                '''
+                            }
+                        }
+                    }
+                }
+
                 stage('Conda packages') {
                     when { not { environment name: 'DOCS_ONLY', value: 'true' } }
                     steps {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -908,9 +908,13 @@ EOF
             // The helper upserts (PATCH if the release exists, else
             // POST) so a manual gpf-release re-run is idempotent, and
             // falls back to a minimal body if changes.rst has no section
-            // for the tag. Run in the conda-builder image (has python +
-            // network); the token is stage-scoped via withCredentials so
-            // a missing credential is caught here, not at pipeline init.
+            // for the tag. That fallback is EXPECTED in the normal flow
+            // (tag first, write notes after): the master Jenkinsfile's
+            // `Sync GitHub release notes` stage backfills the real notes
+            // when changes.rst is later updated. Run in the conda-
+            // builder image (has python + network); the token is stage-
+            // scoped via withCredentials so a missing credential is
+            // caught here, not at pipeline init.
             //
             // Operator prerequisite (one-time): a Jenkins Secret-text
             // credential `github-token-iossifovlab` holding a

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,6 +1,6 @@
 // Jenkins pipeline for the gpf monorepo's tag-driven release.
 //
-// Mirrors gain/Jenkinsfile.release with five gpf-specific deltas:
+// Mirrors gain/Jenkinsfile.release with six gpf-specific deltas:
 //   1. `Fetch upstream artefacts` copies BOTH dist/base-images.lock
 //      AND dist/gain/*.whl from the upstream gpf master CI build —
 //      the gain wheel is the one gpf-master tested against.
@@ -26,6 +26,15 @@
 //      iossifovlab Docker Hub account; (c) add it as two Secret
 //      text Jenkins credentials user.dockerhub.iossifovlab (value
 //      'iossifovlab') + passwd.dockerhub.iossifovlab (the PAT).
+//   6. A `Publish GitHub release` stage creates/updates a GitHub
+//      Release for the tag (notes pulled from changes.rst, body
+//      linking to the published artifacts) via
+//      scripts/make_github_release.py. NON-FATAL (UNSTABLE on
+//      failure) — the release is already published; the GitHub page
+//      is a discovery surface. gain has no equivalent. Operator
+//      prerequisite: a Secret-text credential `github-token-
+//      iossifovlab` = a fine-grained PAT scoped to iossifovlab/gpf
+//      with Contents: Read and write.
 //
 // Triggered by:
 //   - The root Jenkinsfile's `Dispatch release` stage when a CalVer
@@ -45,7 +54,8 @@
 // registry.seqpipe.org (gpf-web-api, gpf-web-ui, gpf-web) tagged
 // :${TAG_NAME} + :stable. The gpf-web bundle is additionally
 // published to Docker Hub (docker.io/iossifovlab/gpf-web) tagged
-// :${TAG_NAME} + :latest as a public artifact (see delta #5).
+// :${TAG_NAME} + :latest as a public artifact (see delta #5). A
+// GitHub Release is created for the tag (see delta #6).
 
 import com.cloudbees.groovy.cps.NonCPS
 
@@ -884,12 +894,81 @@ EOF
             }
         }
 
+        stage('Publish GitHub release') {
+            // Human-facing landing page for the release — runs AFTER
+            // Publish so its body links to artifacts that already
+            // exist. NON-FATAL: by this point wheels + conda + registry
+            // + Docker Hub have all published, so the release itself is
+            // done; a GitHub API blip (or an unprovisioned token) should
+            // mark the build UNSTABLE and notify, not red an otherwise
+            // perfect release (a GitHub Release is trivially creatable
+            // by hand afterwards). Contrast the Docker Hub push, which
+            // is fatal because it is an artefact users pull.
+            //
+            // The helper upserts (PATCH if the release exists, else
+            // POST) so a manual gpf-release re-run is idempotent, and
+            // falls back to a minimal body if changes.rst has no section
+            // for the tag. Run in the conda-builder image (has python +
+            // network); the token is stage-scoped via withCredentials so
+            // a missing credential is caught here, not at pipeline init.
+            //
+            // Operator prerequisite (one-time): a Jenkins Secret-text
+            // credential `github-token-iossifovlab` holding a
+            // fine-grained PAT scoped to iossifovlab/gpf with
+            // `Contents: Read and write` (that scope covers Releases).
+            steps {
+                catchError(
+                    buildResult: 'UNSTABLE',
+                    stageResult: 'UNSTABLE',
+                    message:
+                        'GitHub release creation failed; the release ' +
+                        'itself published fine — create it by hand or ' +
+                        're-run gpf-release (the upsert is idempotent).',
+                ) {
+                    withCredentials([string(
+                        credentialsId: 'github-token-iossifovlab',
+                        variable: 'GH_TOKEN',
+                    )]) {
+                        sh '''
+                            DOCKER_USER="$(id -u):$(id -g)"
+                            docker run --rm \
+                                --user "$DOCKER_USER" \
+                                -e HOME=/tmp \
+                                -e GH_TOKEN \
+                                -v "$PWD:/workspace" \
+                                -w /workspace \
+                                "${CONDA_BUILDER}" \
+                                python scripts/make_github_release.py \
+                                    --tag "${TAG_NAME}" \
+                                    --repo iossifovlab/gpf \
+                                    --gain-version "${GAIN_BUNDLED_VERSION}" \
+                                    --dockerhub-image "${DOCKERHUB_REPO}"
+                        '''
+                    }
+                    // Deterministic release URL (github.com/<repo>/
+                    // releases/tag/<tag>) — only set after the upsert
+                    // succeeds, so Notify includes it only when the
+                    // release is really there.
+                    script {
+                        env.GH_RELEASE_URL =
+                            'https://github.com/iossifovlab/gpf' +
+                            "/releases/tag/${env.TAG_NAME}"
+                    }
+                }
+            }
+        }
+
         stage('Notify') {
             steps {
                 script {
                     def gainNote = params.GAIN_PIN_VERSION ?
                         "gain pinned to ${env.GAIN_BUNDLED_VERSION}" :
                         "gain ${env.GAIN_BUNDLED_VERSION} (auto)"
+                    // Empty when the GitHub release stage failed (it's
+                    // non-fatal), so the announcement only points at a
+                    // release page that actually exists.
+                    def releaseNote = env.GH_RELEASE_URL ?
+                        ", github release: ${env.GH_RELEASE_URL}" : ""
                     zulipSend(
                         topic: 'gpf-releases',
                         message:
@@ -907,7 +986,8 @@ EOF
                             "(all also tagged :stable), " +
                             "docker hub: ${env.DOCKERHUB_REGISTRY}/" +
                                 "${env.DOCKERHUB_REPO}:" +
-                                "${env.TAG_NAME} (also :latest)",
+                                "${env.TAG_NAME} (also :latest)" +
+                            releaseNote,
                     )
                 }
             }

--- a/scripts/make_github_release.py
+++ b/scripts/make_github_release.py
@@ -1,0 +1,241 @@
+"""Create (or update) a GitHub Release for a gpf CalVer tag.
+
+Invoked by the `Publish GitHub release` stage of `Jenkinsfile.release`
+after all artifacts (wheels, conda, registry + Docker Hub images) have
+been published. The release is a human-facing landing page, NOT an
+artifact store: the body links to the existing distribution channels
+rather than re-uploading anything.
+
+Behaviour:
+  - Extracts the release notes for ``--tag`` from the version-keyed
+    ``changes.rst`` (the ``* <version>`` block) and renders them as
+    markdown.
+  - Appends an Install section (public Docker image, wheels index,
+    anaconda) plus the bundled gain version.
+  - Upserts via the REST API: GET the release by tag, PATCH if it
+    already exists, otherwise POST. This mirrors the idempotent
+    re-push semantics of the rest of the release pipeline, so a manual
+    re-run of gpf-release is safe.
+  - Falls back to a minimal body if changes.rst has no section for the
+    tag (does not fail — a missing changelog entry should not block).
+
+Auth: the token is read from the ``GH_TOKEN`` environment variable
+(never passed on argv, which is visible in the process list). It needs
+``Contents: write`` on the target repo — that permission scope covers
+Releases.
+
+Stdlib only (urllib/json/re) so it runs in the conda-builder container
+without extra deps. Use ``--dry-run`` to print the rendered body and
+the action it would take without calling the API (and without a token).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+
+API_VERSION = "2022-11-28"
+
+
+def extract_notes(changes_text: str, version: str) -> str:
+    """Return the markdown notes for ``version`` from changes.rst.
+
+    changes.rst is a flat bullet list keyed by ``* <version>`` headers
+    (no leading indent), with 4-space-indented ``* `` bullets beneath
+    each and 6-space (or deeper) continuation lines wrapping long
+    bullets. Nested bullets are indented a further 4 spaces.
+
+    Returns an empty string if the version has no section.
+    """
+    block: list[str] = []
+    capturing = False
+    for line in changes_text.splitlines():
+        header = re.match(r"^\* (\S+)\s*$", line)
+        if header:
+            if capturing:
+                break  # reached the next version → done
+            capturing = header.group(1) == version
+            continue
+        if capturing:
+            block.append(line)
+
+    # Trim leading/trailing blank lines.
+    while block and not block[0].strip():
+        block.pop(0)
+    while block and not block[-1].strip():
+        block.pop()
+
+    # Normalise indentation to the shallowest bullet so top-level
+    # changelog bullets render as markdown level 0 (`- `) rather than
+    # an over-indented nested list. changes.rst puts top-level bullets
+    # at 4 spaces; deeper bullets (e.g. the 2026.4.1 renames) sit 4
+    # spaces further in per level.
+    indents = [
+        len(m.group(1))
+        for line in block
+        if (m := re.match(r"^( *)\* ", line))
+    ]
+    base = min(indents) if indents else 0
+
+    md: list[str] = []
+    for line in block:
+        bullet = re.match(r"^( *)\* (.*)$", line)
+        if bullet:
+            level = (len(bullet.group(1)) - base) // 4
+            md.append("  " * level + "- " + bullet.group(2).strip())
+        elif line.strip():
+            # Continuation of the previous bullet's wrapped text.
+            if md:
+                md[-1] += " " + line.strip()
+            else:
+                md.append(line.strip())
+    return "\n".join(md).strip()
+
+
+def build_body(notes: str, opts: argparse.Namespace) -> str:
+    """Assemble the release body: notes + an Install section."""
+    parts = [notes] if notes else [f"Release {opts.tag}."]
+    install = [
+        "",
+        "## Install",
+        "",
+        "Public Docker image (runs GPF standalone):",
+        "",
+        "```",
+        f"docker pull {opts.dockerhub_image}:{opts.tag}",
+        "```",
+        "",
+        f"- Wheels: {opts.wheels_url}",
+        f"- Conda: {opts.anaconda}",
+    ]
+    if opts.gain_version:
+        install.append(f"- Bundled gain: `{opts.gain_version}`")
+    parts.append("\n".join(install))
+    return "\n".join(parts).strip() + "\n"
+
+
+def _api(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict | None = None,
+) -> tuple[int, dict]:
+    # URL is always a hardcoded https://api.github.com/... base built
+    # below, never user-controlled, so the scheme audit is moot here.
+    req = urllib.request.Request(url, method=method)  # noqa: S310
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", API_VERSION)
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, data) as resp:  # noqa: S310
+            return resp.status, json.load(resp)
+    except urllib.error.HTTPError as err:
+        try:
+            body = json.load(err)
+        except (ValueError, OSError):
+            body = {"message": err.reason}
+        return err.code, body
+
+
+def upsert_release(opts: argparse.Namespace, body: str, token: str) -> str:
+    """Create or update the release; return its html_url."""
+    base = f"https://api.github.com/repos/{opts.repo}/releases"
+    payload = {
+        "tag_name": opts.tag,
+        "name": opts.tag,
+        "body": body,
+        "draft": False,
+        "prerelease": False,
+        "make_latest": "true",
+    }
+
+    status, existing = _api("GET", f"{base}/tags/{opts.tag}", token)
+    if status == 200:
+        rid = existing["id"]
+        st, result = _api("PATCH", f"{base}/{rid}", token, payload)
+        action = "updated"
+    elif status == 404:
+        st, result = _api("POST", base, token, payload)
+        action = "created"
+    else:
+        raise SystemExit(
+            f"GitHub API error probing release {opts.tag}: "
+            f"HTTP {status} — {existing.get('message')}",
+        )
+
+    if st not in (200, 201):
+        raise SystemExit(
+            f"GitHub API error ({action}) for {opts.tag}: "
+            f"HTTP {st} — {result.get('message')}",
+        )
+    print(f"GitHub release {action}: {result['html_url']}")
+    return result["html_url"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag", required=True, help="CalVer tag, e.g. 2026.6.0",
+    )
+    parser.add_argument("--repo", default="iossifovlab/gpf")
+    parser.add_argument(
+        "--changes",
+        default="docs/source/development/changes.rst",
+        help="Path to the version-keyed changes.rst",
+    )
+    parser.add_argument("--gain-version", default="")
+    parser.add_argument("--dockerhub-image", default="iossifovlab/gpf-web")
+    parser.add_argument(
+        "--wheels-url", default="https://wheels.seqpipe.org/gpf/",
+    )
+    parser.add_argument(
+        "--anaconda", default="https://anaconda.org/iossifovlab",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the rendered body + intended action; no API call.",
+    )
+    opts = parser.parse_args(argv)
+
+    try:
+        changes_text = pathlib.Path(opts.changes).read_text(encoding="utf-8")
+    except OSError as err:
+        print(
+            f"WARNING: could not read {opts.changes}: {err}",
+            file=sys.stderr,
+        )
+        changes_text = ""
+
+    notes = extract_notes(changes_text, opts.tag)
+    if not notes:
+        print(
+            f"WARNING: no changes.rst section for {opts.tag}; "
+            "using a minimal body.",
+            file=sys.stderr,
+        )
+    body = build_body(notes, opts)
+
+    if opts.dry_run:
+        print(f"--- DRY RUN: would upsert {opts.tag} on {opts.repo} ---")
+        print(body)
+        return 0
+
+    token = os.environ.get("GH_TOKEN")
+    if not token:
+        raise SystemExit("GH_TOKEN environment variable is required.")
+    upsert_release(opts, body, token)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/make_github_release.py
+++ b/scripts/make_github_release.py
@@ -24,6 +24,17 @@ Auth: the token is read from the ``GH_TOKEN`` environment variable
 ``Contents: write`` on the target repo — that permission scope covers
 Releases.
 
+Two modes:
+  - default (``--tag``): upsert ONE release at tag time.
+  - ``--sync-existing``: reconcile the notes of EVERY existing release
+    against the current changes.rst. This backfills notes for releases
+    that were tagged before their changelog section was written (the
+    team's normal flow: tag first, write notes after). It rewrites only
+    the notes portion of each body — everything from the ``## Install``
+    heading down (the per-release artifact links + bundled gain) is
+    preserved — and PATCHes only when the notes actually changed. The
+    master CI runs this whenever changes.rst changes.
+
 Stdlib only (urllib/json/re) so it runs in the conda-builder container
 without extra deps. Use ``--dry-run`` to print the rendered body and
 the action it would take without calling the API (and without a token).
@@ -40,6 +51,10 @@ import urllib.error
 import urllib.request
 
 API_VERSION = "2022-11-28"
+# Stable delimiter between the curated notes and the generated artifact
+# links in a release body. --sync-existing rewrites everything before
+# it and preserves everything from it down.
+INSTALL_MARKER = "## Install"
 
 
 def extract_notes(changes_text: str, version: str) -> str:
@@ -181,10 +196,97 @@ def upsert_release(opts: argparse.Namespace, body: str, token: str) -> str:
     return result["html_url"]
 
 
+def _list_releases(repo: str, token: str) -> list[dict]:
+    """Return all releases for the repo (paginated)."""
+    releases: list[dict] = []
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repo}/releases"
+            f"?per_page=100&page={page}"
+        )
+        status, data = _api("GET", url, token)
+        if status != 200:
+            msg = data.get("message") if isinstance(data, dict) else data
+            raise SystemExit(
+                f"GitHub API error listing releases: HTTP {status} — {msg}",
+            )
+        releases.extend(data)
+        if len(data) < 100:
+            break
+        page += 1
+    return releases
+
+
+def reconcile_body(old_body: str, notes: str) -> str:
+    """Replace the notes portion of ``old_body`` with ``notes``.
+
+    Everything from the ``## Install`` heading down (the per-release
+    artifact links + bundled gain version, which sync cannot
+    regenerate) is preserved verbatim.
+    """
+    idx = old_body.find(INSTALL_MARKER)
+    install_part = old_body[idx:] if idx != -1 else ""
+    if install_part:
+        return (notes + "\n\n" + install_part).strip() + "\n"
+    return notes.strip() + "\n"
+
+
+def sync_existing(
+    opts: argparse.Namespace,
+    changes_text: str,
+    token: str,
+) -> int:
+    """Reconcile every existing release's notes against changes.rst.
+
+    Skips releases that have no changes.rst section yet (so a not-yet-
+    documented release is left untouched, not blanked). PATCHes only
+    when the body actually changed. Returns the count updated.
+    """
+    updated = 0
+    for rel in _list_releases(opts.repo, token):
+        tag = rel.get("tag_name", "")
+        notes = extract_notes(changes_text, tag)
+        if not notes:
+            continue
+        old_body = rel.get("body") or ""
+        new_body = reconcile_body(old_body, notes)
+        if new_body.strip() == old_body.strip():
+            continue
+        if opts.dry_run:
+            print(f"[dry-run] would update notes for {tag}")
+            updated += 1
+            continue
+        rid = rel["id"]
+        st, result = _api(
+            "PATCH",
+            f"https://api.github.com/repos/{opts.repo}/releases/{rid}",
+            token,
+            {"body": new_body},
+        )
+        if st != 200:
+            print(
+                f"WARNING: failed to sync {tag}: HTTP {st} — "
+                f"{result.get('message')}",
+                file=sys.stderr,
+            )
+            continue
+        print(f"Synced notes for {tag}: {result['html_url']}")
+        updated += 1
+    print(f"Sync complete: {updated} release(s) updated.")
+    return updated
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--tag", required=True, help="CalVer tag, e.g. 2026.6.0",
+        "--tag",
+        help="CalVer tag, e.g. 2026.6.0 (required unless --sync-existing)",
+    )
+    parser.add_argument(
+        "--sync-existing",
+        action="store_true",
+        help="Reconcile every existing release's notes from changes.rst.",
     )
     parser.add_argument("--repo", default="iossifovlab/gpf")
     parser.add_argument(
@@ -206,6 +308,8 @@ def main(argv: list[str] | None = None) -> int:
         help="Print the rendered body + intended action; no API call.",
     )
     opts = parser.parse_args(argv)
+    if not opts.sync_existing and not opts.tag:
+        parser.error("--tag is required unless --sync-existing is given.")
 
     try:
         changes_text = pathlib.Path(opts.changes).read_text(encoding="utf-8")
@@ -215,6 +319,16 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         changes_text = ""
+
+    token = os.environ.get("GH_TOKEN")
+
+    if opts.sync_existing:
+        # Needs a token even with --dry-run: it must list the live
+        # releases to compute the diff (it just skips the PATCH).
+        if not token:
+            raise SystemExit("GH_TOKEN environment variable is required.")
+        sync_existing(opts, changes_text, token)
+        return 0
 
     notes = extract_notes(changes_text, opts.tag)
     if not notes:
@@ -230,7 +344,6 @@ def main(argv: list[str] | None = None) -> int:
         print(body)
         return 0
 
-    token = os.environ.get("GH_TOKEN")
     if not token:
         raise SystemExit("GH_TOKEN environment variable is required.")
     upsert_release(opts, body, token)


### PR DESCRIPTION
Creates a **GitHub Release** for each CalVer tag, so the repo has a
discoverable per-version landing page — especially relevant now that
`iossifovlab/gpf-web` is published publicly to Docker Hub and external
users land on the GitHub repo looking for "what's new + how to run it".

## What it does

A new **non-fatal** `Publish GitHub release` stage (after `Publish`,
before `Notify`) runs `scripts/make_github_release.py`, which:

- extracts the `* ${TAG_NAME}` block from the version-keyed
  `docs/source/development/changes.rst` → markdown,
- appends an **Install** section linking to the published artifacts
  (`docker pull iossifovlab/gpf-web:${TAG_NAME}`, wheels index,
  anaconda) + the bundled gain version,
- **upserts** via the REST API (GET tag → PATCH if exists, else POST),
  so a manual `gpf-release` re-run is idempotent,
- falls back to a minimal body if `changes.rst` has no section for the
  tag (won't break the release).

`Notify` appends the release URL.

## Design choices

- **Non-fatal** (UNSTABLE + Zulip note on failure). By this point
  wheels + conda + registry + Docker Hub have all published — the
  release itself is done. A GitHub API blip or an unprovisioned token
  should not red an otherwise-perfect release; the page is creatable by
  hand. (Contrast the Docker Hub push, which is fatal because it's an
  artefact users pull.)
- **Token is stage-scoped** via `withCredentials`, so a missing
  credential is caught non-fatally here, not at pipeline init.
- **Helper is stdlib-only** (urllib/json/re), runs in the existing
  `conda-builder` image — no new deps.
- All CI is Jenkins (gpf has no GitHub Actions), and the stage runs
  *after* publishing so the body links to artifacts that already exist
  — a tag-triggered Action would fire too early.

## Operator prerequisite (one-time)

A Jenkins **Secret-text** credential `github-token-iossifovlab` = a
**fine-grained PAT** scoped to `iossifovlab/gpf` with **Contents: Read
and write** (that scope covers Releases). Until it exists, the stage
just marks the build UNSTABLE — it won't block a release.

## Validation

- ✅ `Jenkinsfile.release` — `successfully validated` against the live
  controller's declarative linter.
- ✅ `make_github_release.py` — changes.rst extraction unit-tested via
  `--dry-run` across flat (`2026.4.4`), nested (`2026.4.1`), and
  missing (`2026.99.x`) versions; ruff clean; `py_compile` clean.
- Not exercised end-to-end until a real tagged release runs with the
  credential provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — release-notes backfill (2nd commit)

Handles the team's actual flow (**tag first, write notes after**). At tag
time `changes.rst` has no section yet, so the release gets the minimal
body; the real notes are backfilled later:

- New **`--sync-existing`** mode on the helper reconciles *every* existing
  release's body against the current `changes.rst`.
- New **non-fatal `Sync GitHub release notes` stage** in the **master**
  `Jenkinsfile`, gated on `changes.rst` changing — so editing the
  changelog on master backfills the release page automatically.
- Rewrites only the notes above `## Install`; the per-release artifact
  links + bundled-gain line are preserved. Idempotent (PATCH only on
  change); skips releases that still have no section.

So you keep your habit unchanged — write notes to `changes.rst` whenever —
and the GitHub Release self-heals on the next master build.
