### PR TITLE
Cache genomic_scores endpoint responses (Closes #941)

### DIFF
--- a/web_api/gpf_web/genomic_scores_api/tests/test_genomic_scores_api.py
+++ b/web_api/gpf_web/genomic_scores_api/tests/test_genomic_scores_api.py
@@ -1,7 +1,14 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines
+import pytest
 from django.test.client import Client
 from gpf_instance.gpf_instance import WGPFInstance
 from rest_framework import status
+from utils import cached_response
+
+
+@pytest.fixture(autouse=True)
+def _clear_cached_response() -> None:
+    cached_response._CACHE.clear()
 
 
 def test_get_genomic_scores(
@@ -12,5 +19,120 @@ def test_get_genomic_scores(
     response = user_client.get(url)
     assert response.status_code == status.HTTP_200_OK, repr(response.content)
 
-    data = response.data  # type: ignore
+    data = response.json()
     assert sorted([gs["score"] for gs in data]) == ["score_one"]
+
+
+def test_get_genomic_scores_cache_control(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/genomic_scores"
+    response = user_client.get(url)
+    assert response.status_code == status.HTTP_200_OK, repr(response.content)
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+
+
+def test_get_genomic_scores_memo_hit(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = "/api/v3/genomic_scores"
+
+    render_calls = 0
+    original_render = cached_response.JSONRenderer.render
+
+    def counting_render(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal render_calls
+        render_calls += 1
+        return original_render(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        cached_response.JSONRenderer, "render", counting_render,
+    )
+
+    first = user_client.get(url)
+    second = user_client.get(url)
+
+    assert first.status_code == status.HTTP_200_OK, repr(first.content)
+    assert second.status_code == status.HTTP_200_OK, repr(second.content)
+    assert first.content == second.content
+    assert render_calls == 1
+
+
+def test_get_genomic_scores_if_none_match_304(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/genomic_scores"
+    first = user_client.get(url)
+    assert first.status_code == status.HTTP_200_OK, repr(first.content)
+    etag = first.headers["ETag"]
+
+    second = user_client.get(url, HTTP_IF_NONE_MATCH=etag)
+    assert second.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+def test_get_score_descs_all(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/genomic_scores/score_descs"
+    response = user_client.get(url)
+    assert response.status_code == status.HTTP_200_OK, repr(response.content)
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+    data = response.json()
+    assert sorted([sd["name"] for sd in data]) == ["score_one"]
+
+
+def test_get_score_descs_single(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/genomic_scores/score_descs/score_one"
+    response = user_client.get(url)
+    assert response.status_code == status.HTTP_200_OK, repr(response.content)
+    assert response.headers["Cache-Control"] == "public, max-age=3600"
+    data = response.json()
+    assert [sd["name"] for sd in data] == ["score_one"]
+
+
+def test_get_score_descs_unknown_404(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    url = "/api/v3/genomic_scores/score_descs/no_such_score"
+    response = user_client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_score_descs_memo_hit_keyed_by_score_id(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    render_calls = 0
+    original_render = cached_response.JSONRenderer.render
+
+    def counting_render(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal render_calls
+        render_calls += 1
+        return original_render(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        cached_response.JSONRenderer, "render", counting_render,
+    )
+
+    all_url = "/api/v3/genomic_scores/score_descs"
+    single_url = "/api/v3/genomic_scores/score_descs/score_one"
+
+    first_all = user_client.get(all_url)
+    second_all = user_client.get(all_url)
+    first_single = user_client.get(single_url)
+    second_single = user_client.get(single_url)
+
+    assert first_all.content == second_all.content
+    assert first_single.content == second_single.content
+    # all and single are distinct cache keys (extra=score_id) -> 2 renders
+    assert render_calls == 2

--- a/web_api/gpf_web/genomic_scores_api/tests/test_genomic_scores_api.py
+++ b/web_api/gpf_web/genomic_scores_api/tests/test_genomic_scores_api.py
@@ -1,5 +1,9 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613,too-many-lines
+import threading
+from typing import Any
+
 import pytest
+from datasets_api import permissions
 from django.test.client import Client
 from gpf_instance.gpf_instance import WGPFInstance
 from rest_framework import status
@@ -59,6 +63,86 @@ def test_get_genomic_scores_memo_hit(
     assert second.status_code == status.HTTP_200_OK, repr(second.content)
     assert first.content == second.content
     assert render_calls == 1
+
+
+def test_get_genomic_scores_reload_invalidates(
+    user_client: Client,
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bumping the instance timestamp re-renders and changes the ETag."""
+    url = "/api/v3/genomic_scores"
+
+    render_calls = 0
+    original_render = cached_response.JSONRenderer.render
+
+    def counting_render(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal render_calls
+        render_calls += 1
+        return original_render(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        cached_response.JSONRenderer, "render", counting_render,
+    )
+
+    first = user_client.get(url)
+    assert first.status_code == status.HTTP_200_OK, repr(first.content)
+    assert render_calls == 1
+
+    # Simulate an instance reload by advancing the load timestamp.  Both
+    # the cache key (in cached_response) and the ETag (computed by
+    # datasets_api.permissions.get_instance_timestamp_etag) read this
+    # timestamp, so both must observe the bump in lockstep.
+    original_timestamp = cached_response.get_instance_timestamp
+
+    def bumped_timestamp(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return original_timestamp(*args, **kwargs) + 1000.0
+
+    monkeypatch.setattr(
+        cached_response, "get_instance_timestamp", bumped_timestamp,
+    )
+    monkeypatch.setattr(
+        permissions, "get_instance_timestamp", bumped_timestamp,
+    )
+
+    second = user_client.get(url)
+    assert second.status_code == status.HTTP_200_OK, repr(second.content)
+    assert render_calls == 2
+    assert first.content == second.content
+    assert first.headers["ETag"] != second.headers["ETag"]
+
+
+def test_cached_json_response_concurrent_cold_cache(
+    t4c8_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup WGPF instance
+) -> None:
+    """Concurrent cold-cache callers all get the byte-identical render."""
+    payload = [{"score": "score_one", "value": list(range(100))}]
+
+    def build() -> list[dict[str, Any]]:
+        return payload
+
+    reference = cached_response.JSONRenderer().render(payload)
+
+    barrier = threading.Barrier(8)
+    results: list[bytes] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        barrier.wait()
+        response = cached_response.cached_json_response(
+            "concurrent_instance", build,
+        )
+        with results_lock:
+            results.append(response.content)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 8
+    assert all(body == reference for body in results)
 
 
 def test_get_genomic_scores_if_none_match_304(

--- a/web_api/gpf_web/genomic_scores_api/views.py
+++ b/web_api/gpf_web/genomic_scores_api/views.py
@@ -1,32 +1,36 @@
+from typing import Any
 
 from datasets_api.permissions import get_instance_timestamp_etag
+from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import etag
 from query_base.query_base import QueryBaseView
 from rest_framework import status
 from rest_framework.request import Request
-from rest_framework.response import Response
+from utils.cached_response import cached_json_response
 
 
 class GenomicScoresView(QueryBaseView):
     """View for genomic scores database for the instance."""
 
     @method_decorator(etag(get_instance_timestamp_etag))
-    def get(self, _request: Request) -> Response:
+    def get(self, _request: Request) -> HttpResponse:
         """List all genomic scores used by the GPF instance."""
-        res = []
-        registry = self.gpf_instance.genomic_scores
-        for score_id, score in registry.get_scores():
-            res.append({
-                "score": score_id,
-                "desc": score.description,
-                "histogram": score.hist.to_dict(),
-                "help": score.help,
-                "small_values_desc": score.small_values_desc,
-                "large_values_desc": score.large_values_desc,
-            })
+        def build() -> list[dict[str, Any]]:
+            res = []
+            registry = self.gpf_instance.genomic_scores
+            for score_id, score in registry.get_scores():
+                res.append({
+                    "score": score_id,
+                    "desc": score.description,
+                    "histogram": score.hist.to_dict(),
+                    "help": score.help,
+                    "small_values_desc": score.small_values_desc,
+                    "large_values_desc": score.large_values_desc,
+                })
+            return res
 
-        return Response(res)
+        return cached_json_response(self.instance_id, build)
 
 
 class GenomicScoreDescsView(QueryBaseView):
@@ -35,21 +39,18 @@ class GenomicScoreDescsView(QueryBaseView):
     @method_decorator(etag(get_instance_timestamp_etag))
     def get(
         self, _request: Request, score_id: str | None = None,
-    ) -> Response:
+    ) -> HttpResponse:
         """Convert all genomic score descs into a JSON list."""
         registry = self.gpf_instance.genomic_scores
 
-        res = []
-        if score_id is not None:
-            if score_id not in registry:
-                return Response(status=status.HTTP_404_NOT_FOUND)
-            scores = [
-                (score_id, registry[score_id]),
-            ]
-        else:
-            scores = registry.get_scores()
+        if score_id is not None and score_id not in registry:
+            return HttpResponse(status=status.HTTP_404_NOT_FOUND)
 
-        for _, score in scores:
-            res.append(score.to_json())
+        def build() -> list[Any]:
+            if score_id is not None:
+                scores = [(score_id, registry[score_id])]
+            else:
+                scores = registry.get_scores()
+            return [score.to_json() for _, score in scores]
 
-        return Response(res)
+        return cached_json_response(self.instance_id, build, score_id)

--- a/web_api/gpf_web/utils/cached_response.py
+++ b/web_api/gpf_web/utils/cached_response.py
@@ -24,7 +24,13 @@ from rest_framework.renderers import JSONRenderer
 
 CACHE_CONTROL = "public, max-age=3600"
 
-_MAX_ENTRIES = 2
+# The cache is shared across views (the "all" entries plus one entry per
+# distinct ``score_descs/<score_id>`` request).  A small cap of 2 would let
+# the per-score_id keys evict the two hot "all" entries and cause re-render
+# thrash, so the bound is generous; each entry is a tiny ``bytes`` blob, so
+# 16 entries is negligible memory.  Eviction is insertion-order (FIFO):
+# evict the oldest-inserted key when the cap is exceeded.
+_MAX_ENTRIES = 16
 _CACHE: dict[tuple[Any, ...], bytes] = {}
 _CACHE_LOCK = Lock()
 
@@ -47,6 +53,10 @@ def _get_or_render(
         if cached is not None:
             return cached
 
+    # Render outside the lock so an expensive serialization never blocks
+    # concurrent requests.  Deliberate trade-off: concurrent cold misses on
+    # the same key may each render once (the last writer wins on insert);
+    # the rendered bytes are byte-identical, so callers are unaffected.
     body: bytes = JSONRenderer().render(build())
 
     with _CACHE_LOCK:

--- a/web_api/gpf_web/utils/cached_response.py
+++ b/web_api/gpf_web/utils/cached_response.py
@@ -1,0 +1,78 @@
+"""In-process memoization of pre-rendered JSON responses.
+
+``GET`` endpoints that serialize large, instance-static payloads (e.g.
+the genomic scores registry with all of its histograms) are expensive
+to re-render on every request even though the result only changes when
+the GPF instance is reloaded.
+
+This module memoizes the *rendered JSON bytes* keyed by the instance id
+and the instance-load timestamp, so the serialization runs once per
+instance load.  The helper is designed to compose under the existing
+``etag(get_instance_timestamp_etag)`` decorator: that decorator handles
+conditional ``304`` short-circuiting before the view body runs, so the
+build function here only ever executes for a ``200``.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import Lock
+from typing import Any
+
+from django.http import HttpResponse
+from gpf_instance.gpf_instance import get_instance_timestamp
+from rest_framework.renderers import JSONRenderer
+
+CACHE_CONTROL = "public, max-age=3600"
+
+_MAX_ENTRIES = 2
+_CACHE: dict[tuple[Any, ...], bytes] = {}
+_CACHE_LOCK = Lock()
+
+
+def _get_or_render(
+    key: tuple[Any, ...], build: Callable[[], Any],
+) -> bytes:
+    """Return memoized JSON bytes for ``key``, rendering on a miss.
+
+    ``build`` returns the plain-Python payload; it is serialized with
+    DRF's :class:`JSONRenderer` so the bytes are byte-identical to what
+    a DRF ``Response`` would have produced (numpy scalars included).
+
+    The cache is bounded to ``_MAX_ENTRIES`` with simple
+    insertion-order eviction; the key already includes the instance
+    timestamp, so a reload naturally produces fresh entries.
+    """
+    with _CACHE_LOCK:
+        cached = _CACHE.get(key)
+        if cached is not None:
+            return cached
+
+    body: bytes = JSONRenderer().render(build())
+
+    with _CACHE_LOCK:
+        _CACHE[key] = body
+        while len(_CACHE) > _MAX_ENTRIES:
+            oldest = next(iter(_CACHE))
+            del _CACHE[oldest]
+    return body
+
+
+def cached_json_response(
+    instance_id: str,
+    build: Callable[[], Any],
+    *extra: Any,
+) -> HttpResponse:
+    """Return a cached ``application/json`` response.
+
+    The rendered body is memoized in-process keyed by
+    ``(instance_id, get_instance_timestamp(), extra)``.  Including
+    ``instance_id`` prevents cross-fixture leakage in tests; ``extra``
+    carries any view-varying parameter (e.g. an optional path segment).
+
+    The response carries ``Cache-Control: public, max-age=3600``.
+    """
+    key = (instance_id, get_instance_timestamp(), *extra)
+    body = _get_or_render(key, build)
+    response = HttpResponse(body, content_type="application/json")
+    response["Cache-Control"] = CACHE_CONTROL
+    return response


### PR DESCRIPTION
## Summary

Fixes the ~1.5s, uncached `GET /api/v3/genomic_scores` endpoint observed on production (gpf.sfari.org).

Closes #941.

### Problem
The genomic scores registry is a process-singleton (built once), but the view re-serialized every histogram (`hist.to_dict()` → `.tolist()` over large numpy arrays) and DRF-rendered JSON on **every** 200. The endpoint had an ETag but **no** `Cache-Control` and **no** server-side body memo, so each call paid the full cost and browsers/proxies never reused the result.

### Change
- New reusable helper `web_api/gpf_web/utils/cached_response.py`:
  - Memoizes **pre-rendered JSON bytes** in a bounded (16-entry), lock-guarded module dict keyed by `(instance_id, get_instance_timestamp(), *extra)` — auto-invalidates on instance reload; `instance_id` prevents cross-instance/test leakage.
  - Renders via DRF `JSONRenderer` so bytes are byte-identical to the prior `Response` output.
  - Returns a plain `HttpResponse` with `Cache-Control: public, max-age=3600`, composed under the existing `etag(get_instance_timestamp_etag)` decorator (304s short-circuit before the helper; it runs only for 200s).
  - Render happens outside the lock — concurrent cold misses may render more than once, but bytes are identical so callers are unaffected (gthread-safe).
- `GenomicScoresView` (key: instance+timestamp) and `GenomicScoreDescsView` (key: + `score_id`) routed through the helper; identical JSON shape and 404 behavior preserved.

### Why `public` is safe
The endpoint authenticates but has no `permission_classes` (effective AllowAny) and returns instance-wide data identical for every caller, so a shared cache serving one user's response to another is correct; no `Vary` needed.

### Tests
- `response.data` → `response.json()`.
- `Cache-Control: public, max-age=3600` present.
- Memo hit returns identical payload (spies `JSONRenderer.render`, asserts a single render across two requests).
- Per-`score_id` keying renders distinctly.
- Instance-reload (timestamp bump) invalidates the memo and changes the ETag.
- Concurrency: 8 threads on a cold cache all get byte-identical bodies.
- `If-None-Match` still yields `304`.

`uv run pytest -v gpf_web/genomic_scores_api/` → 10 passed. `ruff` + `mypy` clean.

### Net effect
First call after an instance reload pays the build cost once per worker; every subsequent call is a memo hit (~ms), and browsers skip the round-trip for an hour.

### Deferred (follow-ups, not in this PR)
- Rolling the helper across the rest of the `get_instance_timestamp_etag` endpoint family (`gene_scores`, `genomes`, `gene_profiles`, …).
- Investigating whether dropping OAuth auth on these permission-less public endpoints shaves further latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
