### PR TITLE
Fix flaky test_autogenerate_common_report under pytest -n

### DIFF
--- a/web_api/gpf_web/common_reports_api/tests/test_common_reports_api.py
+++ b/web_api/gpf_web/common_reports_api/tests/test_common_reports_api.py
@@ -247,7 +247,13 @@ def test_autogenerate_common_report(
     study = t4c8_wgpf_instance.get_genotype_data("t4c8_study_1")
     assert study is not None
     report_filename = study.config.common_report.file_path
-    os.remove(report_filename)
+    # The report is generated lazily on first API access, not at instance
+    # setup, so it may or may not exist yet depending on test ordering
+    # (under `pytest -n`, xdist may schedule this test before any other
+    # common-reports test in this worker). Ensure it is absent, then assert
+    # the endpoint autogenerates it.
+    if os.path.exists(report_filename):
+        os.remove(report_filename)
     assert not os.path.exists(report_filename)
 
     url = "/api/v3/common_reports/studies/t4c8_study_1"


### PR DESCRIPTION
## Background

`common_reports_api/tests/test_common_reports_api.py::test_autogenerate_common_report` fails under `pytest -n 10` but passes with a single worker:

```
os.remove(report_filename)
E   FileNotFoundError: [Errno 2] No such file or directory:
    '.../studies/t4c8_study_1/common_report.json'
test_common_reports_api.py:250: FileNotFoundError
```

## Aim

Make the test hermetic so it passes regardless of xdist scheduling.

## Implementation

Root cause is an implicit inter-test dependency. `setup_t4c8_instance` only *configures* `common_report.file_path`; the JSON is generated lazily on first `/api/v3/common_reports/studies/...` access. The `t4c8` instance is session-scoped, so the file exists on disk only if some other common-reports test hit the API earlier in that worker's session. This test assumed pre-existence and called `os.remove()` unconditionally.

- **`-n 1`:** module tests share one session and run in file order — an earlier test generates the file first, so `os.remove()` succeeds.
- **`-n 10`:** xdist `--dist load` scatters tests across workers; this test can land on a worker where no generator ran first → missing file → `FileNotFoundError`.

Fix: guard the removal (`if os.path.exists(...): os.remove(...)`), establishing the "report absent" precondition without depending on prior tests. The autogeneration assertion is unchanged.

Reproduced deterministically by running the single test in isolation (fails before, passes after).

Verification:
- isolated `test_autogenerate_common_report`: passes
- `common_reports_api/` module: 22 passed
- full `web_api` suite under `-n 10`: 684 passed, 3 xfailed (was 683 passed / 1 failed)
