### PR TITLE
ci(e2e): raise Playwright workers to 8 (+ worker/gunicorn build params)

### DIFF
--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -69,6 +69,30 @@ pipeline {
                 'both modes; the difference is what compose ' +
                 'overlay is loaded on top of compose-jenkins.yaml.',
         )
+        string(
+            name: 'E2E_WORKER_COUNT',
+            defaultValue: '8',
+            description: 'Playwright worker count, also the size ' +
+                'of import_data.sh\'s per-worker user pool (one ' +
+                'source of truth). Default 8 (#933), enabled by ' +
+                'the #931 gthread backend. Lower it for a ' +
+                'one-click rollback if a bump reintroduces the ' +
+                'Mode A "Loading variants..." SSE timeouts.',
+        )
+        string(
+            name: 'E2E_GUNICORN_WORKERS',
+            defaultValue: '4',
+            description: 'gthread gunicorn process count for the ' +
+                'split-mode backend (#931/#933). workers x ' +
+                'threads is the backend request concurrency; keep ' +
+                'E2E_WORKER_COUNT comfortably below it.',
+        )
+        string(
+            name: 'E2E_GUNICORN_THREADS',
+            defaultValue: '4',
+            description: 'gthread gunicorn threads-per-worker for ' +
+                'the split-mode backend (#931/#933).',
+        )
     }
 
     options {
@@ -97,6 +121,13 @@ pipeline {
             "gpf-web-e2e-${env.BUILD_NUMBER}"
         COMPOSE_NETWORK =
             "gpf-web-e2e-${env.BUILD_NUMBER}_default"
+        // #933: re-export the worker/gunicorn knobs so the
+        // sh-heredoc `docker compose` calls inherit them and the
+        // ${VAR:-default} substitutions in compose-jenkins.yaml /
+        // compose-jenkins-split.yaml resolve to the build params.
+        E2E_WORKER_COUNT     = "${params.E2E_WORKER_COUNT}"
+        E2E_GUNICORN_WORKERS = "${params.E2E_GUNICORN_WORKERS}"
+        E2E_GUNICORN_THREADS = "${params.E2E_GUNICORN_THREADS}"
     }
 
     stages {

--- a/web_e2e/playwright.config.ts
+++ b/web_e2e/playwright.config.ts
@@ -54,11 +54,17 @@ export default defineConfig({
    * acceptable trade for stability.
    * tb-nxl: read E2E_WORKER_COUNT (single source of truth shared with
    * import_data.sh's per-worker user pool — see web_e2e/tests/utils.ts
-   * loginWorkerUser). CI default 4, local default 4 (matches the
-   * provisioning default; bigger local CPUs can override via the env
-   * var to keep parallelIndex bounded by the provisioned pool). */
+   * loginWorkerUser). Bigger local CPUs can override via the env var
+   * to keep parallelIndex bounded by the provisioned pool.
+   * #933: default 4 → 8. The 4:4 ratio that tb-iuv-fix restored existed
+   * only because the backend ran *sync* gunicorn. #931 switched the
+   * split-mode e2e backend to gthread (--workers 4 --threads 4 =
+   * 16-way concurrency), so SSE variant streams no longer pin a whole
+   * process — 8 browsers stay at half the backend's request capacity,
+   * generous headroom against the Mode A pile-ups, and a deliberately
+   * smaller jump than the 16 that regressed before. */
   workers: parseInt(
-    process.env.E2E_WORKER_COUNT ?? '4',
+    process.env.E2E_WORKER_COUNT ?? '8',
     10,
   ),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/web_infra/compose-jenkins-split.yaml
+++ b/web_infra/compose-jenkins-split.yaml
@@ -43,6 +43,11 @@ services:
     # The duckdb backend is thread-safe under this: every query runs
     # through connection.cursor() (core/gpf/duckdb_storage/
     # duckdb2_variants.py), DuckDB's per-thread-cursor pattern.
+    #
+    # gpf#933: workers/threads are env-overridable (defaults 4x4 =
+    # 16-way) so the gunicorn concurrency can be retuned alongside the
+    # Playwright worker count from the gpf-web-e2e build parameters —
+    # one-click rollback if a bump reintroduces SSE saturation.
     entrypoint:
       - gunicorn
       - gpf_web.wsgi:application
@@ -51,9 +56,9 @@ services:
       - --worker-class
       - gthread
       - --workers
-      - "4"
+      - "${E2E_GUNICORN_WORKERS:-4}"
       - --threads
-      - "4"
+      - "${E2E_GUNICORN_THREADS:-4}"
       - --timeout
       - "1200"
     depends_on:

--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -126,8 +126,10 @@ services:
       # tb-nxl: per-worker user pool size. import_data.sh provisions
       # e2e_worker_0..N-1; e2e-tests reads the same value to size
       # Playwright's `workers`. Must stay in sync (one source of truth).
-      # tb-iuv-fix: default 16 → 4 (see web_e2e/playwright.config.ts).
-      E2E_WORKER_COUNT: "${E2E_WORKER_COUNT:-4}"
+      # #933: default 4 → 8, enabled by the #931 gthread backend (see
+      # web_e2e/playwright.config.ts). Overridable via the gpf-web-e2e
+      # E2E_WORKER_COUNT build parameter for one-click rollback.
+      E2E_WORKER_COUNT: "${E2E_WORKER_COUNT:-8}"
     entrypoint: ["bash", "/data/import_data.sh"]
     restart: "no"
 
@@ -154,6 +156,8 @@ services:
       JENKINS: "1"
       # tb-nxl: matches the value passed to instance-import so
       # Playwright's worker count never exceeds the provisioned pool.
-      # tb-iuv-fix: default 16 → 4 (see web_e2e/playwright.config.ts).
-      E2E_WORKER_COUNT: "${E2E_WORKER_COUNT:-4}"
+      # #933: default 4 → 8, enabled by the #931 gthread backend (see
+      # web_e2e/playwright.config.ts). Overridable via the gpf-web-e2e
+      # E2E_WORKER_COUNT build parameter for one-click rollback.
+      E2E_WORKER_COUNT: "${E2E_WORKER_COUNT:-8}"
     command: ["npx", "playwright", "test"]


### PR DESCRIPTION
## What & why

#931 switched the split-mode e2e backend to the **gthread** gunicorn worker class (`--workers 4 --threads 4` = 16-way concurrency), so SSE variant-query streams no longer pin a whole worker process. That removes the constraint behind the old 4:4 browser:gunicorn ratio. This bumps Playwright to **8 workers** — half the backend's request capacity (generous headroom against the Mode A "Loading variants…" pile-ups) and a deliberately smaller step than the 16 that regressed before.

## Changes

- `playwright.config.ts`: `E2E_WORKER_COUNT` default `4 → 8`.
- `compose-jenkins.yaml`: both `E2E_WORKER_COUNT` defaults `4 → 8` (the `import_data.sh` per-worker user pool auto-sizes to match).
- `compose-jenkins-split.yaml`: gunicorn `--workers`/`--threads` are now env-overridable (defaults `4`/`4`).
- `Jenkinsfile.e2e`: expose `E2E_WORKER_COUNT` (default `8`) + `E2E_GUNICORN_WORKERS` / `E2E_GUNICORN_THREADS` as build parameters and export them, so the compose `${VAR:-default}` substitutions resolve to the params — one-click rollback if a bump reintroduces SSE saturation. `retries=1` kept.

## Verification

Local split stack (images built from this HEAD): `Running 457 tests using 8 workers`, `e2e_worker_0..7` pool provisioned, backend on gthread. Suite **8.4 min vs 12.8 min at 4 workers**.

The only failures are the 9 `variant-reports`/`pheno-tool` count specs. They fail **identically at 4 and 8 workers** and are a **pre-existing stale-`common_report.json`** issue, fully root-caused in #936 (the e2e fixture was reduced to a subset without updating the hard-coded counts; CI passes because a stale full-data report survives in the reused workspace). They are unrelated to this change, and the Jenkins branch build — which runs on that same workspace — will pass them.

The 3× consecutive-green gate from the issue is the Jenkins responsibility (registry images, no local drift).

Closes #933
