### PR TITLE
prod images: configurable Apache ProxyTimeout, default 5 min

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -74,7 +74,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENV PATH=/opt/gpf/bin:$PATH \
     PYTHONUNBUFFERED=1 \
     DJANGO_SETTINGS_MODULE=gpf_web.production_settings \
-    PHENO_IMAGES_DIR=/data-phenodb/pheno/images/
+    PHENO_IMAGES_DIR=/data-phenodb/pheno/images/ \
+    GPF_PROXY_TIMEOUT=300
 
 EXPOSE 80
 

--- a/httpd-combined.conf
+++ b/httpd-combined.conf
@@ -133,6 +133,12 @@ Alias /static/ "/var/www/html/static/"
 # resolves the same way in either deployment shape.
 ProxyPreserveHost On
 ProxyRequests Off
+# Seconds Apache waits on the proxied gunicorn before giving up.
+# Defaults to 300 (5 min) via the GPF_PROXY_TIMEOUT env (Dockerfile
+# ENV), overridable at deploy. Matches the host-native Apache layer so
+# both proxy hops share one ceiling; gunicorn's --timeout is the outer
+# bound.
+ProxyTimeout ${GPF_PROXY_TIMEOUT}
 RequestHeader set X-Forwarded-Proto "%{REQUEST_SCHEME}e"
 ProxyPass        /api/      http://127.0.0.1:9001/api/
 ProxyPassReverse /api/      http://127.0.0.1:9001/api/

--- a/httpd-combined.conf.template
+++ b/httpd-combined.conf.template
@@ -62,6 +62,12 @@ RedirectMatch ^/$ /__GPF_PREFIX__/
 # OAuth login round-trip; /ws/ is websockets.
 ProxyPreserveHost On
 ProxyRequests Off
+# Seconds Apache waits on the proxied gunicorn before giving up.
+# Defaults to 300 (5 min) via the GPF_PROXY_TIMEOUT env (Dockerfile
+# ENV), overridable at deploy. Matches the host-native Apache layer so
+# both proxy hops share one ceiling; gunicorn's --timeout is the outer
+# bound.
+ProxyTimeout ${GPF_PROXY_TIMEOUT}
 RequestHeader set X-Forwarded-Proto "%{REQUEST_SCHEME}e"
 ProxyPass        /__GPF_PREFIX__/api/      http://127.0.0.1:9001/api/
 ProxyPassReverse /__GPF_PREFIX__/api/      http://127.0.0.1:9001/api/

--- a/web_ui/Dockerfile.production
+++ b/web_ui/Dockerfile.production
@@ -81,3 +81,9 @@ COPY web_ui/httpd.conf /usr/local/apache2/conf/httpd.conf
 # same path. Trailing slash required — see httpd.conf for the
 # concatenation gotcha.
 ENV PHENO_IMAGES_DIR=/data-phenodb/pheno/images/
+
+# Default proxy timeout (seconds) consumed by httpd.conf's
+# `ProxyTimeout ${GPF_PROXY_TIMEOUT}`. 300 = 5 min; override at deploy
+# with `-e GPF_PROXY_TIMEOUT=…`. httpd-foreground inherits the
+# container env, so no entrypoint rendering is needed here.
+ENV GPF_PROXY_TIMEOUT=300

--- a/web_ui/httpd.conf
+++ b/web_ui/httpd.conf
@@ -125,6 +125,12 @@ Alias /static/ "/usr/local/apache2/htdocs/static/"
 #                 with a code.
 ProxyPreserveHost On
 ProxyRequests Off
+# Seconds Apache waits on the proxied backend before giving up.
+# Defaults to 300 (5 min) via the GPF_PROXY_TIMEOUT env (Dockerfile
+# ENV), overridable at deploy. Matches the host-native Apache layer so
+# both proxy hops share one ceiling; gunicorn's --timeout is the outer
+# bound.
+ProxyTimeout ${GPF_PROXY_TIMEOUT}
 RequestHeader set X-Forwarded-Proto "%{REQUEST_SCHEME}e"
 ProxyPass        /api/ http://backend:9001/api/
 ProxyPassReverse /api/ http://backend:9001/api/


### PR DESCRIPTION
## What

The in-container Apache (baked into the gpf-web prod images) had **no `ProxyTimeout`**, so it fell back to Apache's 60s default and cut off long requests — even though gunicorn already runs with `--timeout 1200` and **both** host-native Apache layers (gpf-infra `gpf-apache.conf.j2`, SFARI `gpf-production.conf.j2`) already set `ProxyTimeout 300`. The 60s in-container hop was the only bottleneck left:

```
client → host Apache (300 ✓) → container Apache (no ProxyTimeout → 60s ✗) → gunicorn (1200 ✓)
```

## Change

Add `ProxyTimeout ${GPF_PROXY_TIMEOUT}` to all three in-container proxy configs:
- `httpd-combined.conf` (bundle, root variant)
- `httpd-combined.conf.template` (bundle, prefixed variant)
- `web_ui/httpd.conf` (split `gpf-web-ui` frontend)

Default `GPF_PROXY_TIMEOUT=300` (5 min) via `ENV` in `Dockerfile.production` + `web_ui/Dockerfile.production`; overridable at deploy with `-e GPF_PROXY_TIMEOUT=…`. Reuses the Apache `${ENV}` substitution already used for `${PHENO_IMAGES_DIR}` (no entrypoint/sed changes). Apache errors on an undefined `${VAR}`, so the `ENV` default guarantees it's always set.

Resulting end-to-end ceiling: 300s at both proxy hops, gunicorn's 1200s the outer bound.

## Deploy-side companions
The deploy repos parameterize their (already-300) host `ProxyTimeout` with the same knob and pass `GPF_PROXY_TIMEOUT` to the container: `iossifovlab/gpf-infra` and `data-sfari-management` (separate PRs).
