### PR TITLE
docs-e2e: default AGENT_LABEL to pooh (gated on a green prewarm)

### DIFF
--- a/docs_e2e/CLAUDE.md
+++ b/docs_e2e/CLAUDE.md
@@ -61,7 +61,7 @@ failure must carry the originating `RST file:line` (`rst_ref=`).
 
 ## Per-agent GRR cache seeding
 
-The suite is pinned to one agent (`AGENT_LABEL`, default `eyoree`) and
+The suite is pinned to one agent (`AGENT_LABEL`, default `pooh`) and
 needs that agent's node-local `gpf-grr-cache` volume pre-seeded by the
 `gpf-docs-e2e-prewarm` job (it bulk-caches ~15 GB of instance resources
 out of band; the build then validates the warm cache fast). The

--- a/docs_e2e/Jenkinsfile.docs-e2e
+++ b/docs_e2e/Jenkinsfile.docs-e2e
@@ -31,12 +31,12 @@ pipeline {
     // different (seeded) agent.
     // `?:` fallback covers the first run after this param is added,
     // before the jobDsl re-seed makes params.AGENT_LABEL exist.
-    agent { label "${params.AGENT_LABEL ?: 'eyoree'}" }
+    agent { label "${params.AGENT_LABEL ?: 'pooh'}" }
 
     parameters {
         string(
             name: 'AGENT_LABEL',
-            defaultValue: 'eyoree',
+            defaultValue: 'pooh',
             description: 'Agent to run on. Must be an agent seeded ' +
                 'by gpf-docs-e2e-prewarm (the gpf-grr-cache volume ' +
                 'is node-local). Auto-triggered builds inherit this ' +

--- a/docs_e2e/Jenkinsfile.docs-e2e-prewarm
+++ b/docs_e2e/Jenkinsfile.docs-e2e-prewarm
@@ -31,7 +31,8 @@
 //
 // Set AGENT_LABEL to the specific agent you are onboarding (e.g.
 // `eyoree`) — the cache volume is agent-local, so seeding one agent
-// does NOT seed the others.
+// does NOT seed the others. The default is `pooh`, matching
+// gpf-docs-e2e's own AGENT_LABEL default.
 
 pipeline {
     // Pin to the specific agent being seeded. The gpf-grr-cache
@@ -40,15 +41,15 @@ pipeline {
     // `?:` fallback covers a first run where params.AGENT_LABEL is
     // not yet defined; pass AGENT_LABEL explicitly to seed a given
     // agent (the seeded node must match gpf-docs-e2e's AGENT_LABEL).
-    agent { label "${params.AGENT_LABEL ?: 'eyoree'}" }
+    agent { label "${params.AGENT_LABEL ?: 'pooh'}" }
 
     parameters {
         string(
             name: 'AGENT_LABEL',
-            defaultValue: 'eyoree',
+            defaultValue: 'pooh',
             description: 'The specific agent to seed. Must match ' +
                 'the agent gpf-docs-e2e runs on (its AGENT_LABEL ' +
-                'default is also "eyoree") — the gpf-grr-cache ' +
+                'default is also "pooh") — the gpf-grr-cache ' +
                 'volume is node-local. Set a different concrete ' +
                 'name to seed another agent.',
         )

--- a/docs_e2e/README.md
+++ b/docs_e2e/README.md
@@ -76,9 +76,14 @@ band**, into the node-local `gpf-grr-cache` docker volume.
 Before an agent runs `gpf-docs-e2e` for the first time, seed it:
 
 * Run the **`gpf-docs-e2e-prewarm`** Jenkins job with `AGENT_LABEL`
-  set to that agent (e.g. `eyoree`). It clones gpf-getting-started,
-  appends the gnomAD + ClinVar annotation block, and runs
-  `grr_cache_repo` into the volume. ~40 min cold; idempotent.
+  set to that agent (both jobs default to `pooh`). It clones
+  gpf-getting-started, appends the gnomAD + ClinVar annotation block,
+  and runs `grr_cache_repo` into the volume. ~40 min cold; idempotent.
+
+  **Seed before you switch.** `gpf-docs-e2e`'s `AGENT_LABEL` must not
+  be pointed at an agent whose `gpf-grr-cache` volume has no
+  `.docs-e2e-prewarmed` sentinel — the `grr_cache_seeded` guard will
+  fail every build until the prewarm goes green there.
 
 If an agent is not seeded, the build fails **fast** at fixture setup
 (the `grr_cache_seeded` guard) with a message naming the agent and

--- a/docs_e2e/jenkins-jobs/docs_e2e.groovy
+++ b/docs_e2e/jenkins-jobs/docs_e2e.groovy
@@ -13,7 +13,7 @@ pipelineJob('gpf-docs-e2e') {
 
     parameters {
         stringParam(
-            'AGENT_LABEL', 'eyoree',
+            'AGENT_LABEL', 'pooh',
             'Agent to run on. Must be seeded by ' +
             'gpf-docs-e2e-prewarm — the gpf-grr-cache volume is ' +
             'node-local. Auto-triggered builds inherit this default.',

--- a/docs_e2e/jenkins-jobs/docs_e2e_prewarm.groovy
+++ b/docs_e2e/jenkins-jobs/docs_e2e_prewarm.groovy
@@ -23,10 +23,10 @@ pipelineJob('gpf-docs-e2e-prewarm') {
 
     parameters {
         stringParam(
-            'AGENT_LABEL', 'eyoree',
+            'AGENT_LABEL', 'pooh',
             'The specific agent to seed. Must match the agent ' +
             'gpf-docs-e2e runs on (its AGENT_LABEL default is also ' +
-            '"eyoree") — the gpf-grr-cache volume is node-local. ' +
+            '"pooh") — the gpf-grr-cache volume is node-local. ' +
             'Set a different concrete name to seed another agent.',
         )
         stringParam(


### PR DESCRIPTION
Moves the docs-e2e suite off `eyoree` onto `pooh`.

## What changed

The `gpf-grr-cache` volume is **node-local**, so `gpf-docs-e2e` and `gpf-docs-e2e-prewarm` must agree
on their `AGENT_LABEL` default — otherwise the suite runs on an agent the prewarm never seeded. All
six default sites move together:

| file | site |
|---|---|
| `docs_e2e/Jenkinsfile.docs-e2e` | `agent { label … ?: 'pooh' }` + param `defaultValue` |
| `docs_e2e/Jenkinsfile.docs-e2e-prewarm` | `agent { label … ?: 'pooh' }` + param `defaultValue` |
| `docs_e2e/jenkins-jobs/docs_e2e.groovy` | `stringParam('AGENT_LABEL', 'pooh', …)` |
| `docs_e2e/jenkins-jobs/docs_e2e_prewarm.groovy` | `stringParam('AGENT_LABEL', 'pooh', …)` |

The two jobDsl seeds matter as much as the Jenkinsfiles — they are what actually define the job
parameters in Jenkins (applied by the main gpf `Jenkinsfile`'s `Apply Job DSL` stage on master). A
Jenkinsfile-only change would leave the *stored* job default at `eyoree` and auto-triggered builds
would keep inheriting it.

Docs updated to match, plus an explicit "seed before you switch" warning in `docs_e2e/README.md`.

## ⚠️ Do not merge until the prewarm is green on pooh

pooh's `gpf-grr-cache` volume is **not seeded** right now. Checked on the host:

```
$ docker run --rm -v gpf-grr-cache:/grr-cache alpine sh -c 'ls /grr-cache; du -sh /grr-cache'
default            # <- only the `default` child repo; `default_gpf` missing
2.9G    /grr-cache # <- of a ~15 GB cache
$ ls /grr-cache/.docs-e2e-prewarmed
No such file or directory
```

That is residue from the prewarm runs that died on the `bash -lc` quoting bug (fixed in #970, not yet
re-run). Until `gpf-docs-e2e-prewarm` completes green against pooh, this default makes **every**
`gpf-docs-e2e` build fail fast on the `grr_cache_seeded` guard.

Sequence: merge #970 (done) → run `gpf-docs-e2e-prewarm` with `AGENT_LABEL=pooh` → green → merge this.

## Verification

Both Jenkinsfiles validated against the live controller (`Jenkinsfile successfully validated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
