### PR TITLE
feat(prod): adopt gthread gunicorn worker class in the production images (#932)

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,9 +16,16 @@ logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
 [program:gunicorn]
+; #932: gthread worker class (--workers 4 --threads 4) — same change as
+; web_api/Dockerfile.production. Keeps 4 eager-loaded processes (no RAM
+; increase under STUDIES_EAGER_LOADING) while giving 16-way request
+; concurrency, so a single SSE variant stream no longer monopolizes a
+; whole process. This is the combined gpf-web-prod image production ships.
 command=/opt/gpf/bin/gunicorn gpf_web.wsgi:application
     --bind 127.0.0.1:9001
+    --worker-class gthread
     --workers 4
+    --threads 4
     --timeout 1200
 environment=PATH="/opt/gpf/bin:%(ENV_PATH)s",DJANGO_SETTINGS_MODULE=gpf_web.production_settings,PYTHONUNBUFFERED=1
 stdout_logfile=/dev/stdout

--- a/web_api/Dockerfile.production
+++ b/web_api/Dockerfile.production
@@ -115,8 +115,23 @@ EXPOSE 9001
 # (16 → 4) landed in tb-iuv-fix; this restores the 4:4
 # browser:gunicorn ratio. 16-way eager loading also dropped 4×
 # the RAM footprint of the prod pod under STUDIES_EAGER_LOADING.
+#
+# #932: switch from the default *sync* worker class to gthread
+# (--workers 4 --threads 4). A variant-query response is an SSE
+# StreamingHttpResponse that holds a worker for the whole stream;
+# with sync workers a handful of concurrent streams saturate all 4
+# processes and queue every other request. gthread serves each
+# stream on a thread, giving --workers × --threads = 16-way request
+# concurrency while keeping only 4 eager-loaded processes — so the
+# STUDIES_EAGER_LOADING RAM footprint is unchanged from the 4-sync
+# config above. Same shape proven in CI (#931 split overlay) and in
+# web_api/gpf_web/run_gunicorn.sh. Thread-safe on the variant path:
+# the duckdb backend opens a per-query cursor (core/gpf/
+# duckdb_storage/duckdb2_variants.py), DuckDB's per-thread pattern.
 ENTRYPOINT ["gunicorn", \
             "gpf_web.wsgi:application", \
             "--bind", "0.0.0.0:9001", \
+            "--worker-class", "gthread", \
             "--workers", "4", \
+            "--threads", "4", \
             "--timeout", "1200"]


### PR DESCRIPTION
> ⚠️ **Do not merge yet** — gated on the dory load-test (acceptance criteria below). Code is validated locally; the production load/RAM validation is HITL.

## What & why

Switch production gunicorn from the default **sync** worker class to **gthread (`--workers 4 --threads 4`)** in both prod configs:

- `web_api/Dockerfile.production` ENTRYPOINT (standalone backend image)
- `supervisord.conf` `[program:gunicorn]` — the **combined `gpf-web-prod` image that gpf-infra actually deploys**

A variant-query response is an SSE `StreamingHttpResponse` that pins a worker for the whole stream; with sync workers a few concurrent streams saturate all 4 processes and queue everything else (the failure mode #931 fixed for CI). gthread serves each stream on a thread → **16-way request concurrency at the same 4-process eager-loading RAM footprint**. Same shape proven in CI (#931 split overlay), in #933, and in `run_gunicorn.sh`. Thread-safe on the variant path (duckdb per-query cursor).

This is the production counterpart of the CI-only #931; see that issue's scope note.

## Local validation

Built the combined `gpf-web-prod` image from this branch and ran the **combined-mode** e2e (the prod artifact, which #931 deliberately left on sync):

- gunicorn under supervisord launches with `--worker-class gthread --workers 4 --threads 4` ✔
- full suite **457 passed / 0 failed** (6.6 min, 8 workers) ✔

## Remaining gate (HITL — required before merge/rollout)

- [ ] Load test on a representative instance: **no regression in variant-stream latency**, **acceptable RAM under `STUDIES_EAGER_LOADING`**
- [ ] Deploy to **dory/staging** and observe before any production rollout

Note: the branch's `gpf-web-e2e` CI runs split mode by default, where the compose overlay already overrides the entrypoint to gthread (#931/#933) — so CI does not exercise this image change directly. The combined-mode validation above covers the production path.

Refs #932
