### PR TITLE
Fix flaky user-management tb-nxl-fix group under CI load (gpf#962)

### DIFF
--- a/web_e2e/tests/user-management.spec.ts
+++ b/web_e2e/tests/user-management.spec.ts
@@ -1171,6 +1171,11 @@ test.describe('Dataset description access rights '
        'whether the newly created description exists and that it cannot be edited', async({ page }) => {
     await page.locator('a:text("Management")').click();
 
+    // gpf#962: under CI load the Users table renders only a prefix of the
+    // user list, so the last-sorted rows (this user) can be absent for
+    // >20s and the Add-button click times out. Filter the table down to
+    // the target user first so its row is guaranteed to be present.
+    await searchInTable(page, 'user_iossifov_2014@iossifovlab.com');
     await page.locator('[id="user_iossifov_2014@iossifovlab.com-groups-cell"]')
       .getByRole('button', { name: 'Add' }).click();
     await page.waitForSelector('.add-item-button');
@@ -1225,6 +1230,9 @@ test.describe('Dataset description access rights '
     ]);
 
     await page.locator('a:text("Management")').click();
+    // gpf#962: filter to the target user (see the grant step above) so the
+    // row is present under CI load before interacting with its groups-cell.
+    await searchInTable(page, 'user_iossifov_2014@iossifovlab.com');
     await page.locator(
       '[id="user_iossifov_2014@iossifovlab.com-groups-cell"] #iossifov_2014_liftover-list-item gpf-confirm-button'
     ).click();


### PR DESCRIPTION
## Background

`gpf-web-e2e` intermittently failed on `user-management.spec.ts:1175` — the `Add` button in `user_iossifov_2014@iossifovlab.com`'s groups-cell timed out (20s) — e.g. build #364 (and #362 on a sibling test). The commit under test each time was unrelated (#364 = a `web_ui/package.json` allowlist whose child SHA is green in #366), i.e. a flake, not a regression.

## Root cause

Reproduced on the Jenkins-mirrored split stack (agent `pooh`), master `g06a0812ce`, `E2E_WORKER_COUNT=8`, `--retries=0` → ~50% per run. The failure's aria snapshot showed the Users Management table rendered only **12 of the 14 seeded users**, ending at `user_comp_genotypes`; the two missing rows were the last two alphabetically (`user_comp_vcf`, `user_iossifov_2014`). Search box empty, no pagination. So under load the users list renders only a **prefix**, and the test clicked the target row's Add button without first ensuring the row exists → 20s timeout.

## Fix

Call the existing `searchInTable(<user email>)` helper before **both** interactions with that user's groups-cell (the grant at 1172 and the revert at 1227), filtering the table down to the single target user so its row is guaranteed to render. No dependency on the full list rendering.

## Verification

Same stack/loop, post-fix: **0 recurrences across 8 iterations** (7× full `50 passed`; the one failing iteration was an *unrelated* test — `Admin surf … verify his rights` — not this one). Against the ~50% baseline, P(0/8) ≈ 0.4%. `tsc --noEmit` clean.

## Follow-up

Iteration 8 surfaced a *separate* instance of the same class (the Users table prefix-render race) in another test. Filed/《to file》 as a follow-up — the durable hardening is to search-first at every Management users-table interaction.
