### PR TITLE
fix(permissions): memoize permitted_datasets per request (#926)

### DIFF
--- a/web_api/gpf_web/datasets_api/permissions.py
+++ b/web_api/gpf_web/datasets_api/permissions.py
@@ -260,6 +260,21 @@ class IsDatasetAllowed(permissions.BasePermission):
         ):
             return dataset_ids
 
+        # Request-scoped memo: ``user`` is ``request.user``, created fresh
+        # per request by Django auth and living exactly as long as the
+        # request. Memoizing the computed permitted set on the user object
+        # (keyed by ``instance_id``) makes the expensive recursive CTE run
+        # once per request; a new request gets a new user object with an empty
+        # memo, so no cross-request staleness is possible. This avoids the
+        # unsafe alternative of a ``permission_timestamp``-keyed global cache,
+        # which the group-permission mutators do not bump and which would thus
+        # serve stale sets across requests.
+        cache: dict[str, set[str]] | None = getattr(
+            user, "_permitted_datasets_cache", None,
+        )
+        if cache is not None and instance_id in cache:
+            return cache[instance_id]
+
         query = IsDatasetAllowed.prepare_allowed_datasets_query()
 
         with connection.cursor() as cursor:
@@ -267,7 +282,14 @@ class IsDatasetAllowed(permissions.BasePermission):
 
             allowed_datasets_ids = {row[1] for row in cursor.fetchall()}
 
-        return dataset_ids.intersection(allowed_datasets_ids)
+        result = dataset_ids.intersection(allowed_datasets_ids)
+
+        if cache is None:
+            cache = {}
+            user._permitted_datasets_cache = cache  # type: ignore[attr-defined]  # noqa: SLF001
+        cache[instance_id] = result
+
+        return result
 
 
 def get_wdae_dataset(

--- a/web_api/gpf_web/datasets_api/tests/test_permissions.py
+++ b/web_api/gpf_web/datasets_api/tests/test_permissions.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613,C0415,
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from box import Box
@@ -11,6 +12,7 @@ from studies.study_wrapper import WDAEStudy
 
 from datasets_api.models import Dataset
 from datasets_api.permissions import (
+    IsDatasetAllowed,
     add_group_perm_to_dataset,
     add_group_perm_to_user,
     get_dataset_groups,
@@ -41,6 +43,17 @@ def na_user(
     )
     user.save()
     return cast(User, user)
+
+
+def _reload_user(user: User) -> User:
+    """Re-fetch a user from the DB as a fresh instance.
+
+    Simulates a new request: ``request.user`` is built fresh per request, so
+    the request-scoped ``permitted_datasets`` memo never survives a permission
+    mutation in production. Tests that mutate permissions and re-check on the
+    same Python object must reload to model that boundary.
+    """
+    return cast(User, get_user_model().objects.get(pk=user.pk))
 
 
 def test_parents(custom_wgpf: WGPFInstance) -> None:
@@ -75,6 +88,7 @@ def test_basic_rights(user: User, omni_dataset: GenotypeData) -> None:
     assert not user_has_permission(
         "t4c8_instance", user, omni_dataset.study_id)
     add_group_perm_to_user(omni_dataset.study_id, user)
+    user = _reload_user(user)  # new request: fresh memo
     assert user_has_permission("t4c8_instance", user, omni_dataset.study_id)
 
 
@@ -230,6 +244,125 @@ def test_any_user_with_anonymous(omni_dataset: GenotypeData) -> None:
                                omni_dataset.study_id)
 
 
+def test_permitted_datasets_cte_runs_once_per_user(
+    user: User,
+    custom_wgpf: GenotypeData,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    """Within one request (same user instance) the CTE runs once.
+
+    Tracer bullet for gpf#926: a request-scoped memo on the user object
+    means two calls to ``permitted_datasets`` for the same user+instance
+    execute the expensive recursive CTE only once.
+    """
+    add_group_perm_to_user("test_group", user)
+    add_group_perm_to_dataset("test_group", "dataset_1")
+
+    with patch.object(
+        IsDatasetAllowed,
+        "prepare_allowed_datasets_query",
+        wraps=IsDatasetAllowed.prepare_allowed_datasets_query,
+    ) as spy:
+        first = set(IsDatasetAllowed.permitted_datasets(user, "t4c8_instance"))
+        second = set(IsDatasetAllowed.permitted_datasets(user, "t4c8_instance"))
+
+    assert spy.call_count == 1
+    assert first == second
+    assert "dataset_1" in first
+
+
+def test_permitted_datasets_memo_is_correct(
+    user: User,
+    custom_wgpf: GenotypeData,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    """The memoized result equals a freshly-computed permitted set."""
+    add_group_perm_to_user("test_group", user)
+    add_group_perm_to_dataset("test_group", "dataset_1")
+
+    fresh = set(IsDatasetAllowed.permitted_datasets(user, "t4c8_instance"))
+    cached = set(IsDatasetAllowed.permitted_datasets(user, "t4c8_instance"))
+    assert cached == fresh
+    # all real permitted-via-hierarchy datasets present
+    assert {"dataset_1", "omni_dataset",
+            "t4c8_study_1"}.issubset(cached)
+    assert "t4c8_study_2" not in cached
+
+
+def test_permitted_datasets_no_cross_request_leak(
+    custom_wgpf: GenotypeData,  # noqa: ARG001 ; setup WGPF instance
+    db: None,  # noqa: ARG001
+) -> None:
+    """A different user object (new request) recomputes independently.
+
+    Guards against accidental process-global caching: the memo must live
+    on the per-request ``request.user`` instance, not be shared across
+    requests/users.
+    """
+    user_model = get_user_model()
+    user_a = cast(User, user_model.objects.create(
+        email="a@example.com", name="A",
+        is_staff=False, is_active=True, is_superuser=False,
+    ))
+    user_a.save()
+    add_group_perm_to_user("test_group", user_a)
+    add_group_perm_to_dataset("test_group", "dataset_1")
+
+    user_b = cast(User, user_model.objects.create(
+        email="b@example.com", name="B",
+        is_staff=False, is_active=True, is_superuser=False,
+    ))
+    user_b.save()
+    # user_b has no permissions
+
+    a_sets = set(IsDatasetAllowed.permitted_datasets(user_a, "t4c8_instance"))
+    assert "dataset_1" in a_sets
+
+    # Re-fetch user_a from the DB -> a brand new instance, like a new
+    # request. Its memo must be empty and recompute independently.
+    user_a_reloaded = cast(User, user_model.objects.get(email="a@example.com"))
+    with patch.object(
+        IsDatasetAllowed,
+        "prepare_allowed_datasets_query",
+        wraps=IsDatasetAllowed.prepare_allowed_datasets_query,
+    ) as spy:
+        reloaded_sets = set(
+            IsDatasetAllowed.permitted_datasets(
+                user_a_reloaded, "t4c8_instance"))
+    assert spy.call_count == 1
+    assert reloaded_sets == a_sets
+
+    # A different user must not read user_a's cached value.
+    b_sets = set(IsDatasetAllowed.permitted_datasets(user_b, "t4c8_instance"))
+    assert "dataset_1" not in b_sets
+
+
+def test_permitted_datasets_memo_keyed_per_instance(
+    user: User,
+    custom_wgpf: GenotypeData,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    """The per-user memo is keyed by ``instance_id`` and does not collide.
+
+    The same user object querying two different instance IDs must get
+    independent results -- a hit for one instance must not be returned for
+    another. ``t4c8_instance`` has permitted datasets; an unknown instance
+    has none.
+    """
+    add_group_perm_to_user("test_group", user)
+    add_group_perm_to_dataset("test_group", "dataset_1")
+
+    real = set(IsDatasetAllowed.permitted_datasets(user, "t4c8_instance"))
+    assert "dataset_1" in real
+
+    # A second instance_id on the same (now-populated) user object must not
+    # collide with the cached entry for "t4c8_instance".
+    other = set(IsDatasetAllowed.permitted_datasets(user, "other_instance"))
+    assert other == set()
+
+    # And the first instance's cached value is unchanged.
+    real_again = set(
+        IsDatasetAllowed.permitted_datasets(user, "t4c8_instance"))
+    assert real_again == real
+
+
 def test_user_group_permissions(
     user: User,
     omni_dataset: GenotypeData,
@@ -240,11 +373,13 @@ def test_user_group_permissions(
     add_group_perm_to_dataset(
         user.email, omni_dataset.study_id)
 
+    user = _reload_user(user)  # new request: fresh memo
     assert user_has_permission("t4c8_instance", user, omni_dataset.study_id)
 
     remove_group_perm_from_dataset(
         user.email, omni_dataset.study_id,
     )
 
+    user = _reload_user(user)  # new request: fresh memo
     assert not user_has_permission(
         "t4c8_instance", user, omni_dataset.study_id)

--- a/web_api/gpf_web/groups_api/tests/test_groups_rest.py
+++ b/web_api/gpf_web/groups_api/tests/test_groups_rest.py
@@ -5,6 +5,7 @@ from typing import cast
 import pytest
 from datasets_api.models import Dataset
 from datasets_api.permissions import user_has_permission
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, User
 from django.test.client import Client
 from rest_framework import status
@@ -216,6 +217,18 @@ def test_group_has_all_datasets(
     assert data["datasets"][0]["broken"] is False
 
 
+def _reload_user(user: User) -> User:
+    """Re-fetch the user as a fresh instance, modeling a new request.
+
+    ``permitted_datasets`` memoizes its result on the per-request
+    ``request.user`` (gpf#926). A test that mutates permissions and then
+    re-checks on the same Python object must reload to cross that request
+    boundary -- in production the mutation and the next check are separate
+    requests with distinct ``request.user`` instances.
+    """
+    return cast(User, get_user_model().objects.get(pk=user.pk))
+
+
 def test_grant_permission_for_group(
     admin_client: Client, group_with_user: tuple[Group, WdaeUser],
     dataset: Dataset,
@@ -232,6 +245,7 @@ def test_grant_permission_for_group(
     )
 
     assert response.status_code == status.HTTP_200_OK
+    user = _reload_user(user)  # new request: fresh permitted-datasets memo
     assert user_has_permission("t4c8_instance", user, dataset.dataset_id)
 
 
@@ -331,6 +345,7 @@ def test_revoke_permission_for_group(
     )
 
     assert response.status_code == status.HTTP_200_OK
+    user = _reload_user(user)  # new request: fresh permitted-datasets memo
     assert not user_has_permission("t4c8_instance", user, dataset.dataset_id)
 
 


### PR DESCRIPTION
## Problem (#926)

A genotype-browser query computes the permitted-datasets set **twice per request** via the expensive recursive CTE in `IsDatasetAllowed.permitted_datasets(user, instance_id)`: once by the DRF permission class `IsDatasetAllowed`, and again by `user_has_permission` (called from `genotype_browser/views.py`). Both run the same raw recursive CTE over the hierarchy/group tables for the same per-request user.

## Change

Memoize the result **per request** on the `request.user` object — a `dict[str, set[str]]` keyed by `instance_id`. On the authenticated-non-admin CTE path, `permitted_datasets` checks `user._permitted_datasets_cache`; on a hit it returns the cached set, on a miss it runs the CTE once and stores it. The early-return paths (anonymous / `DISABLE_PERMISSIONS` / superuser/staff/admin) are unchanged and unmemoized.

### Why this is safe (no staleness)

`request.user` is built fresh per request by Django auth and dies with the request, so the memo **cannot leak across requests** — a new request always gets an empty memo and recomputes. This deliberately avoids the unsafe alternative of a process-global cache keyed on `(user, instance, permission_timestamp)`: the `add_group_perm_*` / `remove_group_perm_*` helpers mutate permissions without bumping `permission_timestamp`, so a timestamp-keyed global cache would serve stale permitted sets. Per-request scoping sidesteps that hazard entirely.

(Runtime permission mutations don't need cache invalidation here: they mutate the group M2M tables directly and `permitted_datasets` reads them live on the next request — they never went through any rebuild.)

## Tests
- `test_permitted_datasets_cte_runs_once_per_user` — two calls for the same user+instance run the CTE once (spies on `prepare_allowed_datasets_query`). Red→green.
- `test_permitted_datasets_memo_is_correct` — the memoized set equals the freshly-computed one (no behavior change).
- `test_permitted_datasets_no_cross_request_leak` — a reloaded user (new request) and a different user recompute independently (request-scoped contract).
- `test_permitted_datasets_memo_keyed_per_instance` — the same user querying two instances gets independent, non-colliding results.

## Verification
- `datasets_api/tests/` + `genotype_browser/tests/`: 72 passed, 3 xfailed.
- ruff ✓ (scoped), mypy ✓ (`gpf_web`).

## Note
Deferred from this PR (intentionally): making **every** permission mutation bump `permission_timestamp`, which would additionally enable HTTP-level caching. That's a broader, separate change.

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)
