### PR TITLE
fix(permissions): make dataset-hierarchy rebuild atomic (#922)

### DIFF
--- a/web_api/gpf_web/datasets_api/tests/test_reload_datasets_atomic.py
+++ b/web_api/gpf_web/datasets_api/tests/test_reload_datasets_atomic.py
@@ -1,0 +1,96 @@
+# pylint: disable=W0621,C0114,C0116,W0212,W0613,C0415
+"""Tests for atomic, non-destructive hierarchy rebuild (iossifovlab/gpf#922).
+
+``reload_datasets`` rebuilds the dataset-permission hierarchy by clearing
+``DatasetHierarchy`` and re-inserting every relation.  Historically this ran
+without an enclosing transaction, so a failure partway through the rebuild
+left the hierarchy empty/partial -- and a concurrent permission check could
+observe that empty state and compute an empty permitted-datasets set
+("spurious 0 variants").
+
+These tests pin the rebuild to be atomic: a failure mid-rebuild must roll
+back to the previously-loaded hierarchy instead of destroying it.
+"""
+import pytest
+from gpf_instance.gpf_instance import WGPFInstance, reload_datasets
+
+from datasets_api.models import DatasetHierarchy
+
+
+def _hierarchy_rows(instance_id: str) -> set[tuple[str, str, bool]]:
+    return {
+        (rel.ancestor.dataset_id, rel.descendant.dataset_id, rel.direct)
+        for rel in DatasetHierarchy.objects.filter(
+            instance_id=instance_id,
+        ).select_related("ancestor", "descendant")
+    }
+
+
+def test_reload_datasets_failure_preserves_prior_hierarchy(
+    custom_wgpf: WGPFInstance,
+    mocker: "pytest.MockFixture",  # type: ignore[name-defined]
+) -> None:
+    """A failure mid-rebuild rolls back to the prior hierarchy.
+
+    ``custom_wgpf`` has already populated the hierarchy once.  We then run
+    ``reload_datasets`` again, but make ``add_relation`` raise partway through
+    the re-insert loop.  With an atomic rebuild the prior hierarchy must be
+    fully intact afterwards -- never observed empty or partial.
+    """
+    instance_id = custom_wgpf.instance_id
+
+    before = _hierarchy_rows(instance_id)
+    assert before, "precondition: hierarchy populated by custom_wgpf"
+
+    call_count = {"n": 0}
+    real_add_relation = DatasetHierarchy.add_relation.__func__  # type: ignore[attr-defined]
+
+    # ``add_relation`` is only ever called inside the atomic swap, i.e. after
+    # ``clear()`` has already deleted the prior hierarchy.  Raising on the
+    # Nth call therefore lands mid re-insert -- exactly the window where a
+    # non-atomic rebuild would leave the hierarchy empty/partial.  (Keep this
+    # invariant in mind if the fixture's relation count ever changes: N must
+    # stay > 1 and < total relations to exercise the partial-insert state.)
+    def flaky_add_relation(*args: object, **kwargs: object) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 3:
+            raise RuntimeError("induced failure mid-rebuild")
+        real_add_relation(DatasetHierarchy, *args, **kwargs)
+
+    mocker.patch.object(
+        DatasetHierarchy, "add_relation",
+        side_effect=flaky_add_relation,
+    )
+
+    with pytest.raises(RuntimeError, match="induced failure mid-rebuild"):
+        reload_datasets(custom_wgpf)
+
+    after = _hierarchy_rows(instance_id)
+    assert after == before, (
+        "hierarchy must be rolled back to its prior state after a failed "
+        "rebuild; got a partial/empty hierarchy instead"
+    )
+
+
+def test_reload_datasets_clean_rebuild_is_idempotent(
+    custom_wgpf: WGPFInstance,
+) -> None:
+    """A clean rebuild reproduces the exact same relation set.
+
+    ``custom_wgpf`` has already built the hierarchy once.  Running
+    ``reload_datasets`` again with no induced failure must produce an
+    identical relation set -- this guards the tightened-transaction-scope
+    refactor (precompute relations outside the atomic block) against
+    silently changing the produced hierarchy.
+    """
+    instance_id = custom_wgpf.instance_id
+
+    before = _hierarchy_rows(instance_id)
+    assert before, "precondition: hierarchy populated by custom_wgpf"
+
+    reload_datasets(custom_wgpf)
+
+    after = _hierarchy_rows(instance_id)
+    assert after == before, (
+        "a clean rebuild must reproduce the exact same relation set"
+    )

--- a/web_api/gpf_web/gpf_instance/gpf_instance.py
+++ b/web_api/gpf_web/gpf_instance/gpf_instance.py
@@ -395,9 +395,34 @@ def get_wgpf_instance(
 
 
 def reload_datasets(gpf_instance: WGPFInstance) -> None:
-    """Recreate datasets permissions."""
+    """Recreate datasets permissions.
+
+    The slow part of the rebuild -- recreating dataset-permission rows and
+    loading every wdae wrapper to compute the hierarchy relations -- runs
+    *outside* any transaction.  Only the destructive swap of the hierarchy
+    (``DatasetHierarchy.clear`` followed by re-inserting the precomputed
+    relations) is wrapped in ``transaction.atomic`` (iossifovlab/gpf#922).
+    Keeping the wrapper loads out of the atomic block keeps the InnoDB locks
+    taken by ``clear``'s DELETE held for as short a time as possible.
+
+    Wrapping just the swap gives two distinct guarantees:
+
+    (a) *Failure rolls back.*  If an insert fails mid-rebuild the whole swap
+        is rolled back to the previously-loaded hierarchy instead of leaving
+        it empty/partial.  This holds on any backend purely from atomicity.
+
+    (b) *A concurrent reader never observes the partial intermediate state.*
+        This is **not** guaranteed by ``transaction.atomic`` alone -- it
+        relies on InnoDB MVCC: production MySQL runs at the REPEATABLE READ
+        isolation level, and the permitted-datasets CTE used by a permission
+        check is a single autocommit statement, so it reads a consistent MVCC
+        snapshot taken before this writer's uncommitted DELETE/INSERT became
+        visible.  On a backend without MVCC snapshots this property would not
+        hold.
+    """
     # pylint: disable=import-outside-toplevel
     from datasets_api.models import Dataset, DatasetHierarchy
+    from django.db import transaction
 
     valid_dataset_ids = set()
 
@@ -421,21 +446,32 @@ def reload_datasets(gpf_instance: WGPFInstance) -> None:
                 continue
             Dataset.recreate_dataset_perm(study_id)
 
-    DatasetHierarchy.clear(gpf_instance.instance_id)
-
+    # Precompute every relation tuple (ancestor=data_id, descendant=study_id,
+    # direct) -- including each dataset's self-relation -- using the slow
+    # wrapper loads *before* opening the transaction, so the atomic swap below
+    # touches only the database.
+    relations: list[tuple[str, str, bool]] = []
     for data_id in valid_dataset_ids:
         wdae_study = gpf_instance.get_wdae_wrapper(data_id)
-        DatasetHierarchy.add_relation(
-            gpf_instance.instance_id, data_id, data_id,
-        )
         assert wdae_study is not None
+        relations.append((data_id, data_id, False))
         direct_descendants = wdae_study.get_studies_ids(leaves=False)
         for study_id in wdae_study.get_studies_ids():
             if study_id == data_id:
                 continue
             is_direct = study_id in direct_descendants
+            relations.append((data_id, study_id, is_direct))
+
+    # Atomic swap only: clear + re-insert the precomputed relations.  The
+    # per-row ``add_relation`` loop is kept (rather than a single
+    # ``bulk_create``) because ``add_relation`` resolves each dataset via
+    # ``Dataset.objects.get`` -- preserving its exact insert semantics and
+    # validation -- and the relation count is small.
+    with transaction.atomic():
+        DatasetHierarchy.clear(gpf_instance.instance_id)
+        for ancestor_id, descendant_id, is_direct in relations:
             DatasetHierarchy.add_relation(
-                gpf_instance.instance_id, data_id, study_id,
+                gpf_instance.instance_id, ancestor_id, descendant_id,
                 direct=is_direct,
             )
 


### PR DESCRIPTION
## Problem (#922)

Genotype-browser queries intermittently **502 (Apache proxy timeout, ~60–90s)** and sometimes return a spurious **"0 variants"**. The request stalls inside the dataset-permission check, not in genotype storage.

Root cause: `reload_datasets()` rebuilds the dataset-permission hierarchy **destructively and non-atomically** — `DatasetHierarchy.clear()` deletes every row, then `add_relation()` re-inserts them in a loop with **no enclosing transaction** — while concurrent permission checks read those same tables via the recursive `permitted_datasets` CTE (`datasets_api/permissions.py`). A reader landing mid-rebuild observes an empty/partial hierarchy → empty permitted-datasets set → "0 variants". A failure mid-rebuild left the hierarchy destroyed.

## Change

Wrap **only the destructive swap** (`DatasetHierarchy.clear()` + re-insert of precomputed relations) in `transaction.atomic()`. The slow per-dataset permission recreation and the `get_wdae_wrapper()` metadata loads that build the relation tuples now run **outside** the transaction, so the InnoDB locks taken by `clear()`'s `DELETE` are held for as short a time as possible.

Two distinct guarantees (documented in the function docstring):
- **(a) Failure rolls back** to the previously-loaded hierarchy instead of leaving it empty/partial — holds on any backend purely from atomicity.
- **(b) A concurrent reader never observes the partial intermediate state** — this is **not** from `atomic()` alone; it relies on production MySQL/InnoDB REPEATABLE-READ MVCC, where the single-statement permitted-datasets CTE reads a consistent snapshot taken before this writer's uncommitted DELETE/INSERTs became visible.

The per-row `add_relation` loop is kept (rather than `bulk_create`) to preserve its `Dataset.objects.get(...)` resolution/validation semantics; the relation count is small.

## Tests

`datasets_api/tests/test_reload_datasets_atomic.py`:
- `test_reload_datasets_failure_preserves_prior_hierarchy` — patches `add_relation` to raise mid re-insert; asserts the prior hierarchy is preserved (atomic rollback / non-destructive). Verified red→green.
- `test_reload_datasets_clean_rebuild_is_idempotent` — a clean rebuild reproduces the exact same relation set (guards the precompute refactor).

## Verification

- ruff ✓ (scoped to the two changed files), mypy ✓ (`gpf_web`, 242 source files)
- `test_permissions.py` 16 baseline preserved; `datasets_api/tests/` 50 passed; `query_base/` + `genotype_browser/tests/` no regressions (34 passed, 3 xfailed)

## Scope / deferred follow-up

This fixes the **data-corruption half** of #922 (spurious "0 variants" + destructive-on-failure rebuild). Two proposed fixes from the issue are intentionally **deferred** as separate work and this PR does not close them out:

1. **Move `reload_datasets` off the request hot path.** It still runs synchronously on the first request a fresh worker serves (`QueryBaseView.__init__` → `recreated_dataset_perm`, under `_GPF_INSTANCE_LOCK`), so the first-request latency / 502 risk remains. Recommend moving it to startup / a management command.
2. **Memoize `permitted_datasets`** (the CTE runs twice per genotype query). Deferred because not all permission-mutating helpers bump `permission_timestamp`, so a timestamp-keyed cache would serve stale permitted sets — a correctness hazard. Needs all mutations to bump the timestamp first, or a request-scoped cache.

Because the hot-path latency is not addressed here, this PR is framed to **partially** resolve #922 rather than fully close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
