### PR TITLE
ci(e2e): run e2e db on mysql:8.0.33 for production parity (#845)

### DIFF
--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -554,7 +554,7 @@ pipeline {
                             # re-created (its container was created
                             # for an earlier `up` cycle) and re-runs
                             # the whole import. Two imports against
-                            # the same MariaDB volume produce duplicate
+                            # the same MySQL volume produce duplicate
                             # rows in datasets_api_dataset, which then
                             # trip MultipleObjectsReturned in
                             # gpf_instance.reload_datasets and 500 on

--- a/web_e2e/README.md
+++ b/web_e2e/README.md
@@ -226,7 +226,7 @@ docker compose -p "$COMPOSE_PROJECT" -f web_infra/compose-jenkins.yaml -f "$OVER
     down -v --remove-orphans
 ```
 
-`-v` removes the named MariaDB volume; on next start `instance-import` re-runs from a clean DB.
+`-v` removes the named MySQL volume; on next start `instance-import` re-runs from a clean DB.
 
 ### What's special about the compose stack
 

--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -39,40 +39,59 @@ services:
     command: echo "MySQL data only container"
 
   db:
-    # MariaDB rather than mysql:5.7: same wire protocol, the
-    # production image already has libmariadb3 for the client
-    # side, and the upstream MySQL 5.7 image is EOL.
-    image: mariadb:10.11
+    # mysql:8.0.33 — engine + tag parity with production (gpf#845).
+    # Every prod host (SFARI sparkgpf-prod, gpf-infra dory) pins
+    # mysql:8.0.33 via gpf-infra group_vars (mysql_version_tag). CI
+    # previously ran MariaDB 10.11, which silently accepts schema
+    # operations MySQL 8 rejects — e.g. AlterField(TextField(
+    # unique=True)) -> "ERROR 1170 BLOB/TEXT column used in key
+    # specification without a key length", the #836 bug (PR #843)
+    # that broke a real deploy because no CI job exercised the
+    # migration on the production engine. This service mirrors
+    # gpf-infra/templates/compose.yaml.j2's db so an ORM migration
+    # that breaks on MySQL fails here instead of on deploy.
+    image: mysql:8.0.33
     restart: always
     volumes_from:
       - mysql-data
     environment:
-      MARIADB_DATABASE: gpf
-      MARIADB_USER: seqpipe
-      MARIADB_PASSWORD: secret
-      MARIADB_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: gpf
+      MYSQL_USER: seqpipe
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: secret
     command:
       - --character-set-server=utf8
       - --collation-server=utf8_bin
+      # MySQL 8 defaults to caching_sha2_password; force
+      # mysql_native_password so the libmariadb client baked into
+      # the gpf-web image authenticates. Matches prod.
+      - --default-authentication-plugin=mysql_native_password
     healthcheck:
+      # MySQL ships no healthcheck.sh (that's a MariaDB-image
+      # extra); use mysqladmin ping — the same probe gpf-infra prod
+      # uses.
       test:
         - CMD
-        - healthcheck.sh
-        - --connect
-        - --innodb_initialized
+        - mysqladmin
+        - ping
+        - -h
+        - localhost
+        - -u
+        - root
+        - -psecret
       interval: 10s
       timeout: 5s
-      retries: 5
       # Cold init every build: mysql-data declares no volume, so the
-      # data dir is ephemeral and MariaDB does a full first-boot
-      # bootstrap each run. Under concurrent e2e builds on one agent
-      # that can blow past retries*interval (~50s) and get marked
-      # unhealthy with no DB fault — gpf-web-e2e #109 failed here on
-      # the same SHA that #108 ran green. start_period stops failing
-      # checks from counting until init has had time to finish; a
-      # fast cold init still flips healthy at once, so the grace is
-      # effectively free.
-      start_period: 60s
+      # data dir is ephemeral and MySQL does a full first-boot
+      # bootstrap each run — ~30-60s slower than MariaDB was. Under
+      # concurrent e2e builds on one agent a small budget can blow
+      # past init and get marked unhealthy with no DB fault
+      # (gpf-web-e2e #109 hit this on MariaDB). start_period stops
+      # failing checks from counting until init has had time to
+      # finish; a fast cold init still flips healthy at once, so the
+      # grace is effectively free. retries 12 matches prod.
+      retries: 12
+      start_period: 90s
 
   mail:
     image: axllent/mailpit:latest

--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -67,15 +67,27 @@ services:
       # the gpf-web image authenticates. Matches prod.
       - --default-authentication-plugin=mysql_native_password
     healthcheck:
-      # MySQL ships no healthcheck.sh (that's a MariaDB-image
-      # extra); use mysqladmin ping — the same probe gpf-infra prod
-      # uses.
+      # MySQL ships no healthcheck.sh (that's a MariaDB-image extra);
+      # use mysqladmin ping — but over TCP (-h 127.0.0.1), NOT the
+      # default unix socket (-h localhost, the probe gpf-infra prod
+      # uses). On a cold data dir the MySQL entrypoint runs a
+      # *temporary* init server with --skip-networking to seed users:
+      # a socket ping succeeds against it and flips the container
+      # "healthy" while TCP 3306 is still closed. instance-import is
+      # gated on `service_healthy` and connects to db:3306 over TCP,
+      # so the socket probe let it start too early and it died with
+      # (2002, "Can't connect to server on 'db' (115)") — gpf-web-e2e
+      # #316. A TCP ping stays unhealthy through the skip-networking
+      # phase and only flips once the real networked server listens,
+      # which is exactly what the dependents need. Prod uses the
+      # socket probe safely because its volume persists, so it never
+      # does the cold-init temp-server dance on a normal boot.
       test:
         - CMD
         - mysqladmin
         - ping
         - -h
-        - localhost
+        - 127.0.0.1
         - -u
         - root
         - -psecret
@@ -83,15 +95,15 @@ services:
       timeout: 5s
       # Cold init every build: mysql-data declares no volume, so the
       # data dir is ephemeral and MySQL does a full first-boot
-      # bootstrap each run — ~30-60s slower than MariaDB was. Under
-      # concurrent e2e builds on one agent a small budget can blow
-      # past init and get marked unhealthy with no DB fault
-      # (gpf-web-e2e #109 hit this on MariaDB). start_period stops
-      # failing checks from counting until init has had time to
-      # finish; a fast cold init still flips healthy at once, so the
-      # grace is effectively free. retries 12 matches prod.
+      # bootstrap each run — much slower than MariaDB was (observed
+      # 4+ min on a slow agent). A success during start_period flips
+      # healthy immediately, so a long grace is effectively free; it
+      # only delays the *unhealthy* verdict for a genuinely broken
+      # db. Sized generously (start_period 300s + retries 12*10s) to
+      # tolerate slow cold init on the slowest agents without a
+      # premature unhealthy verdict.
       retries: 12
-      start_period: 90s
+      start_period: 300s
 
   mail:
     image: axllent/mailpit:latest


### PR DESCRIPTION
## What

Switch the gpf-web e2e stack's `db` service from `mariadb:10.11` to `mysql:8.0.33`, matching what every production host runs (SFARI `sparkgpf-prod`, gpf-infra dory — both pin `mysql:8.0.33` via `mysql_version_tag`).

Closes #845.

## Why

MariaDB and MySQL 8 disagree on schema operations in our migration history. MariaDB silently accepts `AlterField(TextField(unique=True))`; MySQL 8 rejects it with `ERROR 1170 (42000): BLOB/TEXT column used in key specification without a key length`. That exact bug (#836, fixed in PR #843) reached a **real deploy** (gpf-infra on dory, 2026-05-11) only because no CI job exercised the migration on the production engine. With this swap, that class of bug fails in CI instead of on deploy.

## How

`web_infra/compose-jenkins.yaml` `db` service now mirrors `gpf-infra/templates/compose.yaml.j2`:

- image `mariadb:10.11` → `mysql:8.0.33`
- `MARIADB_*` env → `MYSQL_*`
- add `--default-authentication-plugin=mysql_native_password` (the libmariadb client in the gpf-web image can't do MySQL 8's default `caching_sha2_password`)
- healthcheck `healthcheck.sh --connect --innodb_initialized` → `mysqladmin ping` (no `healthcheck.sh` in the MySQL image; same probe prod uses)
- `retries` 5 → 12, `start_period` 60s → 90s for MySQL's slower first-boot init

Also fixes two now-stale `MariaDB` references (a `Jenkinsfile.e2e` comment and `web_e2e/README.md`).

## Verified locally

Brought up the real `mysql:8.0.33` service from this compose file:

- server reports `8.0.33` / `utf8mb3` / `utf8mb3_bin` / `mysql_native_password`
- `seqpipe` user (created with `mysql_native_password`) connects; `gpf` database exists
- the `mysqladmin ping` healthcheck flips **healthy**
- both split + combined overlays `docker compose config` cleanly

**This PR is opened (rather than direct-pushed) specifically so the `gpf-web-e2e` pipeline validates the migration + fixture data against MySQL 8 before merge** — issue point #4 (fixture edge cases: zero dates, strict-mode trailing whitespace, reserved words) can only be confirmed by a full pipeline run.

## Out of scope (per the issue)

- The dead `web_e2e/scripts/run_mysql.sh` (`mysql:5.7`) local-dev script — Jenkinsfile.e2e doesn't invoke it.
- Extracting a shared `MYSQL_VERSION_TAG` so e2e / gpf-infra / SFARI move in lockstep — a cross-repo follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)