### PR TITLE
Add withdraw_families

### DIFF
--- a/core/gpf/tools/withdraw_families.py
+++ b/core/gpf/tools/withdraw_families.py
@@ -1,0 +1,353 @@
+"""CLI tool to withdraw families from a genotype or phenotype study."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import cast
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+from gain.utils.verbosity_configuration import VerbosityConfiguration
+
+from gpf.duckdb_storage.duckdb_genotype_storage import DuckDbParquetStorage
+from gpf.gpf_instance.gpf_instance import GPFInstance
+from gpf.pheno.pheno_data import PhenotypeGroup, PhenotypeStudy
+from gpf.studies.study import GenotypeDataStudy
+
+logger = logging.getLogger(__name__)
+
+
+def _rewrite_parquet(
+    path: Path,
+    family_ids: set[str],
+    *,
+    dry_run: bool,
+    keep_original: bool,
+) -> tuple[int, int]:
+    """Drop rows for *family_ids* from *path* and write back atomically.
+
+    Returns ``(before, after)`` row counts.
+    """
+    table = pq.read_table(path)
+    before = len(table)
+
+    col = "familyId" if "familyId" in table.schema.names else "family_id"
+    match = pa.compute.is_in(table.column(col), pa.array(list(family_ids)))
+    filtered = table.filter(pa.compute.invert(match))
+    after = len(filtered)
+
+    if not dry_run and before != after:
+        tmp = path.with_suffix(".tmp.parquet")
+        try:
+            pq.write_table(filtered, tmp)
+            if keep_original:
+                path.replace(path.with_suffix(".parquet.orig"))
+            tmp.replace(path)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    return before, after
+
+
+def _remove_from_genotype_leaf(
+    study: GenotypeDataStudy,
+    gpf_instance: GPFInstance,
+    family_ids: set[str],
+    *,
+    dry_run: bool,
+    keep_original: bool,
+) -> None:
+    """Remove *family_ids* from a single leaf genotype study."""
+    storage_id = study.config.get("genotype_storage", {}).get("id")
+    registry = gpf_instance.genotype_storages
+    storage = (
+        registry.get_genotype_storage(storage_id)
+        if storage_id
+        else registry.get_default_genotype_storage()
+    )
+
+    if not isinstance(storage, DuckDbParquetStorage):
+        logger.warning(
+            "[%s] storage type %s is not duckdb_parquet; skipping",
+            study.study_id, type(storage).__name__,
+        )
+        return
+
+    study_data_dir = storage.config.base_dir / study.study_id
+    dry_tag = " [dry-run]" if dry_run else ""
+
+    # Pedigree
+    ped_path = study_data_dir / "pedigree" / "pedigree.parquet"
+    if not ped_path.exists():
+        logger.error("[%s] pedigree not found: %s", study.study_id, ped_path)
+        return
+
+    before, after = _rewrite_parquet(
+        ped_path, family_ids, dry_run=dry_run, keep_original=keep_original,
+    )
+    logger.info(
+        "[%s] pedigree: %d → %d rows (%d removed)%s",
+        study.study_id, before, after, before - after, dry_tag,
+    )
+
+    # Family variants
+    family_dir = study_data_dir / "family"
+    if not family_dir.exists():
+        logger.info(
+            "[%s] no family variants directory at %s; skipping",
+            study.study_id, family_dir,
+        )
+        return
+
+    parquet_files = sorted(family_dir.rglob("*.parquet"))
+    logger.info(
+        "[%s] scanning %d family variant file(s)%s",
+        study.study_id, len(parquet_files), dry_tag,
+    )
+
+    total_removed = 0
+    for pf in parquet_files:
+        before, after = _rewrite_parquet(
+            pf, family_ids, dry_run=dry_run, keep_original=keep_original,
+        )
+        removed = before - after
+        if removed:
+            logger.info(
+                "  %s: %d → %d (%d removed)%s",
+                pf.relative_to(family_dir), before, after, removed, dry_tag,
+            )
+        total_removed += removed
+
+    logger.info(
+        "[%s] family variants: %d row(s) removed total%s",
+        study.study_id, total_removed, dry_tag,
+    )
+
+
+def _remove_genotype(
+    study_id: str,
+    gpf_instance: GPFInstance,
+    family_ids: set[str],
+    *,
+    dry_run: bool,
+    keep_original: bool,
+) -> None:
+    study = gpf_instance.get_genotype_data(study_id)
+    if study.is_group:
+        logger.error(
+            "study %r is a group; pass a leaf study ID instead",
+            study_id,
+        )
+        sys.exit(1)
+    _remove_from_genotype_leaf(
+        cast(GenotypeDataStudy, study), gpf_instance, family_ids,
+        dry_run=dry_run, keep_original=keep_original,
+    )
+
+
+def _remove_from_pheno_leaf(
+    study: PhenotypeStudy,
+    family_ids: set[str],
+    *,
+    dry_run: bool,
+) -> None:
+    """Remove *family_ids* from a single leaf phenotype study."""
+    dbfile = study.db.dbfile
+    dry_tag = " [dry-run]" if dry_run else ""
+    logger.info("[%s] phenotype DB: %s%s", study.pheno_id, dbfile, dry_tag)
+
+    family_params = ", ".join(f"'{fid}'" for fid in sorted(family_ids))
+
+    # The study keeps an open read-only connection; DuckDB won't allow
+    # a second connection with different read_only settings in the same
+    # process. Use the study's existing connection for dry-run, and
+    # close it before opening the write connection for actual deletion.
+    if dry_run:
+        conn = study.db.connection
+        n_persons = conn.execute(
+            f"SELECT COUNT(*) FROM person"  # noqa: S608
+            f" WHERE family_id IN ({family_params})",
+        ).fetchone()[0]  # type: ignore[index]
+        logger.info(
+            "[%s] dry-run: would remove %d person(s)",
+            study.pheno_id, n_persons,
+        )
+        for tbl in study.db.instrument_values_tables.values():
+            tname = tbl.alias_or_name
+            n = conn.execute(
+                f"SELECT COUNT(*) FROM {tname}"  # noqa: S608
+                f" WHERE person_id IN"
+                f" (SELECT person_id FROM person"
+                f"  WHERE family_id IN ({family_params}))",
+            ).fetchone()[0]  # type: ignore[index]
+            if n:
+                logger.info(
+                    "[%s] dry-run: would remove %d row(s) from %s",
+                    study.pheno_id, n, tname,
+                )
+        return
+
+    study.db.connection.close()
+    conn = duckdb.connect(dbfile, read_only=False)
+    try:
+        person_ids = [
+            row[0]
+            for row in conn.execute(
+                f"SELECT person_id FROM person"  # noqa: S608
+                f" WHERE family_id IN ({family_params})",
+            ).fetchall()
+        ]
+        if not person_ids:
+            logger.info(
+                "[%s] no persons found for the given families",
+                study.pheno_id,
+            )
+            return
+
+        person_params = ", ".join(f"'{pid}'" for pid in person_ids)
+
+        for tbl in study.db.instrument_values_tables.values():
+            tname = tbl.alias_or_name
+            conn.execute(
+                f"DELETE FROM {tname}"  # noqa: S608
+                f" WHERE person_id IN ({person_params})",
+            )
+            logger.info(
+                "[%s] cleared instrument table %s", study.pheno_id, tname,
+            )
+
+        conn.execute(
+            f"DELETE FROM person WHERE family_id IN ({family_params})",  # noqa: S608
+        )
+        logger.info(
+            "[%s] removed %d person(s)", study.pheno_id, len(person_ids),
+        )
+
+        conn.execute(
+            f"DELETE FROM family WHERE family_id IN ({family_params})",  # noqa: S608
+        )
+        logger.info("[%s] removed family record(s)", study.pheno_id)
+
+        conn.execute("CHECKPOINT")
+    finally:
+        conn.close()
+
+
+def _remove_pheno(
+    study_id: str,
+    gpf_instance: GPFInstance,
+    family_ids: set[str],
+    *,
+    dry_run: bool,
+) -> None:
+    pheno = gpf_instance.get_phenotype_data(study_id)
+    if isinstance(pheno, PhenotypeGroup):
+        logger.error(
+            "study %r is a phenotype group; pass a leaf study ID instead",
+            study_id,
+        )
+        sys.exit(1)
+    if not isinstance(pheno, PhenotypeStudy):
+        logger.error(
+            "unexpected phenotype data type %s for %s",
+            type(pheno).__name__, study_id,
+        )
+        sys.exit(1)
+    _remove_from_pheno_leaf(pheno, family_ids, dry_run=dry_run)
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    gpf_instance: GPFInstance | None = None,
+) -> None:
+    """Remove families from a genotype or phenotype study."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove one or more families from a genotype or phenotype study. "
+            "For duckdb_parquet genotype studies the pedigree and family "
+            "variant Parquet files are rewritten in place. "
+            "For phenotype studies the PhenoDb is updated via SQL DELETE."
+        ),
+    )
+    VerbosityConfiguration.set_arguments(parser)
+    parser.add_argument(
+        "study",
+        help=(
+            "Study ID to remove families from. "
+            "The GPF instance is used to locate the study data."
+        ),
+    )
+    parser.add_argument(
+        "families",
+        nargs="+",
+        metavar="family_id",
+        help="One or more family IDs to remove.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Report what would be removed without modifying any files.",
+    )
+    parser.add_argument(
+        "--keep-original",
+        action="store_true",
+        default=False,
+        help=(
+            "Rename each original Parquet file to <file>.parquet.orig "
+            "before overwriting it. Has no effect with --dry-run."
+        ),
+    )
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = parser.parse_args(argv)
+    VerbosityConfiguration.set(args)
+
+    # Allow passing a YAML config path — extract the study ID from it.
+    study_arg = args.study
+    study_path = Path(study_arg)
+    if study_path.exists() and study_path.suffix in {".yaml", ".yml"}:
+        with study_path.open() as fh:
+            raw_config = yaml.safe_load(fh)
+        study_id: str = raw_config.get("id") or study_path.stem
+        logger.info("resolved study ID from config: %s", study_id)
+    else:
+        study_id = study_arg
+
+    family_ids: set[str] = set(args.families)
+    logger.info(
+        "removing %d family/families from study %r: %s%s",
+        len(family_ids), study_id, sorted(family_ids),
+        " [dry-run]" if args.dry_run else "",
+    )
+
+    if gpf_instance is None:
+        gpf_instance = GPFInstance.build()
+
+    genotype_ids = set(gpf_instance.get_genotype_data_ids())
+    pheno_ids = set(gpf_instance.get_phenotype_data_ids())
+
+    if study_id in genotype_ids:
+        _remove_genotype(
+            study_id, gpf_instance, family_ids,
+            dry_run=args.dry_run, keep_original=args.keep_original,
+        )
+    elif study_id in pheno_ids:
+        _remove_pheno(
+            study_id, gpf_instance, family_ids, dry_run=args.dry_run,
+        )
+    else:
+        logger.error(
+            "study %r not found in the GPF instance "
+            "(checked %d genotype and %d phenotype studies)",
+            study_id, len(genotype_ids), len(pheno_ids),
+        )
+        sys.exit(1)

--- a/core/gpf/tools/withdraw_families.py
+++ b/core/gpf/tools/withdraw_families.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import shutil
 import sys
 from pathlib import Path
 from typing import cast
@@ -155,6 +156,7 @@ def _remove_from_pheno_leaf(
     family_ids: set[str],
     *,
     dry_run: bool,
+    keep_original: bool,
 ) -> None:
     """Remove *family_ids* from a single leaf phenotype study."""
     dbfile = study.db.dbfile
@@ -193,6 +195,10 @@ def _remove_from_pheno_leaf(
         return
 
     study.db.connection.close()
+    if keep_original:
+        orig = Path(dbfile).with_suffix(".db.orig")
+        shutil.copy2(dbfile, orig)
+        logger.info("[%s] original DB saved as %s", study.pheno_id, orig)
     conn = duckdb.connect(dbfile, read_only=False)
     try:
         person_ids = [
@@ -244,6 +250,7 @@ def _remove_pheno(
     family_ids: set[str],
     *,
     dry_run: bool,
+    keep_original: bool,
 ) -> None:
     pheno = gpf_instance.get_phenotype_data(study_id)
     if isinstance(pheno, PhenotypeGroup):
@@ -258,7 +265,9 @@ def _remove_pheno(
             type(pheno).__name__, study_id,
         )
         sys.exit(1)
-    _remove_from_pheno_leaf(pheno, family_ids, dry_run=dry_run)
+    _remove_from_pheno_leaf(
+        pheno, family_ids, dry_run=dry_run, keep_original=keep_original,
+    )
 
 
 def main(
@@ -342,7 +351,8 @@ def main(
         )
     elif study_id in pheno_ids:
         _remove_pheno(
-            study_id, gpf_instance, family_ids, dry_run=args.dry_run,
+            study_id, gpf_instance, family_ids,
+            dry_run=args.dry_run, keep_original=args.keep_original,
         )
     else:
         logger.error(

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -92,6 +92,7 @@ denovo2vcf = "gpf.tools.denovo2vcf:main"
 dae2vcf = "gpf.tools.dae2vcf:main"
 vcf2tsv = "gpf.tools.vcf2tsv:main"
 verify_parquet = "gpf.tools.verify_parquet:main"
+withdraw_families = "gpf.tools.withdraw_families:main"
 
 [project.entry-points."gpf.genotype_storage.factories"]
 inmemory = "gpf.inmemory_storage.inmemory_genotype_storage:InmemoryGenotypeStorage"

--- a/core/tests/small/tools/test_withdraw_families.py
+++ b/core/tests/small/tools/test_withdraw_families.py
@@ -1,0 +1,305 @@
+# pylint: disable=redefined-outer-name,C0114,C0116
+import pathlib
+import textwrap
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from gain.genomic_resources.testing import setup_pedigree, setup_vcf
+
+from gpf.genotype_storage.genotype_storage_registry import (
+    get_genotype_storage_factory,
+)
+from gpf.gpf_instance.gpf_instance import GPFInstance
+from gpf.pheno.common import DestinationConfig, PhenoImportConfig
+from gpf.pheno.pheno_data import PhenotypeStudy
+from gpf.pheno.pheno_import import import_pheno_data
+from gpf.testing.foobar_import import foobar_gpf
+from gpf.testing.import_helpers import vcf_study
+from gpf.tools.withdraw_families import (
+    _remove_from_pheno_leaf,
+    _rewrite_parquet,
+    main,
+)
+
+
+def _make_family_parquet(
+    path: pathlib.Path, col: str = "family_id",
+) -> None:
+    table = pa.table({
+        col: ["f1", "f1", "f2", "f2", "f3"],
+        "value": [1, 2, 3, 4, 5],
+    })
+    pq.write_table(table, path)
+
+
+def test_rewrite_parquet_removes_matching_families(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "test.parquet"
+    _make_family_parquet(path)
+
+    before, after = _rewrite_parquet(
+        path, {"f1"}, dry_run=False, keep_original=False,
+    )
+
+    assert before == 5
+    assert after == 3
+    result = pq.read_table(path)
+    assert set(result.column("family_id").to_pylist()) == {"f2", "f3"}
+
+
+def test_rewrite_parquet_unchanged_when_no_match(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "test.parquet"
+    _make_family_parquet(path)
+    original_bytes = path.read_bytes()
+
+    before, after = _rewrite_parquet(
+        path, {"f99"}, dry_run=False, keep_original=False,
+    )
+
+    assert before == after == 5
+    assert path.read_bytes() == original_bytes
+
+
+def test_rewrite_parquet_dry_run_does_not_modify(
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "test.parquet"
+    _make_family_parquet(path)
+    original_bytes = path.read_bytes()
+
+    before, after = _rewrite_parquet(
+        path, {"f1"}, dry_run=True, keep_original=False,
+    )
+
+    assert before == 5
+    assert after == 3
+    assert path.read_bytes() == original_bytes
+
+
+def test_rewrite_parquet_keep_original(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "test.parquet"
+    _make_family_parquet(path)
+
+    _rewrite_parquet(path, {"f1"}, dry_run=False, keep_original=True)
+
+    orig = path.with_suffix(".parquet.orig")
+    assert orig.exists()
+    assert len(pq.read_table(orig)) == 5
+    result = pq.read_table(path)
+    assert set(result.column("family_id").to_pylist()) == {"f2", "f3"}
+
+
+def test_rewrite_parquet_familyid_camelcase(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "test.parquet"
+    _make_family_parquet(path, col="familyId")
+
+    before, after = _rewrite_parquet(
+        path, {"f1"}, dry_run=False, keep_original=False,
+    )
+
+    assert before == 5
+    assert after == 3
+    result = pq.read_table(path)
+    assert set(result.column("familyId").to_pylist()) == {"f2", "f3"}
+
+
+@pytest.fixture
+def two_family_gpf(tmp_path: pathlib.Path) -> GPFInstance:
+    storage_config = {
+        "id": "test_storage",
+        "storage_type": "duckdb_parquet",
+        "base_dir": str(tmp_path / "storage"),
+    }
+    storage = get_genotype_storage_factory("duckdb_parquet")(storage_config)
+    gpf = foobar_gpf(tmp_path / "gpf", storage)
+
+    ped_path = setup_pedigree(
+        tmp_path / "data" / "in.ped",
+        """
+        familyId  personId  dadId  momId  sex  status  role
+        f1        m1        0      0      2    1       mom
+        f1        d1        0      0      1    1       dad
+        f1        p1        d1     m1     2    2       prb
+        f2        m2        0      0      2    1       mom
+        f2        d2        0      0      1    1       dad
+        f2        p2        d2     m2     2    2       prb
+        """)
+    vcf_path = setup_vcf(
+        tmp_path / "data" / "in.vcf.gz",
+        """
+        ##fileformat=VCFv4.2
+        ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+        ##contig=<ID=foo>
+        #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT m1  d1  p1  m2  d2  p2
+        foo    13  .  G   C   .    .      .    GT     0/1 0/0 0/1 0/0 0/0 0/0
+        foo    14  .  C   T   .    .      .    GT     0/0 0/1 0/1 0/0 0/0 0/0
+        foo    15  .  A   G   .    .      .    GT     0/0 0/0 0/0 0/1 0/0 0/1
+        """)
+    vcf_study(
+        tmp_path / "data", "two_fam_study", ped_path, [vcf_path],
+        gpf_instance=gpf)
+    return gpf
+
+
+def test_remove_families_genotype_removes_rows(
+    two_family_gpf: GPFInstance,
+) -> None:
+    storage_base = (
+        two_family_gpf.genotype_storages
+        .get_default_genotype_storage()
+        .config.base_dir
+    )
+    ped_path = storage_base / "two_fam_study" / "pedigree" / "pedigree.parquet"
+
+    ped_before = pq.read_table(ped_path)
+    assert set(ped_before.column("family_id").to_pylist()) == {"f1", "f2"}
+
+    main(["two_fam_study", "f1"], gpf_instance=two_family_gpf)
+
+    ped_after = pq.read_table(ped_path)
+    assert set(ped_after.column("family_id").to_pylist()) == {"f2"}
+
+    family_dir = storage_base / "two_fam_study" / "family"
+    for pf in family_dir.rglob("*.parquet"):
+        table = pq.read_table(pf)
+        if len(table) == 0:
+            continue
+        fid_col = (
+            "familyId" if "familyId" in table.schema.names
+            else "family_id"
+        )
+        assert "f1" not in table.column(fid_col).to_pylist()
+
+
+def test_remove_families_genotype_dry_run(
+    two_family_gpf: GPFInstance,
+) -> None:
+    storage_base = (
+        two_family_gpf.genotype_storages
+        .get_default_genotype_storage()
+        .config.base_dir
+    )
+    ped_path = (
+        storage_base / "two_fam_study" / "pedigree" / "pedigree.parquet"
+    )
+    original_bytes = ped_path.read_bytes()
+
+    main(["--dry-run", "two_fam_study", "f1"], gpf_instance=two_family_gpf)
+
+    assert ped_path.read_bytes() == original_bytes
+
+
+def test_remove_families_unknown_study_exits(
+    two_family_gpf: GPFInstance,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["no_such_study", "f1"], gpf_instance=two_family_gpf)
+    assert exc_info.value.code == 1
+
+
+@pytest.fixture
+def pheno_study(tmp_path: pathlib.Path) -> PhenotypeStudy:
+    ped_path = setup_pedigree(
+        tmp_path / "pedigree.ped",
+        """
+        familyId  personId   dadId      momId      sex  status  role
+        fam1      fam1.mom   0          0          2    1       mom
+        fam1      fam1.dad   0          0          1    1       dad
+        fam1      fam1.prb   fam1.dad   fam1.mom   2    2       prb
+        fam2      fam2.mom   0          0          2    1       mom
+        fam2      fam2.dad   0          0          1    1       dad
+        fam2      fam2.prb   fam2.dad   fam2.mom   2    2       prb
+        """)
+    instruments_dir = tmp_path / "instruments"
+    instruments_dir.mkdir(parents=True)
+    (instruments_dir / "instr1.csv").write_text(textwrap.dedent("""\
+        person_id,score
+        fam1.mom,10
+        fam1.dad,20
+        fam1.prb,30
+        fam2.mom,40
+        fam2.dad,50
+        fam2.prb,60
+    """))
+
+    storage_dir = tmp_path / "storage"
+    import_config = PhenoImportConfig(
+        id="test_pheno",
+        input_dir=str(tmp_path),
+        work_dir=str(tmp_path / "work"),
+        instrument_files=[str(instruments_dir)],
+        pedigree=str(ped_path),
+        person_column="person_id",
+        destination=DestinationConfig(storage_dir=str(storage_dir)),
+    )
+    import_pheno_data(import_config)
+    return PhenotypeStudy(
+        "test_pheno",
+        str(storage_dir / "test_pheno" / "test_pheno.db"),
+    )
+
+
+def test_remove_from_pheno_leaf_removes_persons(
+    pheno_study: PhenotypeStudy,
+) -> None:
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM person WHERE family_id = 'fam1'",
+    ).fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert count == 3
+
+    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=False)
+
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM person WHERE family_id = 'fam1'",
+    ).fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert count == 0
+
+
+def test_remove_from_pheno_leaf_removes_family_record(
+    pheno_study: PhenotypeStudy,
+) -> None:
+    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=False)
+
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM family WHERE family_id = 'fam1'",
+    ).fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert count == 0
+
+
+def test_remove_from_pheno_leaf_preserves_other_family(
+    pheno_study: PhenotypeStudy,
+) -> None:
+    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=False)
+
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM person WHERE family_id = 'fam2'",
+    ).fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert count == 3
+
+
+def test_remove_from_pheno_leaf_dry_run_no_changes(
+    pheno_study: PhenotypeStudy,
+) -> None:
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    before = conn.execute("SELECT COUNT(*) FROM person").fetchone()[0]  # type: ignore[index]
+    conn.close()
+
+    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=True)
+
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    after = conn.execute("SELECT COUNT(*) FROM person").fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert after == before

--- a/core/tests/small/tools/test_withdraw_families.py
+++ b/core/tests/small/tools/test_withdraw_families.py
@@ -254,7 +254,9 @@ def test_remove_from_pheno_leaf_removes_persons(
     conn.close()
     assert count == 3
 
-    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=False)
+    _remove_from_pheno_leaf(
+        pheno_study, {"fam1"}, dry_run=False, keep_original=False,
+    )
 
     conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
     count = conn.execute(
@@ -267,7 +269,9 @@ def test_remove_from_pheno_leaf_removes_persons(
 def test_remove_from_pheno_leaf_removes_family_record(
     pheno_study: PhenotypeStudy,
 ) -> None:
-    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=False)
+    _remove_from_pheno_leaf(
+        pheno_study, {"fam1"}, dry_run=False, keep_original=False,
+    )
 
     conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
     count = conn.execute(
@@ -280,7 +284,9 @@ def test_remove_from_pheno_leaf_removes_family_record(
 def test_remove_from_pheno_leaf_preserves_other_family(
     pheno_study: PhenotypeStudy,
 ) -> None:
-    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=False)
+    _remove_from_pheno_leaf(
+        pheno_study, {"fam1"}, dry_run=False, keep_original=False,
+    )
 
     conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
     count = conn.execute(
@@ -297,9 +303,38 @@ def test_remove_from_pheno_leaf_dry_run_no_changes(
     before = conn.execute("SELECT COUNT(*) FROM person").fetchone()[0]  # type: ignore[index]
     conn.close()
 
-    _remove_from_pheno_leaf(pheno_study, {"fam1"}, dry_run=True)
+    _remove_from_pheno_leaf(
+        pheno_study, {"fam1"}, dry_run=True, keep_original=False,
+    )
 
     conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
     after = conn.execute("SELECT COUNT(*) FROM person").fetchone()[0]  # type: ignore[index]
     conn.close()
     assert after == before
+
+
+def test_remove_from_pheno_leaf_keep_original(
+    pheno_study: PhenotypeStudy,
+) -> None:
+    dbfile = pathlib.Path(pheno_study.db.dbfile)
+
+    _remove_from_pheno_leaf(
+        pheno_study, {"fam1"}, dry_run=False, keep_original=True,
+    )
+
+    orig = dbfile.with_suffix(".db.orig")
+    assert orig.exists()
+
+    conn = duckdb.connect(str(orig), read_only=True)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM person WHERE family_id = 'fam1'",
+    ).fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert count == 3
+
+    conn = duckdb.connect(pheno_study.db.dbfile, read_only=True)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM person WHERE family_id = 'fam1'",
+    ).fetchone()[0]  # type: ignore[index]
+    conn.close()
+    assert count == 0


### PR DESCRIPTION
This pull request implements a new tool for withdrawing families from DuckDB parquet genotype studies and phenotype studies.
The tool interface is `withdraw_families <study> <family_id> [<family_id> ...] [--dry-run] [--keep-original]`
Study is either an ID or a path to a configuration.
`--keep-original` leaves a `<filename>.orig` copy of the original
`--dry-run` reports what would be removed.