### PR TITLE
ci(e2e): tear down compose project in post.cleanup (Closes #952)

### DIFF
--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -676,6 +676,19 @@ pipeline {
         }
         cleanup {
             sh '''
+                # Backstop teardown of the whole compose project
+                # (db + volumes + network). The Run-e2e stage's own
+                # `down -v` only fires when the pipeline reaches that
+                # stage; a failure or abort earlier — most commonly
+                # instance-import dying during the mysql cold-init
+                # healthcheck window (#845/#316) — skips straight to
+                # post and would otherwise orphan the `db` container
+                # forever (#952). Keyed on $COMPOSE_PROJECT with no
+                # `-f` files so `down` resolves the project by label
+                # and still works even if checkout never ran.
+                docker compose -p "$COMPOSE_PROJECT" \
+                    down -v --remove-orphans 2>/dev/null || true
+
                 # $COMBINED_IMAGE is always defined in the env
                 # block, but only built/pulled when STACK_MODE
                 # = combined. `2>/dev/null || true` makes the


### PR DESCRIPTION
## Problem

`gpf-web-e2e` leaks the per-build `db` container (plus volume + network) whenever the pipeline fails or is aborted **before** reaching the `Run e2e` stage. Three orphans were found running on an agent:

```
gpf-web-e2e-316-db-1   mysql:8.0.33    # build #316, ~4h old
gpf-web-e2e-227-db-1   mariadb:10.11   # build #227, ~2w old
gpf-web-e2e-226-db-1   mariadb:10.11   # build #226, ~2w old
```

## Root cause

The only compose teardown (`docker compose down -v --remove-orphans`) lived in the `finally` block of the **Run e2e** stage. `post { cleanup }` only ran `docker rmi`. So teardown fired only if the pipeline reached Run-e2e; any earlier failure/abort skipped to `post` and orphaned `db`. The dominant path is `Import e2e instance` dying during the mysql cold-init healthcheck window (#845/#316).

The two mariadb orphans predate the mysql switch (#845), so this is a long-standing teardown-scope gap, not a regression — #845 just made import fail more often, surfacing it.

## Fix

Add a backstop teardown to `post { cleanup }`, keyed on `$COMPOSE_PROJECT` with no `-f` files so `down` resolves the project by label and works even if checkout never ran. The Run-e2e `finally` `down -v` stays as the prompt happy-path release.

Validated against the live controller's declarative linter (`validate_jenkinsfile` -> ok).

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)
