### PR TITLE
docs-e2e: resolve gain-core from gain master build; drop the iossifovlab channel (#916)

### DIFF
--- a/docs_e2e/CLAUDE.md
+++ b/docs_e2e/CLAUDE.md
@@ -18,8 +18,9 @@ build #35: a stray `denovo_instance` in `wgpf_server` → 63 passed, 33
 errors). Only actually running the suite catches it.
 
 Emulate the Jenkins run in the driver container (needs docker,
-`dist/conda/gpf-web-*.conda` artefacts, and a populated `gpf-grr-cache`
-volume — see README § Local iteration):
+`dist/conda/gpf-web-*.conda` **and** `dist/conda/gain-core-*.conda`
+artefacts, and a populated `gpf-grr-cache` volume — see README § Local
+iteration):
 
 ```bash
 # from the gpf checkout, with dist/conda populated:
@@ -33,6 +34,12 @@ docker run --rm -v "$PWD:/workspace" -v gpf-grr-cache:/grr-cache \
 - No local `dist/conda`? Reuse a sibling worktree's
   `dist/conda/*.conda` (any recent gpf build works — the GRR resources
   are version-independent), or pull from a gpf build.
+- The install drops the `iossifovlab` channel (gpf#916), so the local
+  `dist/conda` must **also** hold a `gain-core-*.conda` — the gpf build
+  only produces `gpf-*`. In CI the `gpf-docs-e2e` Jenkinsfile copies it
+  from gain master's last build; locally, drop a `gain-core-*.conda`
+  (from a gain build, or `uv build`/`rattler-build` of `../gain`) into
+  `dist/conda/` or the solve fails with `nothing provides gain-core`.
 - Local `gpf-grr-cache` populated but missing the `.docs-e2e-prewarmed`
   sentinel? `touch` it once:
   `docker run --rm -v gpf-grr-cache:/grr-cache alpine touch /grr-cache/.docs-e2e-prewarmed`

--- a/docs_e2e/Jenkinsfile.docs-e2e
+++ b/docs_e2e/Jenkinsfile.docs-e2e
@@ -72,6 +72,20 @@ pipeline {
                 'lastSuccessful() of UPSTREAM_PROJECT.',
         )
         string(
+            name: 'GAIN_PROJECT',
+            defaultValue: '',
+            description: 'Jenkins project the gain-core conda ' +
+                'is copied from. Empty = fall back to ' +
+                'iossifovlab/gain/master lastSuccessful().',
+        )
+        string(
+            name: 'GAIN_BUILD',
+            defaultValue: '',
+            description: 'gain build number to copy gain-core ' +
+                'from. Empty = use lastSuccessful() of ' +
+                'GAIN_PROJECT.',
+        )
+        string(
             name: 'STAGE_FILTER',
             defaultValue: '',
             description: 'Optional pytest -k expression to ' +
@@ -160,7 +174,12 @@ pipeline {
             // Pull the freshly-built dist/conda/*.conda from the
             // upstream gpf build. (β)-mode install path per #871:
             // the suite tests THIS build's conda, not whatever is
-            // published on the iossifovlab channel.
+            // published on the iossifovlab channel. gain-core is a
+            // first-party dep of gpf-web that gpf does NOT build, so it
+            // is copied separately from gain master's last build
+            // (gpf#916) -- the iossifovlab channel is dropped at install
+            // time, so the local channel must carry every first-party
+            // package the solve needs.
             steps {
                 script {
                     String project = params.UPSTREAM_PROJECT?.trim() ?:
@@ -174,17 +193,35 @@ pipeline {
                         projectName: project,
                         selector: selector,
                     )
+                    // gain-core from gain master's last build, into the same
+                    // local channel. Mirrors how gpf's own CI fetches the gain
+                    // wheel from gain/master lastSuccessful; here we take the
+                    // conda artefact gain master archives (dist/conda/*.conda).
+                    String gainProject = params.GAIN_PROJECT?.trim() ?:
+                                         'iossifovlab/gain/master'
+                    def gainSelector = params.GAIN_BUILD?.trim() ?
+                                       specific(params.GAIN_BUILD) :
+                                       lastSuccessful()
+                    copyArtifacts(
+                        filter: 'dist/conda/gain-core-*.conda',
+                        fingerprintArtifacts: true,
+                        projectName: gainProject,
+                        selector: gainSelector,
+                    )
                 }
                 sh '''
                     ls -la dist/conda/
-                    # The conda package name is `gpf-web` (dash; per
-                    # web_api/conda-recipe/recipe.yaml). The Python
-                    # module is `gpf_web` (underscore). Conda
-                    # normalizes between the two for `mamba install`,
-                    # but the on-disk filename is always the dashed
-                    # form.
+                    # On-disk conda filenames use the dashed package name
+                    # (gpf-web, gain-core) regardless of the underscored
+                    # python module. With the iossifovlab channel dropped at
+                    # install time there is no published fallback, so fail
+                    # loud here if either first-party artefact is missing --
+                    # otherwise it surfaces as an opaque mamba "nothing
+                    # provides gain-core" mid-solve.
                     test -n "$(ls dist/conda/gpf-web-*.conda 2>/dev/null)" \
                         || { echo "ERROR: no gpf-web-*.conda in dist/conda/" >&2; exit 1; }
+                    test -n "$(ls dist/conda/gain-core-*.conda 2>/dev/null)" \
+                        || { echo "ERROR: no gain-core-*.conda in dist/conda/" >&2; exit 1; }
                 '''
             }
         }

--- a/docs_e2e/Jenkinsfile.docs-e2e-prewarm
+++ b/docs_e2e/Jenkinsfile.docs-e2e-prewarm
@@ -68,6 +68,20 @@ pipeline {
                 'UPSTREAM_PROJECT.',
         )
         string(
+            name: 'GAIN_PROJECT',
+            defaultValue: 'iossifovlab/gain/master',
+            description: 'Jenkins project the gain-core conda ' +
+                'is copied from. Must match what gpf-docs-e2e ' +
+                'uses, or the prewarm seeds against a different ' +
+                'gain.',
+        )
+        string(
+            name: 'GAIN_BUILD',
+            defaultValue: '',
+            description: 'gain build number to copy gain-core ' +
+                'from. Empty = lastSuccessful() of GAIN_PROJECT.',
+        )
+        string(
             name: 'GETTING_STARTED_REF',
             defaultValue: 'master',
             description: 'Branch/tag of iossifovlab/' +
@@ -146,11 +160,27 @@ pipeline {
                         projectName: params.UPSTREAM_PROJECT,
                         selector: selector,
                     )
+                    // gain-core from gain master's last build (gpf#916):
+                    // the install drops the iossifovlab channel, so the
+                    // local channel must carry gain-core. Keep this in sync
+                    // with the gpf-docs-e2e build or the prewarm seeds the
+                    // GRR cache against a different gain.
+                    def gainSelector = params.GAIN_BUILD?.trim() ?
+                                       specific(params.GAIN_BUILD) :
+                                       lastSuccessful()
+                    copyArtifacts(
+                        filter: 'dist/conda/gain-core-*.conda',
+                        fingerprintArtifacts: true,
+                        projectName: params.GAIN_PROJECT,
+                        selector: gainSelector,
+                    )
                 }
                 sh '''
                     ls -la dist/conda/
                     test -n "$(ls dist/conda/gpf-web-*.conda 2>/dev/null)" \
                         || { echo "ERROR: no gpf-web-*.conda in dist/conda/" >&2; exit 1; }
+                    test -n "$(ls dist/conda/gain-core-*.conda 2>/dev/null)" \
+                        || { echo "ERROR: no gain-core-*.conda in dist/conda/" >&2; exit 1; }
                 '''
             }
         }
@@ -208,16 +238,18 @@ YAML
                             # Mirror conftest.gpf_env_prefix: install
                             # gpf-web (pulls gain-core + gpf-core, which
                             # provide grr_cache_repo and its -i provider).
-                            # WORKAROUND (iossifovlab/gain#89): gain-core
-                            # imports tqdm in cached_repository.py without
-                            # declaring it, so a fresh gpf-web env lacks it and
-                            # grr_cache_repo dies with ModuleNotFoundError. Pull
-                            # tqdm explicitly until gain-core declares the dep.
-                            # Mirrors conftest.gpf_env_prefix.
+                            # First-party packages come ONLY from the local
+                            # channel (gpf-* from the gpf build, gain-core from
+                            # the gain build copied above); the iossifovlab
+                            # release channel is deliberately dropped so a stale
+                            # published gain-core/gpf-core cannot leak in
+                            # (gpf#916). gain-core's recipe now declares tqdm,
+                            # so the old gain#89 explicit-tqdm workaround is
+                            # gone. Mirrors conftest.gpf_env_prefix.
                             mamba create -y -n prewarm \
                                 -c file:///tmp/channel \
-                                -c iossifovlab -c bioconda -c conda-forge \
-                                gpf-web tqdm
+                                -c bioconda -c conda-forge \
+                                gpf-web
                             # Mirror the conftest.denovo_instance GRR block
                             # byte-for-byte: the GPF default is a `group` of
                             # grr-gpf.iossifovlab.com (GPF-specific resources,

--- a/docs_e2e/conftest.py
+++ b/docs_e2e/conftest.py
@@ -216,17 +216,21 @@ def gpf_env_prefix(
     cmd = [
         "mamba", "create", "-y",
         "--prefix", str(prefix),
+        # First-party packages (gpf-web, gpf-core, gain-core) come ONLY from
+        # the build's local channel; the `iossifovlab` release channel is
+        # deliberately NOT listed, so a stale *published* gain-core/gpf-core
+        # can never leak into the suite (gpf#916 -- this is exactly how
+        # gpf-docs-e2e #87 broke: published gain-core 2026.6.4 predated the
+        # `print_annotation_plan` symbol gpf master imports). The docs-e2e
+        # Jenkinsfile copies gain-core from gain master's last build into this
+        # channel alongside the gpf-* artefacts. All third-party deps resolve
+        # from conda-forge/bioconda.
         "-c", f"file://{conda_channel}",
-        "-c", "iossifovlab",
         "-c", "bioconda",
         "-c", "conda-forge",
         "gpf-web",
-        # WORKAROUND (iossifovlab/gain#89): gain-core imports tqdm in
-        # cached_repository.py but does not declare it as a dependency, so a
-        # fresh gpf-web env lacks it and every gain CLI (grr_cache_repo, wgpf,
-        # import_genotypes) dies with ModuleNotFoundError. Pull tqdm explicitly
-        # until gain-core declares it. Mirrors the prewarm Jenkinsfile.
-        "tqdm",
+        # (gain#89: gain-core's recipe now declares `tqdm`, so the old
+        # explicit-tqdm workaround is gone -- it arrives as a transitive dep.)
     ]
     result = _run(cmd, timeout=_INSTALL_TIMEOUT)
     if result.returncode != 0:


### PR DESCRIPTION
## Summary

Fixes `gpf-docs-e2e` build [#87](https://nemo.seqpipe.org/job/gpf-docs-e2e/87/) (70/178 failing, all cascading from `ImportError: cannot import name 'print_annotation_plan' from 'gain.annotation.annotation_pipeline'`).

**Root cause (release-ordering gap, not a code bug):** the suite installs the build's own `gpf-web` conda from a local `file://dist/conda` channel, but `gpf-web` depends on **unversioned `gain-core`**, which `mamba create` resolved from `-c iossifovlab`. The published `gain-core 2026.6.4` there predates the reannotation work (gain#112) that added `print_annotation_plan`, which gpf master (`d3b2074`, #914) imports. The `iossifovlab` channel only updates on a gain *release*, so gpf master racing ahead of a gain release breaks docs-e2e.

## Fix

docs-e2e is a pre-release integration gate; its honest target is **gpf master + gain master**, and it already overrides `gpf-web` with the build artefact. `gain-core` was the lone first-party package still pulled from the release channel.

- **`Jenkinsfile.docs-e2e`** — `copyArtifacts` `gain-core-*.conda` from `iossifovlab/gain/master` `lastSuccessful()` into the local channel (mirrors how gpf CI already fetches the gain *wheel*); `GAIN_PROJECT`/`GAIN_BUILD` params; fail-loud assert.
- **`conftest.py`** — drop `-c iossifovlab`; channels become `file://<local>` + `bioconda` + `conda-forge`. Drop the gain#89 `tqdm` workaround (gain-core's recipe now declares it).
- **`Jenkinsfile.docs-e2e-prewarm`** — mirror both (it seeds the GRR cache and must use the same gain).
- **`docs_e2e/CLAUDE.md`** — local `dist/conda` now also needs a `gain-core-*.conda`.

### Why drop the channel instead of pinning `gain-core`?

The `iossifovlab` channel hosts **only first-party** packages (`gpf-*`, `gain-*`); every third-party dep (apsw, dask, duckdb, pyarrow, pysam, pybigwig, pyliftover, django, sqlglot, …) is on conda-forge/bioconda. So once the local channel carries `gain-core` too, `iossifovlab` contributes nothing. Dropping it:
- removes the **entire class** of "a stale published first-party package leaks into the build" — `gpf-core` too, not just `gain-core`;
- sidesteps the dev-vs-release conda version-ordering hazard (gain master's hatch-vcs `2026.6.4.post1.devN` vs published `2026.6.4`), so **no version pin is needed**.

## Testing

CI-config change; verified statically: both Jenkinsfiles pass the controller's declarative linter; `conftest.py` compiles and introduces no new ruff findings. End-to-end verification is the `gpf-docs-e2e` run itself — see the canary note below.

## Out of scope (deliberately)

This stops docs-e2e from catching "we shipped gpf needing an unreleased gain symbol" — never its job (guide accuracy != release gating); the prod-image conda solve against the published channel is the right gate. The eventual gain release (so the *published* `gpf-web` image gets `print_annotation_plan`) is tracked separately.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)
