### PR TITLE
ci(e2e): gthread gunicorn for split-mode e2e backend

### DIFF
--- a/web_infra/compose-jenkins-split.yaml
+++ b/web_infra/compose-jenkins-split.yaml
@@ -22,6 +22,40 @@ services:
     # one origin. Backend keeps a literal `backend` hostname
     # because httpd.conf's ProxyPass uses that name.
     hostname: backend
+    # gpf#931: CI-only gthread gunicorn for the e2e backend.
+    # The prod image (web_api/Dockerfile.production) bakes a *sync*
+    # gunicorn (--workers 4) as its ENTRYPOINT. Sync workers hold a
+    # whole process open for the duration of each SSE variant-query
+    # StreamingHttpResponse, so N concurrent streams saturate all 4
+    # workers and queue every other request — the "Loading
+    # variants..." Mode A timeouts that forced the earlier 16->4
+    # Playwright rollback (tb-iuv-fix). gthread serves each stream on
+    # a thread instead, giving --workers x --threads = 16-way
+    # concurrency at the RAM cost of only 4 eager-loaded processes
+    # (STUDIES_EAGER_LOADING loads all studies per *process*). This
+    # unblocks the Playwright worker bump in gpf#933.
+    #
+    # Scoped to CI: we override `entrypoint` here rather than editing
+    # the prod image, so dory/production keep the sync model until
+    # gthread is adopted there deliberately + load-tested (gpf#932).
+    # entrypoint (not command) because the Dockerfile uses ENTRYPOINT
+    # with no CMD — a compose `command` would only append args.
+    # The duckdb backend is thread-safe under this: every query runs
+    # through connection.cursor() (core/gpf/duckdb_storage/
+    # duckdb2_variants.py), DuckDB's per-thread-cursor pattern.
+    entrypoint:
+      - gunicorn
+      - gpf_web.wsgi:application
+      - --bind
+      - 0.0.0.0:9001
+      - --worker-class
+      - gthread
+      - --workers
+      - "4"
+      - --threads
+      - "4"
+      - --timeout
+      - "1200"
     depends_on:
       instance-import:
         condition: service_completed_successfully


### PR DESCRIPTION
## What & why

The split-mode e2e backend runs the prod image, whose baked gunicorn ENTRYPOINT uses the **sync** worker class (`--workers 4`). Sync workers hold a whole process open for each SSE variant-query `StreamingHttpResponse`, so a few concurrent streams saturate all 4 workers and queue everything else — the "Loading variants..." Mode A timeouts that forced the earlier 16→4 Playwright worker rollback (tb-iuv-fix).

This overrides the split-mode backend `entrypoint` to the **gthread** worker class (`--worker-class gthread --workers 4 --threads 4`): each stream runs on a thread, giving 16-way request concurrency at the RAM cost of only 4 eager-loaded processes. This unblocks the Playwright worker bump in #933.

## Scope: CI-only

The override lives in the **compose overlay**, not the prod image — so dory/production keep the sync model until gthread is adopted there deliberately and load-tested (#932). `web_api/Dockerfile.production` and `supervisord.conf` are untouched.

- `entrypoint` (not `command`): the image uses ENTRYPOINT with no CMD, so `command` would only append args.
- Thread-safe: the duckdb backend runs every query through `connection.cursor()` (DuckDB's per-thread-cursor pattern).

## Verification

Ran the split stack locally (images built fresh from this HEAD):

- gunicorn boots with `--worker-class gthread --workers 4 --threads 4` ✔
- Suite: **448 passed / 9 failed** (12.8 min) at the default 4 workers
- The 9 failures (`variant-reports` + `pheno-tool` content assertions) are **not** from this change: an A/B on identical data shows sync and gthread fail the *same* 9, and master CI #281 (same HEAD) is green. Root cause is local gain-wheel drift (fresh gain `2026.6.6` vs CI's registry images).

The Jenkins branch build of `gpf-web-e2e` (registry images, no local drift) is the green-gate for the last box.

Closes #931
