### PR TITLE
gpf-web: inject Google Analytics via GPF_GA_MEASUREMENT_ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1041,6 +1041,29 @@ assert settings.FORCE_SCRIPT_NAME == '/gpf', settings.FORCE_SCRIPT_NAME; \
 assert settings.STATIC_URL == '/gpf/static/', settings.STATIC_URL; \
 print('gpf-web prefix settings OK')"
 
+                            # Google Analytics injection smoke (gpf#910).
+                            # The entrypoint splices a marker-guarded
+                            # gtag.js block into the SPA index when
+                            # GPF_GA_MEASUREMENT_ID is set, and leaves it
+                            # GA-free otherwise. Verify on the real image:
+                            #   - injected (with the ID) when set,
+                            #   - absent when unset,
+                            #   - present alongside GPF_PREFIX,
+                            #   - idempotent across a re-run (one block).
+                            docker run --rm -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 "$IMG" \
+                                grep -q 'id=G-SMOKE123' /var/www/html/index.html
+                            docker run --rm "$IMG" \
+                                sh -c '! grep -q "gpf-ga start" /var/www/html/index.html'
+                            docker run --rm -e GPF_PREFIX=gpf -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 "$IMG" \
+                                sh -c 'grep -q "<base href=\"/gpf/\"" /var/www/html/index.html \
+                                    && grep -q "id=G-SMOKE123" /var/www/html/index.html'
+                            docker run --rm -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 \
+                                --entrypoint bash "$IMG" -c \
+                                '/usr/local/bin/docker-entrypoint.sh true \
+                                 && /usr/local/bin/docker-entrypoint.sh true \
+                                 && [ "$(grep -o "gpf-ga start" /var/www/html/index.html | wc -l)" -eq 1 ]'
+                            echo "gpf-web GA injection smoke OK"
+
                             # Resolve and record the base-image digests
                             # this build used, so a future release
                             # pipeline can rebuild from a tagged commit

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1055,8 +1055,9 @@ print('gpf-web prefix settings OK')"
                             docker run --rm "$IMG" \
                                 sh -c '! grep -q "gpf-ga start" /var/www/html/index.html'
                             docker run --rm -e GPF_PREFIX=gpf -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 "$IMG" \
-                                sh -c 'grep -q "<base href=\"/gpf/\"" /var/www/html/index.html \
-                                    && grep -q "id=G-SMOKE123" /var/www/html/index.html'
+                                grep -q '<base href="/gpf/"' /var/www/html/index.html
+                            docker run --rm -e GPF_PREFIX=gpf -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 "$IMG" \
+                                grep -q 'id=G-SMOKE123' /var/www/html/index.html
                             docker run --rm -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 \
                                 --entrypoint bash "$IMG" -c \
                                 '/usr/local/bin/docker-entrypoint.sh true \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,9 @@ set -euo pipefail
 
 TEMPLATE=/etc/apache2/httpd-combined.conf.template
 APACHE_CONF=/etc/apache2/apache2.conf
-SPA_INDEX=/var/www/html/index.html
+# Overridable so the index.html rewrites can be exercised against a
+# fixture in tests; defaults to the image's real SPA index.
+SPA_INDEX="${SPA_INDEX:-/var/www/html/index.html}"
 
 # Normalise: "/gpf/" | "gpf" | "/gpf" -> "gpf"; unset/"" -> "".
 prefix="${GPF_PREFIX:-}"
@@ -43,6 +45,35 @@ if [[ -n "$prefix" ]]; then
     fi
 else
     echo "gpf-web entrypoint: serving at document root (GPF_PREFIX unset)"
+fi
+
+# Google Analytics: inject a gtag.js snippet into the SPA index when
+# GPF_GA_MEASUREMENT_ID is set; leave the SPA GA-free when it isn't, so
+# the same image stays untracked on hosts that don't opt in (e.g. dory)
+# and tracked where configured (SFARI). Marker-guarded + idempotent:
+# every run first strips any prior gpf-ga block, then re-inserts from
+# the current env value — so restarts and ID changes converge to exactly
+# one block, and clearing the var removes it. The snippet is single-line
+# so the rewrite stays sed-portable and correct whether the built
+# index.html is minified or pretty-printed (same reasoning as the
+# <base href> substring rewrite above). Written via a temp file rather
+# than `sed -i` for an atomic, portable replace.
+ga_id="${GPF_GA_MEASUREMENT_ID:-}"
+if [[ -f "$SPA_INDEX" ]]; then
+    strip='s#<!-- gpf-ga start -->.*<!-- gpf-ga end -->##g'
+    ga_tmp="$(mktemp)"
+    if [[ -n "$ga_id" ]]; then
+        echo "gpf-web entrypoint: injecting Google Analytics tag (${ga_id})"
+        snippet="<!-- gpf-ga start --><script async src=\"https://www.googletagmanager.com/gtag/js?id=${ga_id}\"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${ga_id}');</script><!-- gpf-ga end -->"
+        sed -e "$strip" -e "s#</head>#${snippet}</head>#" \
+            "$SPA_INDEX" > "$ga_tmp" && mv "$ga_tmp" "$SPA_INDEX"
+    elif grep -q '<!-- gpf-ga start -->' "$SPA_INDEX"; then
+        # No ID, but a block lingers from a previous tagged run: drop it.
+        # When there's neither an ID nor a stale block we touch nothing,
+        # so the GA-free root/e2e/compose index stays byte-for-byte intact.
+        sed -e "$strip" "$SPA_INDEX" > "$ga_tmp" && mv "$ga_tmp" "$SPA_INDEX"
+    fi
+    rm -f "$ga_tmp"
 fi
 
 exec "$@"


### PR DESCRIPTION
Closes #910.

## What

The combined `gpf-web` image had **no Google Analytics support**. The SFARI cutover (`gpf.sfari.org`) needs the gtag.js tag the legacy `sfari-frontpage`/`gpf-full` image injected from a host-mounted file; the new image silently dropped it. This restores GA **env-driven and default-off**, so the *same* image stays untracked where `GPF_GA_MEASUREMENT_ID` is unset (e.g. dory) and tracked where it's set (SFARI) — no per-host builds.

## How

- **`docker-entrypoint.sh`** — when `GPF_GA_MEASUREMENT_ID` is set, splice a marker-guarded (`<!-- gpf-ga start/end -->`) gtag.js block before `</head>` in the SPA index; when unset, leave the index GA-free and byte-for-byte untouched. Idempotent: each run strips any prior block then re-inserts from the current env value, so restarts, ID changes, and clears converge to exactly one (or zero) blocks. A single-line snippet + temp-file replace keep the rewrite `sed`-portable (minified or pretty-printed index, GNU or BSD `sed`). `SPA_INDEX` is now overridable so the rewrite is exercisable against a fixture.
- **`Jenkinsfile`** — extend the gpf#903 image smoke: injected (with the ID) when set, absent when unset, present alongside `GPF_PREFIX`, and idempotent across a re-run.

Mirrors the `GPF_PREFIX` entrypoint convention (both are entrypoint-consumed, both rewrite `index.html`).

## Verification

- 11/11 behavioral assertions against the **real** entrypoint locally (set / unset / idempotent-on-restart / ID-change / cleared-after-set)
- `shellcheck docker-entrypoint.sh` clean
- Jenkinsfile validated against the live controller's declarative linter
- CI image-smoke exercises all four cases on the built bundle image

Scope: combined `gpf-web` image only. Prerequisite for the SFARI playbook swap (`iossifovlab/data-sfari-management#1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)