### PR TITLE
fix(e2e): rebuild reports with --force so count specs track fixture data (#936)

### DIFF
--- a/web_e2e/gpf_e2e_instance/import_data.sh
+++ b/web_e2e/gpf_e2e_instance/import_data.sh
@@ -82,8 +82,25 @@ generate_gene_profile \
     --genes CHD8,GRIN2B,SHANK2,FLG,CMIP,TBCD,RAPGEF4,RAPGEFL1,RAPGEF1,RAPGEF2,SENP2,SENP3,SENP1,SENP6,SENP8,SENP3-EIF4A1
 
 # generate common reports
-generate_common_report
-generate_denovo_gene_sets
+#
+# iossifovlab/gpf#936: both generators are cache-aware and skip
+# when a report/cache already exists (study.build_and_save and
+# DenovoGeneSetHelpers.build_collection both no-op without force).
+# The cleanup above removes genotype_storage/ but NOT the
+# gitignored studies/*/common_report.json or the denovo gene set
+# caches, so on a reused workspace a stale full-data report survives
+# the re-import of subset data and the variant-reports / pheno-tool
+# count specs silently assert pre-strip numbers.
+#
+# Regenerating in-place with --force is the fix (not a workspace
+# wipe at checkout): this script runs inside the import container as
+# root and writes OUTPUT/ + studies/ artefacts owned by root into the
+# bind-mounted workspace, which the Jenkins agent user cannot delete
+# (WipeWorkspace fails with EPERM on OUTPUT/import_annotation/* -- see
+# build #287). --force rebuilds from the data just imported, in the
+# same container, so the reports always track the fixture.
+generate_common_report --force
+generate_denovo_gene_sets --force
 
 # create dev users for the e2e suite (idempotent: || true so reruns
 # don't fail once the users already exist)

--- a/web_e2e/tests/pheno-tool.spec.ts
+++ b/web_e2e/tests/pheno-tool.spec.ts
@@ -329,7 +329,7 @@ test.describe('Pheno tool download tests', () => {
       id: '15',
       genotype: 'iossifov_2014_liftover',
       affectedStatus: 'unaffected',
-      set: 'LGDs.Recurrent (3): LGDs.Recurrent '+
+      set: 'LGDs.Recurrent (1): LGDs.Recurrent '+
         '(vcf_helloworld:status:affected;iossifov_2014_liftover:status:unaffected)',
       measure: 'instrument_1.iq'
     }

--- a/web_e2e/tests/variant-reports.spec.ts
+++ b/web_e2e/tests/variant-reports.spec.ts
@@ -398,10 +398,10 @@ test.describe('Variant reports Iossifov count tests', () => {
   });
 
   [
-    {rowIndex: 0, effectType: 'LGDs', expectedCounts: ['393, 0.157(365, 15%)183, 0.096(172, 9%)']},
-    {rowIndex: 2, effectType: 'UTRs', expectedCounts: ['394, 0.157(360, 14%)', '251, 0.131(232, 12%)']},
-    {rowIndex: 6, effectType: 'Missense', expectedCounts: ['1690, 0.674(1190, 47%)', '1151, 0.603(843, 44%)']},
-    {rowIndex: 12, effectType: 'Intron', expectedCounts: ['1004, 0.4(794, 32%)', '688, 0.36(567, 30%)']}
+    {rowIndex: 0, effectType: 'LGDs', expectedCounts: ['68, 0.027(68, 3%)25, 0.013(24, 1%)']},
+    {rowIndex: 2, effectType: 'UTRs', expectedCounts: ['62, 0.025(62, 2%)', '43, 0.023(43, 2%)']},
+    {rowIndex: 6, effectType: 'Missense', expectedCounts: ['274, 0.109(240, 10%)', '189, 0.099(179, 9%)']},
+    {rowIndex: 10, effectType: 'Intron', expectedCounts: ['141, 0.056(136, 5%)', '99, 0.052(96, 5%)']}
   ].forEach(data => {
     test('should display the correct numbers for ' + data.effectType +
        ' effectType in the "Denovo variants of:" role table', async({ page }) => {
@@ -415,10 +415,10 @@ test.describe('Variant reports Iossifov count tests', () => {
   });
 
   [
-    {rowIndex: 0, effectType: 'LGDs', expectedCounts: ['393, 0.157(365, 15%)183, 0.096(172, 9%)']},
-    {rowIndex: 2, effectType: 'UTRs', expectedCounts: ['394, 0.157(360, 14%)', '251, 0.131(232, 12%)']},
-    {rowIndex: 6, effectType: 'Missense', expectedCounts: ['1690, 0.674(1190, 47%)', '1151, 0.603(843, 44%)']},
-    {rowIndex: 12, effectType: 'Intron', expectedCounts: ['1004, 0.4(794, 32%)', '688, 0.36(567, 30%)']}
+    {rowIndex: 0, effectType: 'LGDs', expectedCounts: ['68, 0.027(68, 3%)25, 0.013(24, 1%)']},
+    {rowIndex: 2, effectType: 'UTRs', expectedCounts: ['62, 0.025(62, 2%)', '43, 0.023(43, 2%)']},
+    {rowIndex: 6, effectType: 'Missense', expectedCounts: ['274, 0.109(240, 10%)', '189, 0.099(179, 9%)']},
+    {rowIndex: 10, effectType: 'Intron', expectedCounts: ['141, 0.056(136, 5%)', '99, 0.052(96, 5%)']}
   ].forEach(data => {
     test('should display the correct numbers for ' + data.effectType +
        ' effectType in the "Denovo variants of:" status table', async({ page }) => {


### PR DESCRIPTION
## Problem

Since `3da37c8f8` (2026-05-22, "e2e: strip iossifov_2014 denovo TSV to chr1/14/X") the `iossifov_2014_liftover` denovo import is the **chr1/14/X subset** (892 variants), but `variant-reports.spec.ts` and `pheno-tool.spec.ts` still asserted **full-dataset** denovo counts (LGDs 393, UTRs 394, Missense 1690, Intron 1004; `LGDs.Recurrent (3)`).

CI stayed green for ~3 weeks because the numbers were validated against a **stale `common_report.json`**, not the imported data:

- `import_data.sh`'s `generate_common_report` / `generate_denovo_gene_sets` are **cache-aware** — `study.build_and_save(force=False)` and `DenovoGeneSetHelpers.build_collection(force=False)` both no-op when the cached file already exists.
- the cleanup in `import_data.sh` removes `genotype_storage/` but **not** the gitignored `studies/*/common_report.json` or the denovo gene set caches.

So on a reused Jenkins agent a pre-strip full-data report survived the subset re-import; the genotype_storage was subset-correct (live queries fine) but the **report tables were served from stale JSON** → the un-updated count specs passed. On a clean workspace the report regenerates from the subset and **9 specs fail** (8 variant-reports denovo-count assertions + the pheno-tool `LGDs.Recurrent` gene-set test).

## Fix

- **`import_data.sh`** — pass `--force` to `generate_common_report` and `generate_denovo_gene_sets` so the reports/caches always rebuild from the data just imported.
- **`variant-reports.spec.ts`** — refresh the denovo count strings to the chr1/14/X subset values; `Intron` shifts `rowIndex` 12→10 (the subset has no `noStart`/`noEnd` rows).
- **`pheno-tool.spec.ts`** — the `LGDs.Recurrent` denovo gene set is now `(1)`, not `(3)`; the downloaded report (`pheno_report15.csv`) is unchanged (helloworld persons have 0 events in the set's genes either way).

`--force` is the right layer (not a checkout-time workspace wipe): the script runs inside the import container **as root** and writes `OUTPUT/` + `studies/` artefacts owned by root into the bind-mounted workspace, which the Jenkins agent user cannot delete — a `WipeWorkspace` extension fails with `EPERM` on `OUTPUT/import_annotation/*` (observed in gpf-web-e2e build #287). `--force` regenerates in the same container, so the reports always track the fixture.

Subset count strings were harvested from the regenerated `iossifov_2014_liftover/common_report.json` and confirmed against the live SPA render.

## Verification

Run locally against the **Jenkins-mirrored split compose stack** (`web_infra/compose-jenkins.yaml` + `compose-jenkins-split.yaml`) with prod images built from this branch:

- Before the spec edits (clean workspace): the predicted **9 specs fail**.
- After: `variant-reports.spec.ts` + `pheno-tool.spec.ts` → all green.
- **Full suite: 457 passed, 0 failed** (9.6m, 4 workers as in CI).

Closes #936