### PR TITLE
Fix gpf-docs-e2e red: adopt underscore GRR gene-score ids + harden generate_gene_profile (#919)

### DIFF
--- a/core/gpf/gene_profile/generate_gene_profile.py
+++ b/core/gpf/gene_profile/generate_gene_profile.py
@@ -60,6 +60,13 @@ def generate_gp(
         for score in category["scores"]:
             gene_score_name = score["score_name"]
             score_desc = gene_scores_db.get_score_desc(gene_score_name)
+            if score_desc is None:
+                raise ValueError(
+                    f"gene profile config references gene score "
+                    f"{gene_score_name!r}, which is not available in the "
+                    f"instance gene_scores_db; check the score id and the "
+                    f"gene_scores_db configuration",
+                )
             gene_score = gene_scores_db.get_gene_score(score_desc.resource_id)
             value = gene_score.get_gene_value(gene_score_name, gene_symbol)
             scores[category_name][gene_score_name] = value

--- a/docs/source/administration/getting_started/getting_started_files/gene_profiles.yaml
+++ b/docs/source/administration/getting_started/getting_started_files/gene_profiles.yaml
@@ -36,9 +36,9 @@ gene_scores:
 - category: autism_scores
   display_name: Autism Gene Scores
   scores:
-  - score_name: Satterstrom Buxbaum Cell 2020 qval
+  - score_name: Satterstrom_Buxbaum_Cell_2020_qval
     format: "%%.2f"
-  - score_name: Iossifov Wigler PNAS 2015 post noaut
+  - score_name: Iossifov_Wigler_PNAS_2015_post_noaut
     format: "%%.2f"
 
 - category: protection_scores

--- a/docs_e2e/tests/test_gene_sets.py
+++ b/docs_e2e/tests/test_gene_sets.py
@@ -54,8 +54,8 @@ GENE_SET_COLLECTIONS = ["autism", "GO"]
 # several scored columns (e.g. LGD -> LGD_score + LGD_rank); we assert one
 # representative id per resource.
 GENE_SCORES = [
-    "Satterstrom Buxbaum Cell 2020 qval",   # Satterstrom_Buxbaum_Cell_2020
-    "Iossifov Wigler PNAS 2015 post noaut",  # Iossifov_Wigler_PNAS_2015
+    "Satterstrom_Buxbaum_Cell_2020_qval",    # Satterstrom_Buxbaum_Cell_2020
+    "Iossifov_Wigler_PNAS_2015_post_noaut",  # Iossifov_Wigler_PNAS_2015
     "LGD_score",                             # LGD
     "LOEUF",                                 # LOEUF
 ]


### PR DESCRIPTION
## What

`gpf-docs-e2e` [#94](https://nemo.seqpipe.org/job/gpf-docs-e2e/94/) / [#95](https://nemo.seqpipe.org/job/gpf-docs-e2e/95/) went red with 4 failures — **not** a code regression. Builds #93 (pass) → #94 (fail) stayed on adjacent `gpf-release` commits that don't touch gene scores. The breakage came from **external GRR data**: the live `Satterstrom_Buxbaum_Cell_2020` and `Iossifov_Wigler_PNAS_2015` gene-score resources renamed their exposed score ids from space-form to underscore-form, converging on the convention `LGD_score`/`LOEUF` already use. The unpinned docs-e2e suite caught it.

All 4 failures are that one mismatch — the two gene-profile/table/CHD8 failures are downstream of the `generate_gene_profile` crash.

## Changes (fix forward — underscore ids are canonical)

- **`docs/.../getting_started_files/gene_profiles.yaml`** — `score_name` entries use the underscore ids. This file is both the rendered guide's `literalinclude` target **and** the runtime config the docs-e2e suite reads directly (`docs_e2e/conftest.py:1168`), so guide and runtime stay in lock-step.
- **`docs_e2e/tests/test_gene_sets.py`** — `GENE_SCORES` expectations updated to the underscore ids.
- **`core/gpf/gene_profile/generate_gene_profile.py`** — harden: a configured score that doesn't resolve now raises a clear `ValueError` naming the score, instead of the opaque `AttributeError: 'NoneType' object has no attribute 'resource_id'`.

The suite stays **unpinned** (it's a drift detector working as intended — no `gpf-getting-started`/GRR SHA pin). No `gpf-getting-started` change is needed: that repo doesn't carry `gene_profiles.yaml`; the guide tells users to create it and the fixture materializes it from this repo's docs copy.

## Verification

Will confirm green on the next `gpf-docs-e2e` nemo build (the suite is container/runtime-only; static checks don't exercise the fixture chain).

Closes #919
