### PR TITLE
fix(parquet): adopt gain Attribute.get_value_type() (Closes #943)

### DIFF
--- a/core/gpf/parquet/schema2/processing_pipeline.py
+++ b/core/gpf/parquet/schema2/processing_pipeline.py
@@ -59,8 +59,8 @@ class AnnotationPipelineVariantsFilterMixin:
             if key in self._annotation_internal_attributes:
                 continue
             ainfo = self.annotation_pipeline.get_attribute_info(key)
-            if ainfo and ainfo.value_type == "str" and value is not None and \
-                    not isinstance(value, str):
+            if ainfo and ainfo.get_value_type() == "str" \
+                    and value is not None and not isinstance(value, str):
                 value = stringify(value)
             public_attributes[key] = value
         summary_allele.update_attributes(public_attributes)

--- a/core/gpf/parquet/schema2/serializers.py
+++ b/core/gpf/parquet/schema2/serializers.py
@@ -98,11 +98,11 @@ def build_summary_schema(
         for attr in annotation_schema:
             if attr.internal:
                 continue
-            if attr.value_type in annotation_type_to_pa_type:
+            if attr.get_value_type() in annotation_type_to_pa_type:
                 fields.append(
                     pa.field(
                         attr.name,
-                        annotation_type_to_pa_type[attr.value_type],
+                        annotation_type_to_pa_type[attr.get_value_type()],
                     ),
                 )
     return pa.schema(fields)

--- a/core/gpf/studies/variants_db.py
+++ b/core/gpf/studies/variants_db.py
@@ -280,7 +280,7 @@ class VariantsDb:
                 "name": attribute.name,
                 "source": attribute.name,
             }
-            if attribute.value_type == "float":
+            if attribute.get_value_type() == "float":
                 column["format"] = "%.5f"
             result.append(column)
         return result


### PR DESCRIPTION
## Problem

`gpf-rest-client-integration` has been red every run since build 347 (last green: 346) — and the gpf source is the **same pinned commit** `3606a8b` across both. The nightly re-runs that pinned gpf against the **floating gain wheel** (`gain-core` from `iossifovlab/gain/master` lastSuccessful), so it goes red when gain master breaks compatibility.

gain commit **`bf05bdcde` "Fix aggregators displaying on frontend" (2026-06-18)** removed the plain `Attribute.value_type` field, replacing it with a method `get_value_type(*, aggregated=True)` (so an aggregator's `output_value_type` can take precedence; the raw spec type stays at `attr.spec.value_type`). gpf still read `attr.value_type`, so the integration backend crashed during the t4c8 instance seed:

```
core/gpf/parquet/schema2/serializers.py:101, in build_summary_schema
    if attr.value_type in annotation_type_to_pa_type:
AttributeError: 'Attribute' object has no attribute 'value_type'. Did you mean: 'get_value_type'?
```

The seed never completes → the backend container exits 1 → the runner aborts with `dependency failed to start: backend exited (1)` (the fast-fail mode of builds 348–353).

## Fix

Replace `attr.value_type` → `attr.get_value_type()` at the three gain-`Attribute` call sites:

- `core/gpf/parquet/schema2/serializers.py` — import-time parquet schema (the crash)
- `core/gpf/parquet/schema2/processing_pipeline.py` — import-time allele processing
- `core/gpf/studies/variants_db.py` — query-time download columns

`get_value_type()` defaults to `aggregated=True`, i.e. the produced value type — the correct replacement for all three (schema column type / produced-value handling).

## Verification

Reproduced the t4c8 seed locally against gain master-tip (`e3a8393a0`):
- **Before:** `AttributeError` in `build_summary_schema`.
- **After:** `>>> SEED COMPLETED OK <<<` — single self-contained API break, not the first of a cascade.

`ruff check` passes on all three files.

Closes #943. Companion observability fix tracked in #944 (capture backend logs in `Jenkinsfile.integration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
