### PR TITLE
CI: combined coverage in the Coverage column; enable web_ui coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,13 +105,14 @@ def publishReports(String name) {
     // surfaces as FAILURE.
     junit allowEmptyResults: true, testResults: "reports/${name}/pytest.xml"
 
-    recordCoverage(
-        tools: [[parser: 'COBERTURA', pattern: "reports/${name}/coverage.xml"]],
-        id: "${name}-coverage",
-        name: "${name} coverage",
-        skipPublishingChecks: true,
-        failOnError: false,
-    )
+    // Coverage is NOT recorded here. It's all recorded in the top-level
+    // post.always instead, so we control the ORDER in which the actions
+    // register: the multibranch "Coverage" column (Coverage plugin's
+    // CoverageMetricColumn) shows the *first-registered* CoverageBuildAction
+    // and has no id selector, so the combined report must register first to
+    // own the column. Recording per-project here (in parallel post blocks)
+    // would register them in stage-completion order and the column would show
+    // whichever finished first, not the combined number.
 
     // Static-analysis findings (ruff / mypy / pylint) — separate per-tool
     // record so each gets its own "Issues" tab and trend chart. Quality
@@ -636,6 +637,7 @@ pipeline {
                                                 JEST_JUNIT_OUTPUT_DIR=/reports \\
                                                 JEST_JUNIT_OUTPUT_NAME=jest.xml \\
                                                     npx jest --ci \\
+                                                        --coverage \\
                                                         --collectCoverageFrom=./src/** \\
                                                         --coverageDirectory=/reports/coverage
                                                 jest_exit=\$?
@@ -669,22 +671,17 @@ pipeline {
                                         // publishReports() is Python-specific
                                         // (pytest junit + ruff/mypy/pylint
                                         // recordIssues). For web_ui we publish
-                                        // jest's junit + the cobertura coverage
-                                        // here, and the lint findings via the
-                                        // separate recordIssues below.
+                                        // jest's junit here and the lint
+                                        // findings via the separate
+                                        // recordIssues below. Coverage is NOT
+                                        // recorded here — web_ui's cobertura
+                                        // (reports/web_ui/coverage.xml) is
+                                        // aggregated with the others in the
+                                        // top-level post.always, in a
+                                        // controlled order (see there).
                                         junit(
                                             allowEmptyResults: true,
                                             testResults: 'reports/web_ui/jest.xml',
-                                        )
-                                        recordCoverage(
-                                            tools: [[
-                                                parser: 'COBERTURA',
-                                                pattern: 'reports/web_ui/coverage.xml',
-                                            ]],
-                                            id: 'web_ui-coverage',
-                                            name: 'web_ui coverage',
-                                            skipPublishingChecks: true,
-                                            failOnError: false,
                                         )
                                         recordIssues(
                                             enabledForFailure: true,
@@ -1437,6 +1434,43 @@ print('gpf-web prefix settings OK')"
         always {
             script {
                 try {
+                    // All coverage is published here, in a controlled ORDER,
+                    // rather than in the per-project parallel post blocks. The
+                    // multibranch "Coverage" column shows the *first-registered*
+                    // CoverageBuildAction (Coverage plugin's
+                    // CoverageMetricColumn.getAction(); no id selector), and
+                    // parallel post blocks register in nondeterministic
+                    // stage-completion order — so per-project reports there made
+                    // the column show whichever stage finished first, not a
+                    // combined number.
+                    //
+                    // Register the COMBINED report first (owns the column), then
+                    // the per-project reports (drill-down + trend charts).
+                    // Order among the per-project ones is cosmetic (sidebar
+                    // listing). In post.always (not a stage) so coverage
+                    // publishes on red builds too; failOnError:false makes each
+                    // call a no-op on docs-only / tag builds where its file is
+                    // absent. Only core/web_api/web_ui produce coverage.xml
+                    // (federation/rest_client run skipPytest); the combined glob
+                    // matches exactly those top-level files, and the per-project
+                    // loop lists only them so we never create empty 0% actions.
+                    recordCoverage(
+                        tools: [[parser: 'COBERTURA', pattern: 'reports/*/coverage.xml']],
+                        id: 'coverage',
+                        name: 'Combined coverage',
+                        skipPublishingChecks: true,
+                        failOnError: false,
+                    )
+                    for (proj in ['core', 'web_api', 'web_ui']) {
+                        recordCoverage(
+                            tools: [[parser: 'COBERTURA',
+                                     pattern: "reports/${proj}/coverage.xml"]],
+                            id: "${proj}-coverage",
+                            name: "${proj} coverage",
+                            skipPublishingChecks: true,
+                            failOnError: false,
+                        )
+                    }
                     archiveArtifacts(
                         artifacts: 'reports/**/*.xml',
                         allowEmptyArchive: true,


### PR DESCRIPTION
## What & why

The gpf multibranch **Coverage** column showed an arbitrary single-project number — whichever of core/web_api registered its `CoverageBuildAction` first — because `publishReports` recorded coverage per-project in parallel `post` blocks with no aggregate. Mirrors the gain fix (iossifovlab/gain#243).

Verified against the Coverage plugin source (`CoverageMetricColumn`): the column shows the **first-registered** action via `getAction(CoverageBuildAction.class)` and has **no id/name selector** — so the only lever is **registration order**.

## Change

- **All coverage published from the top-level `post.always`, in order:** combined first (`id: 'coverage'`, glob `reports/*/coverage.xml` → owns the column), then per-project **core → web_api → web_ui** (`id: '${name}-coverage'`, drill-down + trends). federation/rest_client run `skipPytest` (no coverage), so they're excluded from the loop — no empty 0% actions.
- Removed the per-project `recordCoverage` from `publishReports` and the inline one from the web_ui post block. `recordIssues` (ruff/mypy/pylint, eslint/stylelint) is untouched.
- **Enabled web_ui coverage.** `jest.config.js` lists the `cobertura` reporter but has no `collectCoverage`, and the CI jest call passed `--collectCoverageFrom` **without** `--coverage` — so jest collected nothing and no `reports/web_ui/coverage.xml` was written. Added `--coverage` to the CI jest invocation (kept in the Jenkinsfile so local `npm test` stays coverage-free/fast). web_ui is now part of the combined number.

## Design notes

- **`post.always`, not a stage:** coverage publishes on red builds too (a failing project's `publishReports` error path skips later *stages*, but `post.always` still runs after the parallel post blocks wrote `reports/*/coverage.xml`).
- **No double-count:** the combined glob matches only the top-level `reports/*/coverage.xml`, not the nested `reports/web_ui/coverage/cobertura-coverage.xml`.
- **Docs-only / tag builds:** `failOnError:false` → clean no-op when files are absent.

## Verification (branch build #1, SUCCESS)

- web_ui now emits `reports/web_ui/coverage.xml` (the `--coverage` fix).
- Combined `recordCoverage` runs first and reports `found 3 files` (core + web_api + web_ui, 797 source files aggregated); the three per-project calls each `found 1 file` after it.
- Combined line coverage ≈ **83.2%** (34845/41871), vs. the single-project number shown before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)