### PR TITLE
tune(prod): gunicorn gthread 2 workers × 16 threads (was 4×4) (#932)

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,16 +16,18 @@ logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
 [program:gunicorn]
-; #932: gthread worker class (--workers 4 --threads 4) — same change as
-; web_api/Dockerfile.production. Keeps 4 eager-loaded processes (no RAM
-; increase under STUDIES_EAGER_LOADING) while giving 16-way request
-; concurrency, so a single SSE variant stream no longer monopolizes a
-; whole process. This is the combined gpf-web-prod image production ships.
+; #932: gthread worker class (--workers 2 --threads 16) — same change as
+; web_api/Dockerfile.production. Under STUDIES_EAGER_LOADING RAM scales
+; with workers (each process eager-loads all studies), so 2 workers halve
+; the footprint vs the prior 4-sync config while 16 threads/process give
+; 32-way request concurrency — a single SSE variant stream no longer
+; monopolizes a whole process. This is the combined gpf-web-prod image
+; production ships.
 command=/opt/gpf/bin/gunicorn gpf_web.wsgi:application
     --bind 127.0.0.1:9001
     --worker-class gthread
-    --workers 4
-    --threads 4
+    --workers 2
+    --threads 16
     --timeout 1200
 environment=PATH="/opt/gpf/bin:%(ENV_PATH)s",DJANGO_SETTINGS_MODULE=gpf_web.production_settings,PYTHONUNBUFFERED=1
 stdout_logfile=/dev/stdout

--- a/web_api/Dockerfile.production
+++ b/web_api/Dockerfile.production
@@ -116,22 +116,26 @@ EXPOSE 9001
 # browser:gunicorn ratio. 16-way eager loading also dropped 4×
 # the RAM footprint of the prod pod under STUDIES_EAGER_LOADING.
 #
-# #932: switch from the default *sync* worker class to gthread
-# (--workers 4 --threads 4). A variant-query response is an SSE
-# StreamingHttpResponse that holds a worker for the whole stream;
-# with sync workers a handful of concurrent streams saturate all 4
-# processes and queue every other request. gthread serves each
-# stream on a thread, giving --workers × --threads = 16-way request
-# concurrency while keeping only 4 eager-loaded processes — so the
-# STUDIES_EAGER_LOADING RAM footprint is unchanged from the 4-sync
-# config above. Same shape proven in CI (#931 split overlay) and in
-# web_api/gpf_web/run_gunicorn.sh. Thread-safe on the variant path:
-# the duckdb backend opens a per-query cursor (core/gpf/
-# duckdb_storage/duckdb2_variants.py), DuckDB's per-thread pattern.
+# #932: switch from the default *sync* worker class to gthread. A
+# variant-query response is an SSE StreamingHttpResponse that holds a
+# worker for the whole stream; with sync workers a handful of
+# concurrent streams saturate every process and queue all other
+# requests. gthread serves each stream on a thread instead.
+#
+# Shape: --workers 2 --threads 16 (32-way request concurrency). Under
+# STUDIES_EAGER_LOADING each *process* eager-loads all studies, so RAM
+# scales with workers, not threads — 2 workers halves the eager-loading
+# footprint vs the prior 4-sync (and the initial 4×4 gthread) config,
+# while 16 threads/process carry the concurrency. The variant path is
+# I/O-bound (DuckDB releases the GIL in C++ + SSE streaming), so threads
+# give real concurrency there; 2 processes keep worker-level redundancy
+# and 2-core parallelism for the CPU-bound paths. Thread-safe: the
+# duckdb backend opens a per-query cursor (core/gpf/duckdb_storage/
+# duckdb2_variants.py), DuckDB's per-thread pattern.
 ENTRYPOINT ["gunicorn", \
             "gpf_web.wsgi:application", \
             "--bind", "0.0.0.0:9001", \
             "--worker-class", "gthread", \
-            "--workers", "4", \
-            "--threads", "4", \
+            "--workers", "2", \
+            "--threads", "16", \
             "--timeout", "1200"]


### PR DESCRIPTION
Follow-up tweak to the merged #932 (which shipped gthread **4×4**). Re-shapes the production gunicorn to **2 workers × 16 threads**.

## Why
Under `STUDIES_EAGER_LOADING` each *process* eager-loads all studies, so RAM scales with `--workers`, not `--threads`. **2 workers halves the eager-loading RAM** vs the 4-process config, while **16 threads/process give 32-way concurrency**. The variant path is I/O-bound (DuckDB releases the GIL in C++ + SSE streaming), so threads carry it; 2 processes keep worker-level redundancy and 2-core parallelism for CPU-bound paths.

Applied to both prod configs: `web_api/Dockerfile.production` ENTRYPOINT and `supervisord.conf` (combined `gpf-web-prod` image gpf-infra deploys).

## Local validation (combined mode, the prod artifact)
- gunicorn under supervisord runs `--worker-class gthread --workers 2 --threads 16` ✔
- **455 passed / 0 failed / 2 flaky** (6.4 min). The 2 flaky (a GO-term count in `genes-block` and a datasets-dropdown click timeout in `variant-reports`) passed on retry. The earlier 4×4 combined run had 0 flaky — worth noting that fewer processes may be slightly tighter under burst load, though 2 flakes from one run on a contended dev box isn't conclusive.

## Gate
Same as #932: **do not roll to production without the dory load-test** — and that load-test is now also the place to confirm 2 processes don't increase tail latency / queueing vs 4 under real concurrency. If they do, the easy fallback is back to 4×4 (or 4×8) at the cost of RAM.

Refs #932
