### PR TITLE
Add env-var overrides for web-API feature flags

### DIFF
--- a/web_api/gpf_web/gpf_instance/tests/test_feature_flags.py
+++ b/web_api/gpf_web/gpf_instance/tests/test_feature_flags.py
@@ -1,4 +1,8 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
+import importlib
+from collections.abc import Callable, Iterator
+
+import pytest
 from django.test import override_settings
 
 from gpf_instance.feature_flags import (
@@ -6,6 +10,7 @@ from gpf_instance.feature_flags import (
     FeatureFlags,
     get_feature_flags,
 )
+from gpf_web import production_settings
 
 
 def test_is_enabled_unknown_flag_is_false() -> None:
@@ -55,3 +60,58 @@ def test_unknown_override_key_is_dropped(
     assert "made_up_flag" not in flags
     # A stray override key must not disturb the known flags.
     assert flags["pheno_browser_download"] is True
+
+
+# ---------------------------------------------------------------------------
+# production_settings env-var override convention
+#
+# production_settings derives a FEATURE_FLAGS override from
+# ``GPF_FEATURE_FLAG__<NAME>`` env vars (one per known flag). Deployments
+# (dory, SFARI) flip a flag off by setting the matching var; pytest runs under
+# test_settings, so we exercise the loop by reloading the production_settings
+# module directly and inspecting its FEATURE_FLAGS attribute.
+# ---------------------------------------------------------------------------
+_PHENO_ENV = "GPF_FEATURE_FLAG__PHENO_BROWSER_DOWNLOAD"
+
+
+@pytest.fixture
+def reload_production_settings() -> Iterator[Callable[[], object]]:
+    """Reload production_settings on demand, restoring baseline after.
+
+    The env-var loop only runs at module import, so a test toggles env then
+    calls the returned reloader. The teardown reloads once more with a clean
+    env so no test leaves a toggled FEATURE_FLAGS on the shared module object.
+    """
+    def _reload() -> object:
+        return importlib.reload(production_settings)
+
+    yield _reload
+    importlib.reload(production_settings)
+
+
+def test_env_var_disables_known_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_production_settings: Callable[[], object],
+) -> None:
+    monkeypatch.setenv(_PHENO_ENV, "false")
+    prod = reload_production_settings()
+    assert prod.FEATURE_FLAGS["pheno_browser_download"] is False  # type: ignore[attr-defined]
+
+
+def test_env_var_enables_known_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_production_settings: Callable[[], object],
+) -> None:
+    monkeypatch.setenv(_PHENO_ENV, "true")
+    prod = reload_production_settings()
+    assert prod.FEATURE_FLAGS["pheno_browser_download"] is True  # type: ignore[attr-defined]
+
+
+def test_no_env_var_leaves_flag_at_default(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_production_settings: Callable[[], object],
+) -> None:
+    monkeypatch.delenv(_PHENO_ENV, raising=False)
+    prod = reload_production_settings()
+    # No override emitted -> the flag falls through to DEFAULT_FEATURE_FLAGS.
+    assert "pheno_browser_download" not in prod.FEATURE_FLAGS  # type: ignore[attr-defined]

--- a/web_api/gpf_web/gpf_web/production_settings.py
+++ b/web_api/gpf_web/gpf_web/production_settings.py
@@ -7,9 +7,34 @@ real GPF instance on disk (no DAE_DB_DIR access, no DB
 connection at import time).
 """
 # pylint: disable=wildcard-import,unused-wildcard-import
-from .default_settings import *  # noqa: F401,F403
+import os
+
+from gpf_instance.feature_flags import DEFAULT_FEATURE_FLAGS
+
+from .default_settings import *  # noqa: F403
 
 DEBUG = False
+
+# Per-flag env-var overrides of web-API feature flags. For every flag in the
+# canonical registry, a deployment can flip it by setting
+# ``GPF_FEATURE_FLAG__<NAME>`` (name upper-cased). Only ``0``/``false``/``no``
+# (case-insensitive) disable; an unset var leaves the flag at its default, so
+# adding a flag to DEFAULT_FEATURE_FLAGS makes it deployment-toggleable with no
+# further code change. This keeps the mechanism aligned with the stack's
+# "all per-host config flows through the container env" convention.
+#
+# Only flags with a matching env var are emitted here; the rest fall through
+# to their registry default when the flags singleton is built. Since
+# default_settings leaves FEATURE_FLAGS empty, building this dict fresh is
+# equivalent to merging over the inherited value.
+_feature_flags: dict[str, bool] = {}
+for _flag in DEFAULT_FEATURE_FLAGS:
+    _env = f"GPF_FEATURE_FLAG__{_flag.upper()}"
+    if _env in os.environ:
+        _feature_flags[_flag] = os.environ[_env].lower() not in (
+            "0", "false", "no",
+        )
+FEATURE_FLAGS = _feature_flags
 
 # STATIC_ROOT pinned so the web_ui image's django-static stage
 # produces a known path; the Apache stage copies it back out.


### PR DESCRIPTION
## What

`production_settings` now derives a `FEATURE_FLAGS` override from per-flag
`GPF_FEATURE_FLAG__<NAME>` environment variables — one per key in the
`DEFAULT_FEATURE_FLAGS` registry. A deployment disables a flag by setting the
matching var to `0`/`false`/`no` (case-insensitive); an unset var leaves the
flag at its registry default.

Adding a flag to `DEFAULT_FEATURE_FLAGS` makes it deployment-toggleable with
**no further code change** — the loop iterates the registry.

## Why

The dory (`gpf-infra`) and SFARI production deployments need
`pheno_browser_download` **off**. Every real deployment passes config through
the container env already (DB, email, prefix, GA, proxy timeout); this extends
that same pattern to feature flags, so no per-deployment settings module and no
`supervisord.conf` change are required. The infra-side wiring (dory `host_vars`
+ SFARI `deploy-gpf.yaml`) lands separately, after this ships in a `gpf-web`
image.

## Design notes

- Loop lives in `production_settings` — the module every deployed container
  boots under (combined image + split `web_api` image). Dev / `wgpf` / pytest
  run under other settings modules and are unaffected.
- `feature_flags.py` and its `DEFAULT_FEATURE_FLAGS < settings.FEATURE_FLAGS`
  merge are untouched; the loop only populates the `FEATURE_FLAGS` setting.
- Import-safe: only reads `os.environ` and imports the flag registry (stdlib +
  `django` only), preserving the "importable with no GPF instance on disk"
  invariant that `collectstatic` relies on. Smoke-verified.
- Frontend already gates the pheno-browser download button on this flag
  (`94fd98e8`), so disabling it hides the button and 404s the endpoint — no
  broken UI.

## Tests

Three new cases in `test_feature_flags.py` reload `production_settings` under a
toggled env and assert the resulting `FEATURE_FLAGS` (disable / enable / unset →
default), restoring module state on teardown.

Verified locally: `ruff` clean, `pylint` 10.00/10, `mypy gpf_web` exit 0,
`test_feature_flags.py` 9/9, adjacent `test_features_api.py` +
`test_pheno_browser_api.py` 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)