### PR TITLE
gpf-web: preserve index.html mode when injecting GA (fix 403)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1049,7 +1049,9 @@ print('gpf-web prefix settings OK')"
                             #   - injected (with the ID) when set,
                             #   - absent when unset,
                             #   - present alongside GPF_PREFIX,
-                            #   - idempotent across a re-run (one block).
+                            #   - idempotent across a re-run (one block),
+                            #   - index.html keeps its mode so Apache
+                            #     (www-data) can still serve it (else 403).
                             docker run --rm -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 "$IMG" \
                                 grep -q 'id=G-SMOKE123' /var/www/html/index.html
                             docker run --rm "$IMG" \
@@ -1063,6 +1065,13 @@ print('gpf-web prefix settings OK')"
                                 '/usr/local/bin/docker-entrypoint.sh true \
                                  && /usr/local/bin/docker-entrypoint.sh true \
                                  && [ "$(grep -o "gpf-ga start" /var/www/html/index.html | wc -l)" -eq 1 ]'
+                            docker run --rm -e GPF_GA_MEASUREMENT_ID=G-SMOKE123 \
+                                --entrypoint bash "$IMG" -c \
+                                'm0=$(stat -c %a /var/www/html/index.html) \
+                                 && /usr/local/bin/docker-entrypoint.sh true \
+                                 && m1=$(stat -c %a /var/www/html/index.html) \
+                                 && echo "index.html mode $m0 -> $m1" \
+                                 && [ "$m0" = "$m1" ]'
                             echo "gpf-web GA injection smoke OK"
 
                             # Resolve and record the base-image digests

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,8 +56,11 @@ fi
 # one block, and clearing the var removes it. The snippet is single-line
 # so the rewrite stays sed-portable and correct whether the built
 # index.html is minified or pretty-printed (same reasoning as the
-# <base href> substring rewrite above). Written via a temp file rather
-# than `sed -i` for an atomic, portable replace.
+# <base href> substring rewrite above). The sed output is written back
+# into the existing file (`cat tmp > index`) rather than `mv`'d over it,
+# so index.html keeps its original mode/owner — Apache runs as www-data
+# and a mktemp-then-mv would leave the file root-only (0600) and serve
+# 403. No atomicity concern: this runs before supervisord starts apache.
 ga_id="${GPF_GA_MEASUREMENT_ID:-}"
 if [[ -f "$SPA_INDEX" ]]; then
     strip='s#<!-- gpf-ga start -->.*<!-- gpf-ga end -->##g'
@@ -66,12 +69,12 @@ if [[ -f "$SPA_INDEX" ]]; then
         echo "gpf-web entrypoint: injecting Google Analytics tag (${ga_id})"
         snippet="<!-- gpf-ga start --><script async src=\"https://www.googletagmanager.com/gtag/js?id=${ga_id}\"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${ga_id}');</script><!-- gpf-ga end -->"
         sed -e "$strip" -e "s#</head>#${snippet}</head>#" \
-            "$SPA_INDEX" > "$ga_tmp" && mv "$ga_tmp" "$SPA_INDEX"
+            "$SPA_INDEX" > "$ga_tmp" && cat "$ga_tmp" > "$SPA_INDEX"
     elif grep -q '<!-- gpf-ga start -->' "$SPA_INDEX"; then
         # No ID, but a block lingers from a previous tagged run: drop it.
         # When there's neither an ID nor a stale block we touch nothing,
         # so the GA-free root/e2e/compose index stays byte-for-byte intact.
-        sed -e "$strip" "$SPA_INDEX" > "$ga_tmp" && mv "$ga_tmp" "$SPA_INDEX"
+        sed -e "$strip" "$SPA_INDEX" > "$ga_tmp" && cat "$ga_tmp" > "$SPA_INDEX"
     fi
     rm -f "$ga_tmp"
 fi


### PR DESCRIPTION
## Problem

The GA injection from #910 (shipped in `2026.6.2`) rewrote `index.html` with `mktemp` + `mv`, so the served file inherited the tempfile's **`0600` root-only** mode. Apache runs as `www-data`, so it could no longer read the SPA index — `/gpf/` and `/gpf/index.html` return **403**. Proxied API paths (`/gpf/api/...`) were unaffected, which is why both the CI smoke and the deploy healthcheck stayed green.

**Found by the dory GA canary** — the first time the page was served over real HTTP to a non-root user. The CI smoke greps the file as root (`docker exec` / `docker run grep`), so it never exercised the `www-data` read path.

## Fix

Write the `sed` output back into the existing file (`cat tmp > index.html`) instead of `mv`-ing the tempfile over it, so `index.html` keeps its original mode/owner. No atomicity concern — the entrypoint runs before supervisord starts Apache.

## Regression guard

`Jenkinsfile`: added a smoke assertion that the entrypoint preserves `index.html`'s mode (`stat %a` before == after). The pre-existing greps read as root and structurally cannot catch a `www-data`-unreadable file.

## Verification

- Reproduced locally (RED): `0644 -> 0600` after the old entrypoint.
- Fixed (GREEN): 14/14 local assertions — injection content / idempotency / ID-change / clear **plus** world-readable preserved on every path.
- `shellcheck` clean; Jenkinsfile validated against the live controller.
- Will re-run the dory canary on the resulting release before SFARI.

Fast-follow to #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
