### PR TITLE
Bump django 5.2.14 -> 5.2.16 (CVE-2026-7666)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -781,16 +781,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "5.2.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Clears the one open Dependabot alert on this repo (#141, `GHSA-mm6v-q8q9-pgcf` / `CVE-2026-7666`, severity **low**).

## The advisory

`django.core.mail.backends.smtp.EmailBackend` fails to prevent reuse of a partially-initialized connection after a failed `STARTTLS` handshake **when `fail_silently=True`** — an on-path attacker can then read email content in cleartext. Affects `>= 5.2, < 5.2.15`; we were on 5.2.14.

## Actual exposure here: none

Worth stating plainly, so this is reviewed as hygiene rather than an incident:

- We do configure the affected backend (`EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"`, `default_settings.py`).
- But the vulnerable path requires `fail_silently=True`, and **`fail_silently` is never set anywhere in this repo**. The single `send_mail` call (`users_api/models.py:129`) passes four positional args, so it takes the default `fail_silently=False`.

So the trigger condition was never met. We bump anyway to clear the alert and pick up the rest of the 5.2.15/5.2.16 fixes.

## The change

Lockfile-only — 3 lines. `web_api/pyproject.toml` already requires `django>=5.2,<5.3` and `web_api/conda-recipe/recipe.yaml` already says `django >=5.2,<5.3`, so 5.2.16 (current 5.2.x patch, >= the 5.2.15 fix) satisfies both with no constraint edits.

The diff is deliberately **django-only**. A plain `uv lock --upgrade-package django` also repins `gain-core` (to whatever wheel happens to sit in the local `dist/gain/`) and drags in its new `pathspec` dep — CI overrides the gain pin with `--upgrade-package gain-core` regardless, so that churn does not belong in this PR. Those hunks were reverted; the committed hashes were verified against the PyPI JSON API.

## Verification

- `uv sync` + `python -c "import django"` → `django 5.2.16`.
- Full Django suite: `cd web_api && pytest -n 10 gpf_web/` → **699 passed, 3 xfailed**, 0 failures.

## Unrelated, not fixed here

- `requirements.txt` (repo root) pins `django=4.2.17` — an EOL series. It is a **dead file**: referenced by no Jenkinsfile, Dockerfile, README or script, last touched 2025-01-08, and internally stale (pins `python=3.11`, `lark-parser=0.6.7`, `pyarrow=16.1`, all contradicting the real `pyproject.toml`). Nothing consumes it, which is why Dependabot never flagged it. Suggest deleting it separately.
- `EMAIL_USE_TLS = os.environ.get("WDAE_EMAIL_USE_TLS", False)` returns a *string* when the env var is set, so any value (including `"false"`) is truthy. It errs toward enabling TLS, so it is not a hole — but it is a latent footgun next to `EMAIL_PORT`, which does convert with `int()`.