### PR TITLE
docs-e2e: run prewarm script from a quoted heredoc, not inline in bash -lc

### DIFF
--- a/docs_e2e/Jenkinsfile.docs-e2e-prewarm
+++ b/docs_e2e/Jenkinsfile.docs-e2e-prewarm
@@ -221,45 +221,49 @@ annotation:
     - allele_score: hg38/scores/ClinVar_20240730
 YAML
 
-                    docker run --rm \
-                        -v "$PWD:/workspace" \
-                        -v "$GRR_CACHE_VOLUME:/grr-cache" \
-                        -w /workspace \
-                        "$DRIVER_IMAGE" \
-                        bash -lc '
-                            set -eu
-                            # Mirror conftest.conda_channel: build an
-                            # indexed local channel from the copied
-                            # .conda artefacts.
-                            rm -rf /tmp/channel
-                            mkdir -p /tmp/channel/noarch
-                            cp /workspace/dist/conda/*.conda /tmp/channel/noarch/
-                            /opt/conda/bin/python -m conda_index /tmp/channel
-                            # Mirror conftest.gpf_env_prefix: install
-                            # gpf-web (pulls gain-core + gpf-core, which
-                            # provide grr_cache_repo and its -i provider).
-                            # First-party packages come ONLY from the local
-                            # channel (gpf-* from the gpf build, gain-core from
-                            # the gain build copied above); the iossifovlab
-                            # release channel is deliberately dropped so a stale
-                            # published gain-core/gpf-core cannot leak in
-                            # (gpf#916). gain-core's recipe now declares tqdm,
-                            # so the old gain#89 explicit-tqdm workaround is
-                            # gone. Mirrors conftest.gpf_env_prefix.
-                            mamba create -y -n prewarm \
-                                -c file:///tmp/channel \
-                                -c bioconda -c conda-forge \
-                                gpf-web
-                            # Mirror the conftest.denovo_instance GRR block
-                            # byte-for-byte: the GPF default is a `group` of
-                            # grr-gpf.iossifovlab.com (GPF-specific resources,
-                            # e.g. enrichment/samocha_background) and
-                            # grr.iossifovlab.com (general annotation
-                            # resources). The cache keys on each child repo
-                            # id, so the prewarm MUST use the same ids the
-                            # suite uses (default_gpf / default) or the suite
-                            # cold-re-pulls under a mismatched path.
-                            cat > /root/.grr_definition.yaml <<YAML
+                    # The seeding script is written to a FILE through a
+                    # QUOTED heredoc and then run inside the container —
+                    # it is deliberately NOT inlined into
+                    # `bash -lc '<script>'`. A quoted heredoc is taken
+                    # literally, so an apostrophe in a comment cannot
+                    # close the quote and spill the rest of the script
+                    # onto the AGENT HOST. Inlining broke this job
+                    # twice: fixed in gpf#871, regressed in gpf#916
+                    # (`gain-core's recipe`), where the host — not the
+                    # container — ran `mamba create` and died with
+                    # `mamba: command not found`, exit 127. Keep the
+                    # script in a heredoc; apostrophes are safe here.
+                    cat > .prewarm-inner.sh <<'PREWARM'
+set -eu
+
+# Mirror conftest.conda_channel: build an indexed local channel from
+# the copied .conda artefacts.
+rm -rf /tmp/channel
+mkdir -p /tmp/channel/noarch
+cp /workspace/dist/conda/*.conda /tmp/channel/noarch/
+/opt/conda/bin/python -m conda_index /tmp/channel
+
+# Mirror conftest.gpf_env_prefix: install gpf-web (pulls gain-core +
+# gpf-core, which provide grr_cache_repo and its -i provider).
+# First-party packages come ONLY from the local channel (gpf-* from the
+# gpf build, gain-core from the gain build copied above); the
+# iossifovlab release channel is deliberately dropped so a stale
+# published gain-core/gpf-core cannot leak in (gpf#916). gain-core's
+# recipe now declares tqdm, so the old gain#89 explicit-tqdm workaround
+# is gone.
+mamba create -y -n prewarm \
+    -c file:///tmp/channel \
+    -c bioconda -c conda-forge \
+    gpf-web
+
+# Mirror the conftest.denovo_instance GRR block byte-for-byte: the GPF
+# default is a `group` of grr-gpf.iossifovlab.com (GPF-specific
+# resources, e.g. enrichment/samocha_background) and
+# grr.iossifovlab.com (general annotation resources). The cache keys on
+# each child repo id, so the prewarm MUST use the same ids the suite
+# uses (default_gpf / default) or the suite cold-re-pulls under a
+# mismatched path.
+cat > /root/.grr_definition.yaml <<YAML
 id: "default_gpf_grr"
 type: "group"
 cache_dir: "/grr-cache"
@@ -271,25 +275,33 @@ children:
     type: "http"
     url: "https://grr.iossifovlab.com"
 YAML
-                            cd /workspace/gs
-                            # -j 1: one download worker gets the full GRR
-                            # link (~6 MB/s) instead of splitting it 4 ways
-                            # (grr_cache_repo default -j 4), so large
-                            # gnomAD chunk reads finish well within the
-                            # aiohttp 300s default timeout. gain hardcodes
-                            # HTTPFileSystem with no timeout override
-                            # (fsspec_protocol.py), so -j 1 + less GRR
-                            # server contention is the lever until the
-                            # durable gain timeout/retry fix lands (no
-                            # apostrophes here: this is inside bash -lc).
-                            mamba run -n prewarm grr_cache_repo -i \
-                                minimal_instance/gpf_instance.yaml -j 1
-                            # Sentinel: only a SUCCESSFUL full cache
-                            # write reaches here. The build guard checks
-                            # for this, so a partial cache cannot
-                            # false-pass.
-                            touch /grr-cache/.docs-e2e-prewarmed
-                        '
+
+cd /workspace/gs
+
+# -j 1: one download worker gets the full GRR link (~6 MB/s) instead of
+# splitting it 4 ways (grr_cache_repo's default -j 4), so large gnomAD
+# chunk reads finish well within the aiohttp 300s default timeout. gain
+# hardcodes HTTPFileSystem with no timeout override (fsspec_protocol.py),
+# so -j 1 + less GRR server contention is the lever until the durable
+# gain timeout/retry fix lands.
+mamba run -n prewarm grr_cache_repo -i \
+    minimal_instance/gpf_instance.yaml -j 1
+
+# Sentinel: only a SUCCESSFUL full cache write reaches here. The build
+# guard checks for this, so a partial cache cannot false-pass.
+touch /grr-cache/.docs-e2e-prewarmed
+PREWARM
+
+                    # Catch a syntax error in the generated script now,
+                    # not 90 minutes into the GRR download.
+                    bash -n .prewarm-inner.sh
+
+                    docker run --rm \
+                        -v "$PWD:/workspace" \
+                        -v "$GRR_CACHE_VOLUME:/grr-cache" \
+                        -w /workspace \
+                        "$DRIVER_IMAGE" \
+                        bash -lc 'bash /workspace/.prewarm-inner.sh'
                 '''
             }
         }
@@ -299,7 +311,8 @@ YAML
         always {
             sh '''
                 docker rmi "$DRIVER_IMAGE" || true
-                docker run --rm -v "$PWD:/wd" -w /wd alpine rm -rf gs || true
+                docker run --rm -v "$PWD:/wd" -w /wd alpine \
+                    rm -rf gs .prewarm-inner.sh || true
             '''
         }
         success {


### PR DESCRIPTION
## The failure

`gpf-docs-e2e-prewarm` build 9 failed after 95s with `mamba: command not found`, exit 127.

## Root cause

The seeding script is inlined into a single-quoted `bash -lc '<script>'` argument. A comment added
by #916 contains an apostrophe:

```
# (gpf#916). gain-core's recipe now declares tqdm,
```

The apostrophe in `gain-core's` **closes the quote early**. So the container received only the
truncated prefix of the script (through `conda_index`), ran it, and exited 0 — which is why the
console shows a clean conda-index run. Everything after the apostrophe fell out of the quoted string
and was parsed by the **agent host's** shell, so `mamba create -y -n prewarm …` executed on the
Jenkins agent, which has no `mamba`.

The tell is the error path — a durable-task wrapper *on the agent*, not a container path:

```
…/workspace/gpf-docs-e2e-prewarm@tmp/durable-83030208/script.sh.copy: line 34: mamba: command not found
```

Nothing harmful leaked to the agent: `set -eu` aborted at the first leaked command, so the
`cat > /root/.grr_definition.yaml` heredoc further down never ran there.

## This is a regression of #871

| commit | date | |
|---|---|---|
| `1163dffe0` | 2026-06-02 | docs-e2e: fix stray apostrophe breaking prewarm bash -lc quoting (#871) |
| `fa2e8eba1` | 2026-06-10 | docs-e2e: resolve gain-core from gain master, drop iossifovlab channel (#916) |

#871 fixed exactly this bug — an apostrophe in `conftest.denovo_instance's GRR block`. Eight days
later #916 reintroduced it in a *new* comment. Build 8, the last green prewarm, built commit
`1163dffe0` (the fix commit itself); build 9 is the first prewarm run since the regression landed.

## The fix

Rewording the comment fixes the instance and leaves the bug class: the script is inlined into a
quoted string, so *any* future apostrophe in *any* comment silently reintroduces it — as already
happened once, despite a warning comment in the file saying "no apostrophes here".

Instead, the script is now written to a file through a **quoted heredoc** (`<<'PREWARM'`), which is
taken literally — apostrophes cannot terminate anything — and the container runs that file:

```sh
cat > .prewarm-inner.sh <<'PREWARM'
… script; apostrophes safe, and gain-core's comment is kept verbatim …
PREWARM

bash -n .prewarm-inner.sh    # fail fast on a syntax error, not 90 min into the GRR download

docker run --rm … "$DRIVER_IMAGE" bash -lc 'bash /workspace/.prewarm-inner.sh'
```

The script body is otherwise unchanged. The stale "no apostrophes here" comment is gone, and the
post-build cleanup removes `.prewarm-inner.sh` alongside `gs`.

## Verification

- Extracted the `sh` stage body exactly as Jenkins renders it and ran it with `git`/`docker`/`mamba`
  stubbed. `docker`'s final argument is exactly `bash /workspace/.prewarm-inner.sh` — nothing leaks —
  and a `mamba` tripwire on the host never fires. Against the current `master` the same harness *does*
  execute `mamba` on the host, reproducing the bug.
- The generated script is complete: 56 lines, `set -eu` through the sentinel
  `touch /grr-cache/.docs-e2e-prewarmed`, with `conda_index`, `mamba create`, and `grr_cache_repo` all
  present.
- `bash -n` clean; declarative syntax validated against the live controller.

The prewarm is a ~90-minute job, so the real gate is a green re-run of `gpf-docs-e2e-prewarm` against
`pooh` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
