### PR TITLE
Add mysql CLI to gpf-web image so `wdaemanage dbshell` works

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -43,10 +43,17 @@ FROM ${PYTHON_IMAGE} AS runtime
 # libmagic1 + libmariadb3 + curl: same runtime deps as the
 # backend image (the venv we copy in expects them). apache2
 # + supervisor are the new pieces specific to this image.
+# default-mysql-client (mariadb-client) adds the `mysql` CLI
+# so `wdaemanage dbshell` works in the deployed container: the
+# Python driver only links libmariadb3, but Django's dbshell
+# shells out to the `mysql` binary. It also gives operators
+# mysqldump/mysqladmin against the configured DB from inside
+# the running app container.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         apache2 \
         curl \
+        default-mysql-client \
         libmagic1 \
         libmariadb3 \
         supervisor \


### PR DESCRIPTION
## What

Add `default-mysql-client` (mariadb-client) to the runtime stage of the combined `Dockerfile.production`.

## Why

The gpf-web image installs `libmariadb3` — the runtime library the Python `mysqlclient` driver links against — but **not** the `mysql` command-line binary. Django's `dbshell` shells out to that binary, so `wdaemanage dbshell` in the deployed container fails with:

```
CommandError: You appear not to have the 'mysql' program installed or on your path.
```

Installing the client restores `dbshell` (verified: it then opens a working `mysql` prompt against the configured DB) and additionally gives operators `mysqldump`/`mysqladmin` against the configured DB from inside the running app container — a recurring operational need.

## Scope / cost

- **Combined `Dockerfile.production` only.** The image's runtime stage is a fresh `python:3.12-slim` that copies only `/opt/gpf` from the backend, so `web_api/Dockerfile.production` would not propagate; `gpf-web-api` is not deployed standalone.
- Adds ~80 MB (`mariadb-client` + core + compat) to the image. The slimmer `mariadb-client-core` (~15 MB, shell only) was considered; the full client was chosen deliberately to also ship `mysqldump`/admin tools in the container.

## Verification

Reproduced the failure and the fix by installing `default-mysql-client` into a running `iossifovlab/gpf-web:2026.6.5` container — `/usr/bin/mysql` appears and `wdaemanage dbshell` returns query results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)