### PR TITLE
ci(integration): label builds with branch @ commit (rest_client + federation)

### DIFF
--- a/federation/Jenkinsfile.integration
+++ b/federation/Jenkinsfile.integration
@@ -57,10 +57,24 @@ pipeline {
     stages {
         stage('Start') {
             steps {
-                zulipSend(
-                    message: "Started build #${env.BUILD_NUMBER} of project ${env.JOB_NAME} (${env.BUILD_URL})",
-                    topic: "${env.JOB_NAME}",
-                )
+                script {
+                    // Replace the default '#42' with '#42 <branch>'
+                    // (plus '@<short-sha>' on manual COMMIT_SHA pins) so
+                    // the build list shows which branch a build is for —
+                    // mirrors web_e2e/Jenkinsfile.e2e. Set before any
+                    // stage that can fail so it survives early aborts;
+                    // Checkout refines it with the resolved commit.
+                    String label = params.BRANCH_NAME
+                    if (params.COMMIT_SHA?.trim()) {
+                        label += " @ ${params.COMMIT_SHA.take(7)}"
+                    }
+                    currentBuild.displayName =
+                        "#${env.BUILD_NUMBER} ${label}"
+                    zulipSend(
+                        message: "Started build #${env.BUILD_NUMBER} [${label}] of project ${env.JOB_NAME} (${env.BUILD_URL})",
+                        topic: "${env.JOB_NAME}",
+                    )
+                }
             }
         }
 
@@ -80,7 +94,7 @@ pipeline {
                 script {
                     String ref = params.COMMIT_SHA?.trim() ?: \
                                  params.BRANCH_NAME
-                    checkout([
+                    def scmVars = checkout([
                         $class: 'GitSCM',
                         branches: [[name: ref]],
                         userRemoteConfigs: [[
@@ -91,6 +105,12 @@ pipeline {
                                       noTags: true,
                                       depth: 1]],
                     ])
+                    // Refine the build label with the actually-resolved
+                    // commit — nightly triggers pass BRANCH_NAME only,
+                    // no COMMIT_SHA, so this is where the sha appears.
+                    currentBuild.displayName =
+                        "#${env.BUILD_NUMBER} ${params.BRANCH_NAME}" +
+                        " @ ${scmVars.GIT_COMMIT.take(7)}"
                 }
             }
         }

--- a/rest_client/Jenkinsfile.integration
+++ b/rest_client/Jenkinsfile.integration
@@ -58,10 +58,24 @@ pipeline {
     stages {
         stage('Start') {
             steps {
-                zulipSend(
-                    message: "Started build #${env.BUILD_NUMBER} of project ${env.JOB_NAME} (${env.BUILD_URL})",
-                    topic: "${env.JOB_NAME}",
-                )
+                script {
+                    // Replace the default '#42' with '#42 <branch>'
+                    // (plus '@<short-sha>' on manual COMMIT_SHA pins) so
+                    // the build list shows which branch a build is for —
+                    // mirrors web_e2e/Jenkinsfile.e2e. Set before any
+                    // stage that can fail so it survives early aborts;
+                    // Checkout refines it with the resolved commit.
+                    String label = params.BRANCH_NAME
+                    if (params.COMMIT_SHA?.trim()) {
+                        label += " @ ${params.COMMIT_SHA.take(7)}"
+                    }
+                    currentBuild.displayName =
+                        "#${env.BUILD_NUMBER} ${label}"
+                    zulipSend(
+                        message: "Started build #${env.BUILD_NUMBER} [${label}] of project ${env.JOB_NAME} (${env.BUILD_URL})",
+                        topic: "${env.JOB_NAME}",
+                    )
+                }
             }
         }
 
@@ -81,7 +95,7 @@ pipeline {
                 script {
                     String ref = params.COMMIT_SHA?.trim() ?: \
                                  params.BRANCH_NAME
-                    checkout([
+                    def scmVars = checkout([
                         $class: 'GitSCM',
                         branches: [[name: ref]],
                         userRemoteConfigs: [[
@@ -92,6 +106,12 @@ pipeline {
                                       noTags: true,
                                       depth: 1]],
                     ])
+                    // Refine the build label with the actually-resolved
+                    // commit — nightly triggers pass BRANCH_NAME only,
+                    // no COMMIT_SHA, so this is where the sha appears.
+                    currentBuild.displayName =
+                        "#${env.BUILD_NUMBER} ${params.BRANCH_NAME}" +
+                        " @ ${scmVars.GIT_COMMIT.take(7)}"
                 }
             }
         }


### PR DESCRIPTION
## What

Label `gpf-rest-client-integration` and `gpf-federation-integration` builds with the branch and commit, the way `gpf-web-e2e` already does (e.g. `#305 master @ 3606a8b`). These two jobs previously showed only `#353` in the build list, giving no hint which branch/commit a run tested.

## How

Mirrors `web_e2e/Jenkinsfile.e2e`:

- **Start stage** sets `currentBuild.displayName = "#<N> <branch>"` (plus `@<short-sha>` when a `COMMIT_SHA` is explicitly pinned) — set early so the label survives an early-abort, and adds the `[branch]` tag to the "Started build" Zulip message.
- **Checkout stage** refines it to `"#<N> <branch> @ <short-sha>"` from the actually-resolved `GIT_COMMIT`.

The resolved-commit refinement is the one deviation from web_e2e, and it's deliberate: the nightly triggers these jobs with `BRANCH_NAME` only and **no `COMMIT_SHA`** (unlike the gpf-master pipeline, which passes `COMMIT_SHA` to web_e2e). A params-only label would therefore read just `master` on every nightly run; reading `GIT_COMMIT` from the checkout captures the commit regardless of how the job was triggered.

## Verification

Both files pass the Jenkins declarative linter (validated against the live controller). Change is identical in both files.
