### PR TITLE
datasets_reload: fail loudly when rebuild yields empty hierarchy (#929)

### DIFF
--- a/web_api/gpf_web/datasets_api/tests/test_datasets_reload_command.py
+++ b/web_api/gpf_web/datasets_api/tests/test_datasets_reload_command.py
@@ -5,8 +5,10 @@ With the request-path trigger removed from ``QueryBaseView``, the
 dataset-permission hierarchy is rebuilt out-of-band by a management command
 that the deploy runs as a pre-start step (alongside DB migrations).
 """
+import pytest
 import pytest_mock
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from gpf_instance.gpf_instance import WGPFInstance
 from users_api.management.commands.datasets_reload import Command
 
@@ -30,6 +32,12 @@ def test_datasets_reload_command_calls_reload_datasets(
     """Running the command rebuilds the hierarchy via ``reload_datasets``."""
     spy = mocker.patch(
         "users_api.management.commands.datasets_reload.reload_datasets",
+    )
+    # Stub the dataset list to empty so the no-op ``reload_datasets`` mock
+    # leaves an (legitimately) empty hierarchy without tripping the
+    # non-empty post-condition -- this test isolates the delegation check.
+    mocker.patch.object(
+        custom_wgpf_module, "get_available_data_ids", return_value=[],
     )
 
     command = Command(gpf_instance=custom_wgpf_module)
@@ -79,3 +87,40 @@ def test_datasets_reload_command_is_idempotent(
     assert rows_after_second == rows_after_first, (
         "the hierarchy relation set must be identical after a second run"
     )
+
+
+def test_datasets_reload_command_fails_when_hierarchy_empty(
+    custom_wgpf_module: WGPFInstance,
+    db: None,  # noqa: ARG001
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Fail loudly when datasets exist but the rebuild leaves no relations."""
+    # The instance has datasets...
+    assert custom_wgpf_module.get_available_data_ids(), (
+        "precondition: the test instance must have datasets"
+    )
+    # ...but the rebuild is a no-op, so the hierarchy stays empty.
+    mocker.patch(
+        "users_api.management.commands.datasets_reload.reload_datasets",
+    )
+
+    command = Command(gpf_instance=custom_wgpf_module)
+    with pytest.raises(CommandError, match="no relations"):
+        call_command(command)
+
+
+def test_datasets_reload_command_allows_empty_when_no_datasets(
+    custom_wgpf_module: WGPFInstance,
+    db: None,  # noqa: ARG001
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """An instance with no datasets legitimately yields an empty hierarchy."""
+    mocker.patch(
+        "users_api.management.commands.datasets_reload.reload_datasets",
+    )
+    mocker.patch.object(
+        custom_wgpf_module, "get_available_data_ids", return_value=[],
+    )
+
+    command = Command(gpf_instance=custom_wgpf_module)
+    call_command(command)  # must not raise

--- a/web_api/gpf_web/users_api/management/commands/datasets_reload.py
+++ b/web_api/gpf_web/users_api/management/commands/datasets_reload.py
@@ -8,6 +8,7 @@ of paying the rebuild cost on the first request a fresh worker serves.
 """
 from typing import Any
 
+from datasets_api.models import DatasetHierarchy
 from django.core.management.base import BaseCommand, CommandError
 from gpf_instance.gpf_instance import (
     WGPFInstance,
@@ -40,3 +41,25 @@ class Command(BaseCommand):
                 )
                 raise CommandError(str(exc)) from exc
         reload_datasets(self.gpf_instance)
+
+        available = self.gpf_instance.get_available_data_ids()
+        relation_count = DatasetHierarchy.objects.filter(
+            instance_id=self.gpf_instance.instance_id,
+        ).count()
+        if available and relation_count == 0:
+            # An instance that *has* datasets must yield a non-empty
+            # hierarchy. An empty one here means auth is broken (every user
+            # denied); fail loudly so the deploy step is actionable
+            # (iossifovlab/gpf#929). An instance with no datasets
+            # legitimately yields an empty hierarchy -- do not false-fail.
+            self.stderr.write(
+                "dataset-permission hierarchy is EMPTY after rebuild, "
+                f"but {len(available)} dataset(s) are available",
+            )
+            raise CommandError(
+                "dataset-permission hierarchy rebuild produced no relations",
+            )
+        self.stdout.write(
+            f"dataset-permission hierarchy rebuilt: {relation_count} "
+            f"relation(s) for {len(available)} dataset(s)",
+        )


### PR DESCRIPTION
## Summary

Makes `wdaemanage datasets_reload` the canonical, loud-failing deploy pre-start step that builds the dataset-permission hierarchy (gpf#929), rather than relying on the in-process boot rebuild as the primary mechanism.

- After `reload_datasets()`, the command asserts a post-condition: an instance that **has** datasets must produce a **non-empty** `DatasetHierarchy`. If datasets exist but the hierarchy comes back empty, it raises `CommandError` (non-zero exit, clear message) so a broken deploy step is actionable.
- An instance with **no** datasets legitimately yields an empty hierarchy and is **not** failed — keeps the command usable on empty dev/test instances.
- On success it reports the relation/dataset counts to stdout for deploy-log visibility.
- The in-process boot safety net (`ensure_dataset_hierarchy()` in `WDAEConfig.ready()`) is **unchanged** and remains a pure fallback — its emptiness guard makes it a no-op once the command has run.

Design decisions (per the issue's open questions): reuse `datasets_reload` rather than a leaner hierarchy-only command (building the hierarchy requires loading wrappers and `Dataset` rows anyway); keep the assertion in the command (portable across both deploys).

## Deploy wiring (separate infra repos, landing alongside)

- `iossifovlab/gpf-infra` `deploy-gpf.yml` — reuses the `gpf-migrate` one-shot with an entrypoint override, after migrate and before service start.
- `data-sfari-management` `deployment/deploy-gpf.yaml` — mirrors the migrate one-shot, swapping `migrate --noinput` for `datasets_reload`.

## Test Plan

- [x] `pytest gpf_web/datasets_api/tests/test_datasets_reload_command.py` — 5 passed (2 new: loud-fail on empty-with-datasets, no-false-fail on empty-without-datasets)
- [x] full `gpf_web/datasets_api/tests/` — 61 passed
- [x] `ruff check` clean
- [x] `mypy gpf_web` — no issues in 249 source files

Closes #929