### PR TITLE
ci(integration): clean copied dist wheels before fetching gain (rest_client + federation)

### DIFF
--- a/federation/Jenkinsfile.integration
+++ b/federation/Jenkinsfile.integration
@@ -120,6 +120,14 @@ pipeline {
             //     sources via uv sync, so dist/core / dist/web_api
             //     would be dead weight here.
             steps {
+                // Stale-artifact guard: this agent's workspace persists
+                // across builds and copyArtifacts only *adds* files, so
+                // dist/gain/ otherwise accumulates every past gain wheel.
+                // uv's --find-links then resolves gain-core to the
+                // highest *version* present, which silently picks a stale
+                // wheel if gain master is ever rolled back. Wipe the copy
+                // targets so only this build's fetched wheel is present.
+                sh 'rm -rf dist/core dist/web_api dist/gain'
                 script {
                     if (params.UPSTREAM_PROJECT?.trim()) {
                         copyArtifacts(

--- a/rest_client/Jenkinsfile.integration
+++ b/rest_client/Jenkinsfile.integration
@@ -121,6 +121,14 @@ pipeline {
             //     sources via uv sync, so dist/core / dist/web_api
             //     would be dead weight here.
             steps {
+                // Stale-artifact guard: this agent's workspace persists
+                // across builds and copyArtifacts only *adds* files, so
+                // dist/gain/ otherwise accumulates every past gain wheel.
+                // uv's --find-links then resolves gain-core to the
+                // highest *version* present, which silently picks a stale
+                // wheel if gain master is ever rolled back. Wipe the copy
+                // targets so only this build's fetched wheel is present.
+                sh 'rm -rf dist/core dist/web_api dist/gain'
                 script {
                     if (params.UPSTREAM_PROJECT?.trim()) {
                         copyArtifacts(


### PR DESCRIPTION
## Problem

The `gpf-rest-client-integration` and `gpf-federation-integration` jobs stage the `gain-core` wheel into `dist/gain/` via `copyArtifacts`, on a **persistent agent workspace that nothing cleans** — the "Prepare workspace" stage only wipes `reports/`. Since `copyArtifacts` only *adds* files, `dist/gain/` accumulates the gain wheel from every past build.

[rest-client-integration #353](https://nemo.seqpipe.org/job/gpf-rest-client-integration/353) carried **24** stale wheels:

```
dist/gain/gain_core-2026.5.7.post1.dev1+g7544c4dda.d20260527-py3-none-any.whl
...  (22 more, spanning 2026.5.7 .. 2026.6.7)
dist/gain/gain_core-2026.6.7.post1.dev38+ge3a8393a0.d20260620-py3-none-any.whl
```

The Dockerfile's `uv sync --find-links ./dist/gain --upgrade-package gain-core` then resolves `gain-core` to the **highest version present**, not necessarily the wheel this build just fetched. It coincides while gain master advances monotonically — but if gain master is ever rolled back, uv resolves to a stale higher-versioned wheel and the job **silently tests the wrong gain**, defeating the drift-detection these nightlies exist for. It also grows the workspace and docker build context without bound.

## Fix

Wipe the `copyArtifacts` targets (`dist/core`, `dist/web_api`, `dist/gain`) at the start of the "Fetch gain wheel" stage in **both** Jenkinsfiles, so only this build's freshly-fetched wheel is present.

A plain `rm` (not the docker-alpine dance `reports/` needs) is correct here: these wheels are written by `copyArtifacts` as the jenkins user and only *read* by the docker build — never written as root.

## Verification

- Both files pass the Jenkins declarative linter (validated against the live controller — `copyArtifacts`, `zulipSend`, etc. all resolve).
- Change is identical and self-documenting in each file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
