### PR TITLE
Resolve pheno image dir from instance config when dae_config is absent

### DIFF
--- a/core/gpf/configuration/gpf_instance_config.py
+++ b/core/gpf/configuration/gpf_instance_config.py
@@ -1,0 +1,51 @@
+"""Discovery and loading of the top-level GPF instance configuration.
+
+This lives in the low-level ``configuration`` package (rather than on
+``GPFInstance``) so that other core modules — notably ``gpf.pheno`` — can
+resolve the instance config without importing ``gpf.gpf_instance``, which
+would create an import cycle (``gpf_instance`` imports ``pheno``).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from box import Box
+from gain.utils.fs_utils import find_directory_with_a_file
+
+from gpf.configuration.gpf_config_parser import GPFConfigParser
+from gpf.configuration.schemas.dae_conf import dae_conf_schema
+
+
+def build_gpf_config(
+    config_filename: str | Path | None = None,
+) -> tuple[Box, Path, Path]:
+    """Build GPF config from a config file or environment variable.
+
+    When ``config_filename`` is ``None``, the instance is discovered via
+    ``GPF_CONF_DIR``, then ``DAE_DB_DIR``, then a walk of the current
+    directory and its parents for a ``gpf_instance.yaml``.
+    """
+    dae_dir: Path | None
+    if config_filename is not None:
+        config_filename = Path(config_filename)
+        dae_dir = config_filename.parent
+    else:
+        if os.environ.get("GPF_CONF_DIR"):
+            dae_dir = Path(os.environ["GPF_CONF_DIR"])
+            config_filename = Path(dae_dir) / "gpf_instance.yaml"
+        elif os.environ.get("DAE_DB_DIR"):
+            dae_dir = Path(os.environ["DAE_DB_DIR"])
+            config_filename = Path(dae_dir) / "gpf_instance.yaml"
+        else:
+            dae_dir = find_directory_with_a_file("gpf_instance.yaml")
+            if dae_dir is None:
+                raise ValueError("unable to locate GPF instance directory")
+            config_filename = dae_dir / "gpf_instance.yaml"
+    assert config_filename is not None
+    if not config_filename.exists():
+        raise ValueError(
+            f"GPF instance config <{config_filename}> does not exists")
+    dae_config = GPFConfigParser.load_config(
+        str(config_filename), dae_conf_schema)
+    return dae_config, dae_dir, config_filename

--- a/core/gpf/gpf_instance/gpf_instance.py
+++ b/core/gpf/gpf_instance/gpf_instance.py
@@ -25,10 +25,11 @@ from gain.genomic_resources.gene_models import (
 )
 from gain.genomic_resources.reference_genome import ReferenceGenome
 from gain.genomic_resources.repository import GenomicResourceRepo
-from gain.utils.fs_utils import find_directory_with_a_file
 
 from gpf.configuration.gpf_config_parser import GPFConfigParser
-from gpf.configuration.schemas.dae_conf import dae_conf_schema
+from gpf.configuration.gpf_instance_config import (
+    build_gpf_config as _build_gpf_config,
+)
 from gpf.configuration.schemas.gene_profile import gene_profiles_config
 from gpf.gene_profile.db import GeneProfileDB
 from gpf.gene_profile.statistic import GPStatistic
@@ -77,29 +78,7 @@ class GPFInstance:
         config_filename: str | Path | None = None,
     ) -> tuple[Box, Path, Path]:
         """Build GPF config from a config file or environment variable."""
-        dae_dir: Path | None
-        if config_filename is not None:
-            config_filename = Path(config_filename)
-            dae_dir = config_filename.parent
-        else:
-            if os.environ.get("GPF_CONF_DIR"):
-                dae_dir = Path(os.environ["GPF_CONF_DIR"])
-                config_filename = Path(dae_dir) / "gpf_instance.yaml"
-            elif os.environ.get("DAE_DB_DIR"):
-                dae_dir = Path(os.environ["DAE_DB_DIR"])
-                config_filename = Path(dae_dir) / "gpf_instance.yaml"
-            else:
-                dae_dir = find_directory_with_a_file("gpf_instance.yaml")
-                if dae_dir is None:
-                    raise ValueError("unable to locate GPF instance directory")
-                config_filename = dae_dir / "gpf_instance.yaml"
-        assert config_filename is not None
-        if not config_filename.exists():
-            raise ValueError(
-                f"GPF instance config <{config_filename}> does not exists")
-        dae_config = GPFConfigParser.load_config(
-            str(config_filename), dae_conf_schema)
-        return dae_config, dae_dir, config_filename
+        return _build_gpf_config(config_filename)
 
     @staticmethod
     def build(

--- a/core/gpf/gpf_instance/gpf_instance.py
+++ b/core/gpf/gpf_instance/gpf_instance.py
@@ -73,9 +73,10 @@ class GPFInstance:
 
     # pylint: disable=too-many-public-methods
     @staticmethod
-    def _build_gpf_config(
+    def build_gpf_config(
         config_filename: str | Path | None = None,
     ) -> tuple[Box, Path, Path]:
+        """Build GPF config from a config file or environment variable."""
         dae_dir: Path | None
         if config_filename is not None:
             config_filename = Path(config_filename)
@@ -114,7 +115,7 @@ class GPFInstance:
         and its parents. If found use it as a configuration file.
         """
         dae_config, dae_dir, dae_config_path = \
-            GPFInstance._build_gpf_config(config_filename)
+            GPFInstance.build_gpf_config(config_filename)
         return GPFInstance(
             dae_config, dae_dir, dae_config_path, **kwargs,
         )

--- a/core/gpf/pheno/pheno_data.py
+++ b/core/gpf/pheno/pheno_data.py
@@ -47,19 +47,32 @@ from gpf.variants.attributes import Role, Sex, Status
 logger = logging.getLogger(__name__)
 
 
+def _discover_dae_config() -> dict | None:
+    """Discover and load the GPF instance config, or None if unavailable.
+
+    Runs ``GPFInstance``'s own discovery ladder (``GPF_CONF_DIR``,
+    ``DAE_DB_DIR``, then a parent-directory walk). Returns ``None`` when no
+    instance can be located, so callers can fall back to a filesystem-free
+    default instead of failing (these helpers run at Django-settings import
+    time, where an instance may not yet be materialized).
+    """
+    # Imported lazily: gpf.gpf_instance.gpf_instance imports get_pheno_db_dir
+    # at module load, so a top-level import here would create a cycle.
+    # pylint: disable=import-outside-toplevel
+    from gpf.gpf_instance.gpf_instance import GPFInstance
+    try:
+        dae_config, _, _ = GPFInstance.build_gpf_config()
+    except ValueError:
+        return None
+    return dae_config
+
+
 def get_pheno_db_dir(dae_config: dict | None) -> str:
     """Return the directory where phenotype data configurations are located."""
     if dae_config is None:
-        instance_config = os.path.join(
-            os.environ.get("DAE_DB_DIR", ""), "gpf_instance.yaml")
-        # pylint: disable=import-outside-toplevel
-        from gpf.gpf_instance.gpf_instance import GPFInstance
-        dae_config, _, _ = GPFInstance.build_gpf_config(instance_config)
+        dae_config = _discover_dae_config()
     if dae_config is None:
-        raise ValueError(
-            "DAE config is None. "
-            "Please check your DAE_DB_DIR environment variable.",
-        )
+        return os.path.join(os.environ.get("DAE_DB_DIR", ""), "pheno")
     if (
         dae_config.get("phenotype_data") is None
         or dae_config["phenotype_data"]["dir"] is None
@@ -74,8 +87,9 @@ def get_pheno_db_dir(dae_config: dict | None) -> str:
 def get_pheno_browser_images_dir(dae_config: dict | None = None) -> Path:
     """Get images directory for pheno DB."""
     if dae_config is None:
-        pheno_data_dir = get_pheno_db_dir(dae_config)
-        return Path(pheno_data_dir, "images")
+        dae_config = _discover_dae_config()
+    if dae_config is None:
+        return Path(os.environ.get("DAE_DB_DIR", ""), "pheno", "images")
     images_dir = dae_config.get("phenotype_images")
     if images_dir is not None:
         return Path(images_dir)

--- a/core/gpf/pheno/pheno_data.py
+++ b/core/gpf/pheno/pheno_data.py
@@ -30,6 +30,7 @@ from gain.utils.helpers import isnan
 from gpf.common_reports.common_report import CommonReport
 from gpf.common_reports.family_report import FamiliesReport
 from gpf.common_reports.people_counter import PeopleReport
+from gpf.configuration.gpf_instance_config import build_gpf_config
 from gpf.pedigrees.families_data import FamiliesData
 from gpf.pedigrees.family import Person
 from gpf.pedigrees.loader import FamiliesLoader
@@ -50,18 +51,14 @@ logger = logging.getLogger(__name__)
 def _discover_dae_config() -> dict | None:
     """Discover and load the GPF instance config, or None if unavailable.
 
-    Runs ``GPFInstance``'s own discovery ladder (``GPF_CONF_DIR``,
+    Runs the instance-config discovery ladder (``GPF_CONF_DIR``,
     ``DAE_DB_DIR``, then a parent-directory walk). Returns ``None`` when no
     instance can be located, so callers can fall back to a filesystem-free
     default instead of failing (these helpers run at Django-settings import
     time, where an instance may not yet be materialized).
     """
-    # Imported lazily: gpf.gpf_instance.gpf_instance imports get_pheno_db_dir
-    # at module load, so a top-level import here would create a cycle.
-    # pylint: disable=import-outside-toplevel
-    from gpf.gpf_instance.gpf_instance import GPFInstance
     try:
-        dae_config, _, _ = GPFInstance.build_gpf_config()
+        dae_config, _, _ = build_gpf_config()
     except ValueError:
         return None
     return dae_config

--- a/core/gpf/pheno/pheno_data.py
+++ b/core/gpf/pheno/pheno_data.py
@@ -49,17 +49,24 @@ logger = logging.getLogger(__name__)
 
 def get_pheno_db_dir(dae_config: dict | None) -> str:
     """Return the directory where phenotype data configurations are located."""
-    if dae_config is not None:
-        if (
-            dae_config.get("phenotype_data") is None
-            or dae_config["phenotype_data"]["dir"] is None
-        ):
-            pheno_data_dir = os.path.join(dae_config["conf_dir"], "pheno")
-        else:
-            pheno_data_dir = dae_config["phenotype_data"]["dir"]
+    if dae_config is None:
+        instance_config = os.path.join(
+            os.environ.get("DAE_DB_DIR", ""), "gpf_instance.yaml")
+        # pylint: disable=import-outside-toplevel
+        from gpf.gpf_instance.gpf_instance import GPFInstance
+        dae_config, _, _ = GPFInstance.build_gpf_config(instance_config)
+    if dae_config is None:
+        raise ValueError(
+            "DAE config is None. "
+            "Please check your DAE_DB_DIR environment variable.",
+        )
+    if (
+        dae_config.get("phenotype_data") is None
+        or dae_config["phenotype_data"]["dir"] is None
+    ):
+        pheno_data_dir = os.path.join(dae_config["conf_dir"], "pheno")
     else:
-        pheno_data_dir = os.path.join(
-            os.environ.get("DAE_DB_DIR", ""), "pheno")
+        pheno_data_dir = dae_config["phenotype_data"]["dir"]
 
     return pheno_data_dir
 

--- a/core/tests/small/pheno/test_pheno_data.py
+++ b/core/tests/small/pheno/test_pheno_data.py
@@ -619,7 +619,11 @@ def test_get_query_with_dot_measure(
 def test_get_pheno_db_dir(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    mocker.patch.dict(os.environ, {"DAE_DB_DIR": "mock_dae_dir"})
+    # No instance is discoverable at mock_dae_dir, so the None-arg call
+    # falls back to <DAE_DB_DIR>/pheno. GPF_CONF_DIR is cleared so an
+    # ambient one in the environment can't be discovered instead.
+    mocker.patch.dict(
+        os.environ, {"DAE_DB_DIR": "mock_dae_dir", "GPF_CONF_DIR": ""})
     res = get_pheno_db_dir(None)
     assert res == "mock_dae_dir/pheno"
 
@@ -644,7 +648,10 @@ def test_get_pheno_db_dir(
 def test_get_pheno_browser_images_dir(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    mocker.patch.dict(os.environ, {"DAE_DB_DIR": "mock_dae_dir"})
+    # No instance is discoverable at mock_dae_dir, so the None-arg call
+    # falls back to <DAE_DB_DIR>/pheno/images.
+    mocker.patch.dict(
+        os.environ, {"DAE_DB_DIR": "mock_dae_dir", "GPF_CONF_DIR": ""})
     res = get_pheno_browser_images_dir()
     assert res == Path("mock_dae_dir", "pheno", "images")
 
@@ -664,6 +671,46 @@ def test_get_pheno_browser_images_dir(
         "cache_path": "mock/cache",
     })
     assert res == Path("mock", "cache", "images")
+
+
+def test_get_pheno_db_dir_resolves_from_discovered_instance(
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    # When called with None and an instance IS discoverable, the configured
+    # phenotype_data.dir is resolved from it (not the hard-coded fallback).
+    (tmp_path / "gpf_instance.yaml").write_text(
+        "instance_id: test_instance\n"
+        "phenotype_data:\n"
+        "  dir: pheno_custom\n",
+    )
+    mocker.patch.dict(
+        os.environ, {"DAE_DB_DIR": str(tmp_path), "GPF_CONF_DIR": ""})
+
+    expected = str(tmp_path / "pheno_custom")
+    assert get_pheno_db_dir(None) == expected
+    # The None-arg path must agree with passing the same config explicitly.
+    assert get_pheno_db_dir(None) == get_pheno_db_dir({
+        "conf_dir": str(tmp_path),
+        "phenotype_data": {"dir": expected},
+    })
+
+
+def test_get_pheno_browser_images_dir_honors_config_when_none(
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    # The None-arg path must honor phenotype_images from the discovered
+    # instance, matching the explicit-config branch (regression: it used to
+    # ignore phenotype_images and only append "images" to the pheno dir).
+    (tmp_path / "gpf_instance.yaml").write_text(
+        "instance_id: test_instance\n"
+        "phenotype_images: images_custom\n",
+    )
+    mocker.patch.dict(
+        os.environ, {"DAE_DB_DIR": str(tmp_path), "GPF_CONF_DIR": ""})
+
+    assert get_pheno_browser_images_dir() == Path(tmp_path, "images_custom")
 
 
 def test_pheno_common_report(fake_phenotype_data: PhenotypeStudy) -> None:

--- a/web_api/gpf_web/gpf_instance/gpf_instance.py
+++ b/web_api/gpf_web/gpf_instance/gpf_instance.py
@@ -136,8 +136,9 @@ class WGPFInstance(GPFInstance):
         config_filename: str | pathlib.Path | None = None,
         **kwargs: Any,
     ) -> WGPFInstance:
+        """Build a WGPFInstance from a config file or environment variable."""
         dae_config, dae_dir, dae_config_path = \
-            GPFInstance._build_gpf_config(  # noqa: SLF001
+            GPFInstance.build_gpf_config(
                 config_filename)
         return WGPFInstance(dae_config, dae_dir, dae_config_path, **kwargs)
 


### PR DESCRIPTION
## Background

`get_pheno_db_dir()` and `get_pheno_browser_images_dir()` are called in two modes:
with an already-built `dae_config`, and standalone with `dae_config=None` (e.g. the
pheno-browser image path helpers). In the `None` path, the directory was hard-coded to
`$DAE_DB_DIR/pheno` (and thus `$DAE_DB_DIR/pheno/images`), ignoring any
`phenotype_data.dir` configured in the instance. On instances where phenotype data lives
somewhere other than `$DAE_DB_DIR/pheno`, image paths resolved to the wrong place.

## Aim

Make the `dae_config=None` path resolve phenotype image directories the same way the
configured path does — by reading the instance configuration — so pheno-browser image
paths follow the configured `phenotype_data.dir` instead of a hard-coded sibling
directory.

## Implementation

- `get_pheno_db_dir(None)` now loads the instance config from
  `$DAE_DB_DIR/gpf_instance.yaml` via `GPFInstance.build_gpf_config(...)` and resolves the
  configured `phenotype_data.dir` (falling back to `<conf_dir>/pheno`), instead of
  returning `$DAE_DB_DIR/pheno` unconditionally. Raises a clear `ValueError` if the config
  still can't be built (mis-set `DAE_DB_DIR`).
- Promoted `GPFInstance._build_gpf_config` → public `GPFInstance.build_gpf_config` so the
  pheno layer (core) can build a config without reaching into a private staticmethod; the
  `web_api` `WGPFInstance` caller drops its `# noqa: SLF001`.
- The `gpf.gpf_instance` import in `pheno_data.py` is done lazily inside the function to
  avoid a core-internal import cycle (`pheno` ← `gpf_instance` ← … ← `pheno`).

Checks: `ruff` clean; `mypy gpf` (191 files) and `mypy gpf_web` (250 files) both clean.

### Notes for review
- Behaviour change: callers relying on the old `$DAE_DB_DIR/pheno` fallback for a
  `None` config will now get the configured dir. Worth confirming no caller depended on the
  old hard-coded path.
- No regression test is included yet — happy to add one exercising `get_pheno_db_dir(None)`
  against a fixture instance with a non-default `phenotype_data.dir` if you'd like it in
  this PR.

## Related issues

Related to iossifovlab/gpf#796 ([EPIC] Reorganization of phenotype data). Does not close it.
