### PR TITLE
Reannotation plan output + fix --dry-run in annotate_schema2_parquet (#912)

### DIFF
--- a/core/gpf/parquet/schema2/annotate_schema2_parquet.py
+++ b/core/gpf/parquet/schema2/annotate_schema2_parquet.py
@@ -29,6 +29,7 @@ from gain.annotation.annotation_factory import (
 from gain.annotation.annotation_pipeline import (
     AnnotationPipeline,
     ReannotationPipeline,
+    print_annotation_plan,
 )
 from gain.genomic_resources.cli import VerbosityConfiguration
 from gain.genomic_resources.genomic_context import (
@@ -492,6 +493,36 @@ def _add_tasks_to_graph(  # pylint:disable=too-many-positional-arguments
     )
 
 
+def _print_annotation_plan(
+    args: dict[str, Any],
+    pipeline: AnnotationPipeline,
+    grr: GenomicResourceRepo,
+    loader: ParquetLoader,
+) -> None:
+    """Print the (re)annotation plan to stderr.
+
+    When the dataset already carries an embedded annotation, the previous
+    pipeline is loaded from its meta and a :class:`ReannotationPipeline` plan
+    is rendered; otherwise the plain all-ADDED annotation plan is rendered.
+    """
+    if not loader.has_annotation:
+        print_annotation_plan(pipeline)
+        return
+
+    pipeline_previous = load_pipeline_from_yaml(
+        loader.meta["annotation_pipeline"], grr)
+    try:
+        reannotation = ReannotationPipeline(
+            pipeline, pipeline_previous,
+            full_reannotation=args["full_reannotation"])
+        reannotation.print_plan(reference="embedded annotation")
+    finally:
+        # The ReannotationPipeline wrapper shares the live new-pipeline
+        # annotators, so close only the previous pipeline here, not the
+        # wrapper.
+        pipeline_previous.close()
+
+
 def cli(raw_args: list[str] | None = None) -> None:
     """Entry method for running the Schema2 Parquet annotation tool."""
     if not raw_args:
@@ -510,8 +541,10 @@ def cli(raw_args: list[str] | None = None) -> None:
     grr = get_grr_from_context(context)
     assert grr.definition is not None
 
+    loader = ParquetLoader.load_from_dir(input_dir)
+    if args["dry_run"] or loader.has_annotation:
+        _print_annotation_plan(args, pipeline, grr, loader)
     if args["dry_run"]:
-        pipeline.print()
         return
 
     if not os.path.exists(args["work_dir"]):

--- a/core/tests/small/parquet/schema2/test_annotate_schema2_parquet.py
+++ b/core/tests/small/parquet/schema2/test_annotate_schema2_parquet.py
@@ -587,7 +587,11 @@ def test_autodetection_reannotate(
         "-i", str(pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"),
     ])
 
-    assert spy.call_count == 1
+    # Reannotation is autodetected from the dataset's embedded annotation.
+    # ReannotationPipeline is constructed twice: once for the always-on plan
+    # (_print_annotation_plan) and again by the in-process worker
+    # (process_parquet, observable here because -j 1 runs it in-process).
+    assert spy.call_count == 2
 
 
 def test_reannotate_in_place(
@@ -867,6 +871,152 @@ def test_full_reannotation_flag(
     # from previous annotations properly
     assert "score_A" in attrs
     assert "score_two" not in attrs
+
+
+def test_dry_run_prints_reannotation_plan(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: pathlib.Path,
+    t4c8_instance: GPFInstance,
+    t4c8_study_nonpartitioned: str,
+) -> None:
+    root_path = pathlib.Path(t4c8_instance.dae_dir) / ".."
+    annotation_file_new = str(root_path / "new_annotation_2.yaml")
+    grr_file = str(root_path / "grr.yaml")
+    work_dir = str(tmp_path / "work")
+
+    # --dry-run is mutually exclusive with -o/--output; the tool must not
+    # write any output dataset regardless of the work dir.
+    cli([
+        t4c8_study_nonpartitioned, annotation_file_new,
+        "-w", work_dir,
+        "--grr", grr_file,
+        "-j", "1",
+        "--dry-run",
+        "-i", str(pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"),
+    ])
+
+    captured = capsys.readouterr()
+    plan = captured.err
+    assert "Reannotation plan (vs embedded annotation):" in plan
+    assert "COPIED" in plan
+    assert "ADDED" in plan
+    assert "COMPUTED" in plan
+    assert "DELETED" in plan
+
+    # nothing is written on a dry-run
+    assert not pathlib.Path(work_dir).exists()
+
+
+def test_dry_run_reannotation_plan_has_copied(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: pathlib.Path,
+    t4c8_instance: GPFInstance,
+    t4c8_study_nonpartitioned: str,
+) -> None:
+    root_path = pathlib.Path(t4c8_instance.dae_dir) / ".."
+    # The study is annotated with resource "one" (score_A) + "two".
+    # new_annotation_2.yaml swaps "one" -> "three" (still score_A) but
+    # keeps "two" unchanged, so the "two" annotator must land under COPIED.
+    annotation_file_new = str(root_path / "new_annotation_2.yaml")
+    grr_file = str(root_path / "grr.yaml")
+    work_dir = str(tmp_path / "work")
+
+    cli([
+        t4c8_study_nonpartitioned, annotation_file_new,
+        "-w", work_dir,
+        "--grr", grr_file,
+        "-j", "1",
+        "--dry-run",
+        "-i", str(pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"),
+    ])
+
+    plan = capsys.readouterr().err
+    copied_line = next(
+        line for line in plan.splitlines() if "COPIED" in line)
+    # the unchanged "two" annotator -> score_two must be COPIED
+    assert "score_two" in copied_line
+
+
+def test_dry_run_full_reannotation_tag(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: pathlib.Path,
+    t4c8_instance: GPFInstance,
+    t4c8_study_nonpartitioned: str,
+) -> None:
+    root_path = pathlib.Path(t4c8_instance.dae_dir) / ".."
+    annotation_file_new = str(root_path / "new_annotation_2.yaml")
+    grr_file = str(root_path / "grr.yaml")
+    work_dir = str(tmp_path / "work")
+
+    cli([
+        t4c8_study_nonpartitioned, annotation_file_new,
+        "-w", work_dir,
+        "--grr", grr_file,
+        "-j", "1",
+        "--dry-run",
+        "--full-reannotation",
+        "-i", str(pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"),
+    ])
+
+    plan = capsys.readouterr().err
+    assert "[full reannotation]" in plan
+    assert not pathlib.Path(work_dir).exists()
+
+
+def test_dry_run_prints_plain_plan_for_unannotated(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: pathlib.Path,
+    t4c8_instance: GPFInstance,
+    t4c8_annotationless_study: str,
+) -> None:
+    root_path = pathlib.Path(t4c8_instance.dae_dir) / ".."
+    annotation_file_new = str(root_path / "new_annotation.yaml")
+    grr_file = str(root_path / "grr.yaml")
+    work_dir = str(tmp_path / "work")
+
+    cli([
+        t4c8_annotationless_study, annotation_file_new,
+        "-w", work_dir,
+        "--grr", grr_file,
+        "-j", "1",
+        "--dry-run",
+        "-i", str(pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"),
+    ])
+
+    plan = capsys.readouterr().err
+    assert "Annotation plan:" in plan
+    assert "Reannotation plan" not in plan
+    assert not pathlib.Path(work_dir).exists()
+
+
+def test_reannotation_run_prints_plan_and_writes(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: pathlib.Path,
+    t4c8_instance: GPFInstance,
+    t4c8_study_nonpartitioned: str,
+) -> None:
+    root_path = pathlib.Path(t4c8_instance.dae_dir) / ".."
+    annotation_file_new = str(root_path / "new_annotation_2.yaml")
+    grr_file = str(root_path / "grr.yaml")
+    output_dir = tmp_path / "out"
+    work_dir = str(tmp_path / "work")
+
+    cli([
+        t4c8_study_nonpartitioned, annotation_file_new,
+        "-o", str(output_dir),
+        "-w", work_dir,
+        "--grr", grr_file,
+        "-j", "1",
+        "-i", str(pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"),
+    ])
+
+    plan = capsys.readouterr().err
+    # always-on plan is printed for a real reannotation run
+    assert "Reannotation plan (vs embedded annotation):" in plan
+
+    # and the output dataset is still produced
+    loader_result = ParquetLoader.load_from_dir(str(output_dir))
+    assert len(list(loader_result.fetch_summary_variants())) == 6
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Brings the reannotation **plan output** to the Schema2 Parquet annotation tool and repairs its broken `--dry-run`. This is the gpf-side companion to the gain reannotation work (iossifovlab/gain#108–#111, merged to gain master).

### Before
`annotate_schema2_parquet --dry-run` called `pipeline.print()` in `cli()` on the **un-wrapped new pipeline** — the previous annotation (the dataset's embedded `meta["annotation_pipeline"]`) was never loaded there, and the current `ReannotationPipeline` no longer overrides `print()`, so it emitted a misleading reannotation-unaware "NEW ATTRIBUTES" list.

### After
A `_print_annotation_plan` helper loads the previous pipeline from the dataset's embedded annotation meta, builds the `ReannotationPipeline`, and prints the real plan to **stderr**:

```
Reannotation plan (vs embedded annotation):
  COPIED   (N): ...
  ADDED    (N): ...
  COMPUTED (N): ...
  DELETED  (N): ...
```

- **`--dry-run` / `-n`**: prints the plan and exits **before** resource caching / work-dir creation / the task graph — writes nothing. Falls back to the plain `Annotation plan:` for a not-yet-annotated dataset.
- **Always-on**: a real reannotation run prints the plan to stderr, then annotates as before (`process_parquet` worker unchanged).
- `--full-reannotation` shows the `[full reannotation]` tag.

Because the gain work_dir-reuse fix (iossifovlab/gain#111) is now in, reannotation reuse actually triggers here — **COPIED is genuinely populated** (a test asserts an unchanged annotator lands under COPIED via the dry-run).

## Testing

- 5 new tests: dry-run reannotation plan (header + four buckets, no output written), dry-run plain plan for an unannotated dataset, always-on plan on a real run, `[full reannotation]` tag, and a COPIED-is-populated assertion proving reuse via the dry-run.
- ruff + mypy clean; `tests/small/parquet/schema2/` green (57 passed in the changed file's module).

## Dependencies / notes

- Requires a gain build that includes the reannotation work (`ReannotationPipeline.print_plan`, `print_annotation_plan`, the work_dir-reuse fix) — gain master at/after `d3d2459ca`. CI's `Fetch gain wheel` pulls gain master's last successful build, which includes it.
- No `uv.lock` change: gpf CI re-resolves gain via `uv sync --upgrade-package gain-core --find-links ./dist/gain`, so the locked gain version is not authoritative.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
