### PR TITLE
fix(parquet): key summary schema on raw spec value type (Closes #949)

### DIFF
--- a/core/gpf/parquet/schema2/processing_pipeline.py
+++ b/core/gpf/parquet/schema2/processing_pipeline.py
@@ -59,7 +59,13 @@ class AnnotationPipelineVariantsFilterMixin:
             if key in self._annotation_internal_attributes:
                 continue
             ainfo = self.annotation_pipeline.get_attribute_info(key)
-            if ainfo and ainfo.get_value_type() == "str" \
+            # Raw declared (spec) type, NOT the post-aggregation type:
+            # a str score's default `list` aggregator reports
+            # get_value_type()=="list", so the aggregated list value would
+            # not be stringified and would clash with the pa.string()
+            # column build_summary_schema stores it in. Keep in lockstep
+            # with serializers.py; do NOT change to aggregated=True.
+            if ainfo and ainfo.get_value_type(aggregated=False) == "str" \
                     and value is not None and not isinstance(value, str):
                 value = stringify(value)
             public_attributes[key] = value

--- a/core/gpf/parquet/schema2/serializers.py
+++ b/core/gpf/parquet/schema2/serializers.py
@@ -98,11 +98,19 @@ def build_summary_schema(
         for attr in annotation_schema:
             if attr.internal:
                 continue
-            if attr.get_value_type() in annotation_type_to_pa_type:
+            # Use the raw declared (spec) value type, NOT the
+            # post-aggregation type. A str score's default `list`
+            # aggregator reports get_value_type()=="list", which isn't a
+            # scalar parquet type and would drop the column (e.g. CLNSIG)
+            # so score filters later fail with a duckdb Binder error. The
+            # aggregated value is stringified into this column (see
+            # processing_pipeline.py). Do NOT change to aggregated=True.
+            value_type = attr.get_value_type(aggregated=False)
+            if value_type in annotation_type_to_pa_type:
                 fields.append(
                     pa.field(
                         attr.name,
-                        annotation_type_to_pa_type[attr.get_value_type()],
+                        annotation_type_to_pa_type[value_type],
                     ),
                 )
     return pa.schema(fields)

--- a/core/gpf/studies/variants_db.py
+++ b/core/gpf/studies/variants_db.py
@@ -280,7 +280,9 @@ class VariantsDb:
                 "name": attribute.name,
                 "source": attribute.name,
             }
-            if attribute.get_value_type() == "float":
+            # Raw declared (spec) type, matching the storage schema
+            # (serializers.py) rather than the post-aggregation type.
+            if attribute.get_value_type(aggregated=False) == "float":
                 column["format"] = "%.5f"
             result.append(column)
         return result

--- a/core/tests/small/parquet/schema2/test_summary_schema_value_type.py
+++ b/core/tests/small/parquet/schema2/test_summary_schema_value_type.py
@@ -1,0 +1,99 @@
+"""Regression (#949): summary-parquet storage keys on the raw declared
+(spec) value type, not the post-aggregation type.
+
+A ``str`` genomic score defaults to the ``list`` position/allele
+aggregator (``ListAggregator.output_value_type == "list"``). Two coupled
+sites must therefore look at the spec type, not the aggregated type:
+
+* ``build_summary_schema`` -- keying the column on ``"list"`` drops it
+  (not a scalar parquet type), so score-filter queries later fail with
+  ``Binder Error: Table "sa" does not have a column named "CLNSIG"`` and
+  return zero variants.
+* the annotation stringify gate -- a ``list`` value must be stringified
+  into the ``pa.string()`` column the schema reserves for it.
+
+If only one of the two is changed, a list value clashes with its column,
+so both are tested here together.
+"""
+from types import SimpleNamespace
+
+import pyarrow as pa
+from gain.annotation.annotate_utils import stringify
+from gain.annotation.annotation_config import Attribute
+from gain.annotation.annotation_pipeline import AttributeSpec
+from gain.genomic_resources.aggregators import (
+    ListAggregator,
+    MeanAggregator,
+)
+
+from gpf.parquet.schema2.processing_pipeline import (
+    AnnotationPipelineVariantsFilterMixin,
+)
+from gpf.parquet.schema2.serializers import build_summary_schema
+
+
+def _attr(value_type: str, aggregator: object) -> Attribute:
+    return Attribute(
+        "score", "SCORE", internal=False,
+        spec=AttributeSpec(
+            source="SCORE", value_type=value_type,
+            description="", internal_default=False),
+        aggregator_instance=aggregator,
+    )
+
+
+def test_str_score_with_list_aggregator_is_kept_as_string_column() -> None:
+    # ListAggregator.output_value_type == "list"; keying on that drops the
+    # column. The spec type "str" must win -> pa.string().
+    schema = build_summary_schema([_attr("str", ListAggregator())])
+
+    assert "score" in schema.names
+    assert schema.field("score").type == pa.string()
+
+
+def test_score_column_keys_on_spec_type_not_aggregator_output() -> None:
+    # MeanAggregator.output_value_type == "float". The column must follow
+    # the declared spec type ("int" -> int32), locking in aggregated=False;
+    # a regression to aggregated=True would type this column as float32.
+    schema = build_summary_schema([_attr("int", MeanAggregator())])
+
+    assert schema.field("score").type == pa.int32()
+
+
+class _OneAttrPipeline:
+    """Minimal annotation-pipeline stand-in exposing only what the
+    variants filter mixin reads: the attribute set and per-key lookup."""
+
+    def __init__(self, attr: Attribute) -> None:
+        self._attr = attr
+
+    def get_attributes(self) -> list[Attribute]:
+        return [self._attr]
+
+    def get_attribute_info(self, key: str) -> Attribute | None:
+        return self._attr if key == self._attr.name else None
+
+
+class _RecordingAllele:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+
+    def update_attributes(self, attributes: dict[str, object]) -> None:
+        self.attributes.update(attributes)
+
+
+def test_list_value_for_str_score_is_stringified_for_storage() -> None:
+    # The coupled half: a str-typed score whose aggregated value is a list
+    # must be stringified, so it fits the pa.string() column the schema
+    # reserves. Driven by the spec type ("str"), not get_value_type()
+    # ("list") -- otherwise the raw list would clash with the column.
+    attr = _attr("str", ListAggregator())
+    flt = AnnotationPipelineVariantsFilterMixin(_OneAttrPipeline(attr))
+    allele = _RecordingAllele()
+    annotation = SimpleNamespace(context={"score": ["Pathogenic", "Benign"]})
+
+    flt._apply_annotation_to_allele(allele, annotation)
+
+    stored = allele.attributes["score"]
+    assert isinstance(stored, str)
+    assert stored == stringify(["Pathogenic", "Benign"])


### PR DESCRIPTION
Closes #949.

## Problem

`gpf-web-e2e` #307 (first run of merged #945 against current gain) failed 6 `genomic-scores-block` / `genotype-browser` specs — every one: filtering by a genomic score returns **0 variants selected**. The wdae log shows the real cause:

```
_duckdb.BinderException: Binder Error: Table "sa" does not have a column named "CLNSIG"
```

The ClinVar **categorical (str) score** columns `CLNSIG`/`CLNDN` are missing from the summary-alleles parquet, so any query filtering on them throws and returns nothing.

## Root cause

Regression from #945. `build_summary_schema` keeps a column only if its value type ∈ `{float,int,str}`. #945 changed `attr.value_type` → `attr.get_value_type()`, whose default `aggregated=True` returns the **aggregator's** output type. A `str` score's default aggregator is `list` (gain `genomic_scores.py`), whose `output_value_type` is `"list"` — not in the map → the column is dropped at import → the BinderException above.

## Fix

Use `attr.get_value_type(aggregated=False)` — the raw declared (spec) type — at the three sites #945 touched, restoring the long-standing spec-type column keying:

| site | role |
|---|---|
| `parquet/schema2/serializers.py` | summary column type (the drop) |
| `parquet/schema2/processing_pipeline.py` | stringify gate (coupled — a list value must be stringified into the `pa.string()` column the schema reserves) |
| `studies/variants_db.py` | download float format |

Each site has an explanatory comment ("do NOT change to `aggregated=True`") so the coupling isn't accidentally reverted.

## Tests

New `core/tests/small/parquet/schema2/test_summary_schema_value_type.py` (verified red→green):
- str score + `ListAggregator` ⇒ kept as `pa.string()` column (the #307 bug).
- int score + `MeanAggregator` (output `"float"`) ⇒ column stays `int32` — locks in `aggregated=False` against a future revert.
- the coupled stringify gate: a `list` value for a str score is stringified for storage.

`ruff` + `mypy` clean on all three source files.

## Scope / follow-up

- **Richer typed storage** for `list`/`object`/`bool` aggregator outputs (instead of stringify/spec-coerce) is deferred to **#948**.
- Note for #948: this keys columns on the **spec** type, so a type-changing aggregator (e.g. `mean` over an `int` score → `float` value) gets an `int` column. That matches the dominant str/list case and the historical spec-type property, but #948 should not assume a *pure* restore for type-changing aggregators.

## Verification gate

`gpf-web-e2e` green on this branch (the 6 previously-failing specs) is the merge gate — running now via the branch pipeline.

A subagent code review was run on the diff; its findings (add the coupled stringify test, add the int/float assertion, document the mean-over-int nuance) are all addressed here.
