### PR TITLE
web_e2e: switch the CI GRR from the dead NFS mount to https://grr.seqpipe.org + persistent cache

### DIFF
--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -238,7 +238,18 @@ pipeline {
                 // creates a *missing* bind source as root:root — a
                 // dir the non-root instance-import / backend could
                 // not write into.
+                //
+                // GRR_CACHE_DIR / AGENT_UID / AGENT_GID are re-derived from
+                // the shell rather than trusted from the environment{}
+                // block — see the `Compose env` stage for why. Here it also
+                // matters for correctness of the chown: a `chown -R ":"`
+                // (empty uid:gid) is an error, and `mkdir -p ""` is too.
                 sh '''
+                    : "${GRR_CACHE_DIR:=$HOME/grr_cache}"
+                    AGENT_UID="$(id -u)"
+                    AGENT_GID="$(id -g)"
+                    export GRR_CACHE_DIR AGENT_UID AGENT_GID
+
                     mkdir -p "$GRR_CACHE_DIR"
 
                     docker run --rm \
@@ -275,6 +286,99 @@ pipeline {
                                       depth: 1]],
                     ])
                 }
+            }
+        }
+
+        // Make the compose stack's view of GRR_CACHE_DIR / AGENT_UID /
+        // AGENT_GID deterministic, then PROVE it before anything starts.
+        //
+        // gain-web-e2e #1042 (identical compose pattern) declared all three
+        // in the pipeline `environment{}` block and `docker compose` still
+        // did not see them: `docker inspect` on the live container showed
+        // the bind source as <workspace>/web_infra/grr_cache — the
+        // `${GRR_CACHE_DIR:-./grr_cache}` FALLBACK, i.e. inside the
+        // workspace, wiped by the next build's cleanup — and User=0:0, the
+        // `${AGENT_UID:-0}` fallback. Both designs, the persistent cache and
+        // the non-root ownership, were completely inert, and nothing failed.
+        //
+        // Rather than chase Jenkins' env-export semantics, pin it:
+        //
+        //   1. Re-derive the values HERE, in the shell, from `$HOME` and
+        //      `id -u`/`id -g` — the shell's own view is authoritative and
+        //      cannot be half-exported.
+        //   2. Write them to web_infra/.env — the compose PROJECT directory
+        //      (the dir of the first `-f` file), which is where Compose
+        //      auto-loads a .env from.
+        //   3. Pass `--env-file web_infra/.env` explicitly on every compose
+        //      call anyway, so nothing depends on which directory Compose
+        //      decides the project dir is.
+        //   4. `set -a; . ./web_infra/.env` before each compose call, because
+        //      --env-file is NOT enough on its own: the process environment
+        //      OUTRANKS --env-file, so a var that is present-but-EMPTY in the
+        //      shell still wins and still selects the fallback (verified
+        //      against docker compose). Sourcing makes the shell agree with
+        //      the file, which closes that hole.
+        //
+        // The ${VAR:-default} fallbacks stay in the compose YAML as a
+        // last-resort guard for local `docker compose up` outside CI.
+        stage('Compose env') {
+            steps {
+                sh '''
+                    set -eu
+
+                    : "${GRR_CACHE_DIR:=$HOME/grr_cache}"
+                    mkdir -p "$GRR_CACHE_DIR"
+
+# Heredoc body is at column 0 on purpose: compose's dotenv parser takes
+# the line verbatim, and a leading-space "  KEY=value" is not reliably
+# the same thing as "KEY=value".
+cat > web_infra/.env <<EOF
+GRR_CACHE_DIR=$GRR_CACHE_DIR
+AGENT_UID=$(id -u)
+AGENT_GID=$(id -g)
+EOF
+
+                    echo "--- web_infra/.env ---"
+                    cat web_infra/.env
+                '''
+
+                // The teeth. A silent fallback to a workspace-local cache
+                // running as root is EXACTLY the bug above; it must never
+                // pass quietly again. This asserts on the RESOLVED config
+                // (`docker compose config`), not on what we believe we
+                // exported, and fails the build with expected-vs-actual.
+                //
+                // BOTH overlays are checked on every build, not just the
+                // STACK_MODE one: split is the default, so a regression in
+                // the combined overlay would otherwise sit unnoticed until
+                // someone opted into combined mode.
+                sh '''
+                    set -eu
+                    set -a; . ./web_infra/.env; set +a
+
+                    echo "########## split mode ##########"
+                    EXPECT_GRR_SERVICES="instance-import backend" \
+                    ./web_infra/verify-compose-env.sh \
+                        web_infra/.env \
+                        web_infra/compose-jenkins.yaml \
+                        web_infra/compose-jenkins-split.yaml
+
+                    echo
+                    echo "########## combined mode ##########"
+                    # `frontend` is the documented root exception: the
+                    # combined image IS the production artefact, and its
+                    # supervisord.conf declares user=root and hard-exits
+                    # ("Can't drop privilege as nonroot user") for anyone
+                    # else. It still gets the cache bind + GRR_DEFINITION_FILE;
+                    # only the uid leg is waived, and the `Prepare workspace`
+                    # chown reclaims whatever it leaves root-owned.
+                    EXPECT_GRR_SERVICES="instance-import frontend" \
+                    ROOT_OK_SERVICES="frontend" \
+                    ./web_infra/verify-compose-env.sh \
+                        web_infra/.env \
+                        web_infra/compose-jenkins.yaml \
+                        web_infra/compose-jenkins-combined.yaml
+                '''
             }
         }
 
@@ -503,7 +607,9 @@ pipeline {
             // committed package-lock.json and the test sources).
             steps {
                 sh '''
+                    set -a; . ./web_infra/.env; set +a
                     docker compose \
+                        --env-file web_infra/.env \
                         -p "$COMPOSE_PROJECT" \
                         -f web_infra/compose-jenkins.yaml \
                         -f $COMPOSE_OVERLAY \
@@ -537,7 +643,9 @@ pipeline {
             // actual exit code.
             steps {
                 sh '''
+                    set -a; . ./web_infra/.env; set +a
                     docker compose \
+                        --env-file web_infra/.env \
                         -p "$COMPOSE_PROJECT" \
                         -f web_infra/compose-jenkins.yaml \
                         -f $COMPOSE_OVERLAY \
@@ -550,6 +658,7 @@ pipeline {
                     # the log dump runs.
                     EXIT_CODE=0
                     docker compose \
+                        --env-file web_infra/.env \
                         -p "$COMPOSE_PROJECT" \
                         -f web_infra/compose-jenkins.yaml \
                         -f $COMPOSE_OVERLAY \
@@ -561,6 +670,7 @@ pipeline {
                     # container under `up -d`, not on the
                     # compose invocation's stdout).
                     docker compose \
+                        --env-file web_infra/.env \
                         -p "$COMPOSE_PROJECT" \
                         -f web_infra/compose-jenkins.yaml \
                         -f $COMPOSE_OVERLAY \
@@ -608,6 +718,7 @@ pipeline {
                     lock(resource: "e2e-on-${env.NODE_NAME}") {
                     try {
                         sh '''
+                            set -a; . ./web_infra/.env; set +a
                             mkdir -p web_e2e/reports
 
                             # Stack-mode-aware HTTP-tier service list.
@@ -636,6 +747,7 @@ pipeline {
                             # gpf_instance.reload_datasets and 500 on
                             # /api/v3/datasets/visible.
                             docker compose \
+                                --env-file web_infra/.env \
                                 -p "$COMPOSE_PROJECT" \
                                 -f web_infra/compose-jenkins.yaml \
                                 -f $COMPOSE_OVERLAY \
@@ -654,6 +766,7 @@ pipeline {
                             # still gets copied.
                             TEST_RC=0
                             docker compose \
+                                --env-file web_infra/.env \
                                 -p "$COMPOSE_PROJECT" \
                                 -f web_infra/compose-jenkins.yaml \
                                 -f $COMPOSE_OVERLAY \
@@ -692,6 +805,7 @@ pipeline {
                         // artefact tree. Both `|| true` so a capture
                         // hiccup can't tank a green build.
                         sh '''
+                            set -a; . ./web_infra/.env; set +a
                             if [ "$STACK_MODE" = "combined" ]; then
                                 log_services="frontend e2e-tests"
                             else
@@ -699,6 +813,7 @@ pipeline {
                             fi
 
                             docker compose \
+                                --env-file web_infra/.env \
                                 -p "$COMPOSE_PROJECT" \
                                 -f web_infra/compose-jenkins.yaml \
                                 -f $COMPOSE_OVERLAY \
@@ -708,6 +823,7 @@ pipeline {
                             for svc in $log_services; do
                                 echo "===== compose logs: $svc ====="
                                 docker compose \
+                                    --env-file web_infra/.env \
                                     -p "$COMPOSE_PROJECT" \
                                     -f web_infra/compose-jenkins.yaml \
                                     -f $COMPOSE_OVERLAY \
@@ -717,6 +833,7 @@ pipeline {
                                   reports/web_e2e/ \
                                   2>/dev/null || true
                             docker compose \
+                                --env-file web_infra/.env \
                                 -p "$COMPOSE_PROJECT" \
                                 -f web_infra/compose-jenkins.yaml \
                                 -f $COMPOSE_OVERLAY \
@@ -762,6 +879,12 @@ pipeline {
                 # forever (#952). Keyed on $COMPOSE_PROJECT with no
                 # `-f` files so `down` resolves the project by label
                 # and still works even if checkout never ran.
+                #
+                # Deliberately NO --env-file here (unlike every other
+                # compose call): with no `-f` there is no compose file to
+                # interpolate, so there is nothing an env-file could
+                # affect — and this backstop has to survive the case where
+                # checkout never ran and web_infra/.env does not exist.
                 docker compose -p "$COMPOSE_PROJECT" \
                     down -v --remove-orphans 2>/dev/null || true
 

--- a/web_e2e/Jenkinsfile.e2e
+++ b/web_e2e/Jenkinsfile.e2e
@@ -96,7 +96,19 @@ pipeline {
     }
 
     options {
-        timeout(time: 1, unit: 'HOURS')
+        // 4h, not 1h: the GRR is no longer a bind-mounted NFS
+        // directory but https://grr.seqpipe.org +
+        // https://grr-sfari.seqpipe.org behind a persistent
+        // per-agent cache, and the cache's unit is a whole file
+        // rather than a byte range — the first build on a given
+        // agent downloads every resource the instance-import and
+        // the suite touch, in full (~32.5 GB worst case). Cold
+        // builds are expected to be slow (and are allowed to be);
+        // warm builds should beat the old NFS baseline, since they
+        // read from local disk. Trim this back once warm-build
+        // times have been measured. Note the timeout also covers
+        // the per-agent `Run e2e` lock wait.
+        timeout(time: 4, unit: 'HOURS')
         buildDiscarder(logRotator(numToKeepStr: '20'))
     }
 
@@ -128,6 +140,35 @@ pipeline {
         E2E_WORKER_COUNT     = "${params.E2E_WORKER_COUNT}"
         E2E_GUNICORN_WORKERS = "${params.E2E_GUNICORN_WORKERS}"
         E2E_GUNICORN_THREADS = "${params.E2E_GUNICORN_THREADS}"
+
+        // Persistent across builds, and shared with gain-web-e2e:
+        // both name the main GRR `grr.sync`, and a group's cache is
+        // keyed by child repo id (GenomicResourceCachedRepo joins
+        // cache_url with proto_id), so both jobs populate and reuse
+        // the same ${HOME}/grr_cache/grr.sync/ tree. Same shape as
+        // gain's web_e2e/Jenkinsfile.e2e and core/
+        // Jenkinsfile.integration: anchored to the agent home (on
+        // pooh, /var/lib/jenkins -> ZFS via the home symlink) rather
+        // than a hardcoded mount, bind-mounted into the containers
+        // by web_infra/compose-jenkins*.yaml.
+        //
+        // Created below with `mkdir -p` rather than relying on the
+        // agent being pre-provisioned (seqpipe/infra#66 provisions it
+        // on the agents, but this job's label is `!dory`, so it must
+        // work on any of them). Concurrent builds on one agent are
+        // safe: the caching protocol takes a per-file lock before
+        // copying.
+        GRR_CACHE_DIR = "${env.HOME}/grr_cache"
+
+        // instance-import and the split-mode backend run as the
+        // agent's uid/gid instead of root, so the long-lived GRR
+        // cache — and the instance dir they rewrite — stay owned by
+        // `jenkins` and remain prunable. Root-owned artefacts in a
+        // workspace are a bug class this stack has already been
+        // bitten by. (The combined-mode image still needs root; see
+        // web_infra/compose-jenkins-combined.yaml.)
+        AGENT_UID = sh(script: 'id -u', returnStdout: true).trim()
+        AGENT_GID = sh(script: 'id -g', returnStdout: true).trim()
     }
 
     stages {
@@ -162,22 +203,57 @@ pipeline {
         stage('Prepare workspace') {
             steps {
                 // Playwright writes traces / videos to
-                // web_e2e/reports and the backend writes Django
-                // file-logs to web_infra/wdae-logs as root (no
-                // USER directive in either container), so the
-                // host Jenkins user can't `rm` them on the next
-                // build. Run the cleanup inside an alpine
-                // container as root to sidestep that. Wiping
-                // wdae-logs each build keeps the captured
-                // artefact attributable to this build only.
-                // Then mkdir runs on the host so the new reports
-                // dir is Jenkins-owned and the post-stage
-                // host-side `cp` can write into it.
+                // web_e2e/reports as root (the e2e-tests container
+                // has no USER directive and needs none), so the host
+                // Jenkins user can't `rm` them on the next build. Run
+                // the cleanup inside an alpine container as root to
+                // sidestep that. Wiping wdae-logs each build keeps
+                // the captured artefact attributable to this build
+                // only.
+                //
+                // The chown in the same container reclaims everything
+                // a root container has left behind, and is what makes
+                // the non-root switch survivable:
+                //   - the import residue under web_e2e/
+                //     gpf_e2e_instance (OUTPUT/, genotype_storage/,
+                //     ...) written by earlier root-run imports — a
+                //     now-non-root instance-import could not rm -rf a
+                //     root-owned directory tree, since unlinking its
+                //     contents needs write permission on the
+                //     directories themselves;
+                //   - GRR cache entries downloaded by a combined-mode
+                //     run, which must stay root (see
+                //     web_infra/compose-jenkins-combined.yaml).
+                // It is metadata-only, so it costs inodes, not bytes.
+                //
+                // GRR_CACHE_DIR is the one thing that must NOT be
+                // wiped — it is the persistent cross-build cache —
+                // so it is only ever mkdir'd and re-chowned. Created
+                // here rather than assumed pre-provisioned, so the
+                // job works on any `!dory` agent.
+                //
+                // Then mkdir runs on the host so the new reports and
+                // wdae-logs dirs are Jenkins-owned: the post-stage
+                // host-side `cp` writes into reports/, and dockerd
+                // creates a *missing* bind source as root:root — a
+                // dir the non-root instance-import / backend could
+                // not write into.
                 sh '''
-                    docker run --rm -v "$PWD:/wd" -w /wd alpine \
-                        rm -rf dist reports web_e2e/reports \
-                               web_infra/wdae-logs
-                    mkdir -p reports/web_e2e
+                    mkdir -p "$GRR_CACHE_DIR"
+
+                    docker run --rm \
+                        -v "$PWD:/wd" \
+                        -v "$GRR_CACHE_DIR:/grr_cache" \
+                        -e AGENT_UID -e AGENT_GID \
+                        -w /wd alpine sh -c '
+                            set -eu
+                            rm -rf dist reports web_e2e/reports \
+                                   web_infra/wdae-logs
+                            chown -R "$AGENT_UID:$AGENT_GID" \
+                                  /wd /grr_cache
+                        '
+
+                    mkdir -p reports/web_e2e web_infra/wdae-logs
                 '''
             }
         }

--- a/web_e2e/README.md
+++ b/web_e2e/README.md
@@ -45,7 +45,7 @@ export DJANGO_SETTINGS_MODULE=gpf_web.settings  # or wgpf_settings; see below
 
 The script's `wdaemanage createapplication` call uses redirect URIs that include `http://localhost:4200/login` and `http://127.0.0.1:8080/gpf/login`, so both dev-server topologies (Angular CLI on 4200 against Django on 8000, **or** `wgpf` on 8080) authenticate out of the box.
 
-`import_data.sh` reads from whatever GRR your shell has configured. CI uses both `grr` and `grr_sfari` (combined as a group via `gpf_e2e_instance/grr-definition.yaml` — see the Jenkins-mirrored compose section below); local-dev uses your machine's default GRR. Once test fixtures start referencing `grr_sfari`-only resources, your local GRR will need both repos available too — point `GRR_DEFINITION_FILE` at `gpf_e2e_instance/grr-definition.yaml` (adjusting the `directory:` paths to your local layout) or roll your own definition with the same children.
+`import_data.sh` reads from whatever GRR your shell has configured. CI uses both `grr` and `grr_sfari` over https, combined as a group via `gpf_e2e_instance/grr-definition.yaml` (see the Jenkins-mirrored compose section below); local-dev uses your machine's default GRR. Once test fixtures start referencing `grr_sfari`-only resources, your local GRR will need both repos available too — point `GRR_DEFINITION_FILE` at `gpf_e2e_instance/grr-definition.yaml` (its `cache_dir: /grr_cache` needs to be an absolute path you can write to) or roll your own definition with the same children.
 
 ### Run the dev servers
 
@@ -135,7 +135,25 @@ There are two stack modes (matching the Jenkins job's `STACK_MODE` parameter):
 
 Both overlays expose a service literally named `frontend`; the test suite's `http://frontend` baseURL works unchanged. Pick a mode by passing the matching overlay file alongside the shared base.
 
-The compose stack bind-mounts two GRR repos from the CSHL Jenkins agents — `/mnt/cephfs/seqpipe/grr` and `/mnt/cephfs/seqpipe/grr_sfari` — and points `GRR_DEFINITION_FILE` at `gpf_e2e_instance/grr-definition.yaml`, which combines them as a `group` repo (`grr_sfari` first, so its enrichment backgrounds override matching IDs in `grr`). On a host without those mounts, either provide equivalent paths or override `GRR_DEFINITION_FILE` to a definition that uses your local layout.
+### The GRR: https + a persistent cache
+
+Every GRR-reading service (`instance-import`, split-mode `backend`, combined-mode `frontend`) points `GRR_DEFINITION_FILE` at `gpf_e2e_instance/grr-definition.yaml`, which is a `group` of the two **http** repos kowalski's `grr-sync` mirrors serve:
+
+| child id | url |
+|---|---|
+| `grr_sfari.sync` | <https://grr-sfari.seqpipe.org> |
+| `grr.sync` | <https://grr.seqpipe.org> |
+
+`grr_sfari` stays **first** — a group resolves an id from the first child that has it, and grr_sfari's enrichment backgrounds deliberately override the matching ids in `grr`. (This replaces the old `/mnt/cephfs/seqpipe/grr{,_sfari}` NFS bind-mounts, which died with piglet's decommissioning; a bind-mount of a missing host path silently yields an *empty* directory.)
+
+The group carries `cache_dir: /grr_cache`, and the compose files bind `${GRR_CACHE_DIR:-./grr_cache}` there. The cache **auto-partitions by child repo id** (`<cache_dir>/grr.sync/`, `<cache_dir>/grr_sfari.sync/`), so:
+
+- **Don't rename the children.** The cache is keyed by their ids; a rename orphans the warm cache instead of failing loudly. `grr.sync` is also what `gain-web-e2e` calls the main GRR, so on a shared agent the two jobs reuse **one** cached copy of it.
+- **The cache's unit is a whole file, not a byte range.** A resource the suite touches at all is downloaded in full. The first run on a fresh cache is slow by design (~32.5 GB worst case: dbSNP, gnomAD genomes/exomes, MPC, ClinVar, GRCh38); every run after it reads from local disk. That is why the job's timeout is 4h and the web-tier healthchecks carry a 3600s `start_period` (a probe failing inside `start_period` burns no retry, so a warm cache pays nothing for it).
+
+In Jenkins, `GRR_CACHE_DIR` is `${HOME}/grr_cache` on the agent (`web_e2e/Jenkinsfile.e2e` `mkdir -p`s it). Locally it defaults to `web_infra/grr_cache`; export `GRR_CACHE_DIR=/some/roomy/path` to put it elsewhere, and expect the first run to download.
+
+`instance-import` and the split-mode `backend` run as **`${AGENT_UID}:${AGENT_GID}`** (the Jenkinsfile exports them; they default to `0:0` outside CI) so the shared cache never fills with root-owned files the `jenkins` user cannot prune or refresh. The combined-mode `frontend` is the exception — the production image's supervisord declares `user=root` and refuses to start otherwise, so the Jenkinsfile chowns the cache back to the agent uid at the start of every build.
 
 ### Build the prod images locally
 
@@ -176,6 +194,16 @@ export BACKEND_IMAGE=gpf-web-api-prod:local
 export FRONTEND_IMAGE=gpf-web-ui-prod:local
 export COMBINED_IMAGE=gpf-web-prod:local         # only used in combined mode
 export COMPOSE_PROJECT=gpf-web-e2e-local
+
+# GRR cache. Unset, it falls back to web_infra/grr_cache (gitignored)
+# and the containers run as root, as they always did locally. Point it
+# at a roomy path you want to keep across runs — the first run
+# downloads every resource the import + the suite touch, in full.
+export GRR_CACHE_DIR="$HOME/grr_cache"
+# Optional: run the non-root services as you, so the cache stays
+# yours. This is what Jenkins does.
+export AGENT_UID="$(id -u)" AGENT_GID="$(id -g)"
+mkdir -p "$GRR_CACHE_DIR"
 
 # Pick one:
 export OVERLAY=web_infra/compose-jenkins-split.yaml      # split mode

--- a/web_e2e/README.md
+++ b/web_e2e/README.md
@@ -151,9 +151,24 @@ The group carries `cache_dir: /grr_cache`, and the compose files bind `${GRR_CAC
 - **Don't rename the children.** The cache is keyed by their ids; a rename orphans the warm cache instead of failing loudly. `grr.sync` is also what `gain-web-e2e` calls the main GRR, so on a shared agent the two jobs reuse **one** cached copy of it.
 - **The cache's unit is a whole file, not a byte range.** A resource the suite touches at all is downloaded in full. The first run on a fresh cache is slow by design (~32.5 GB worst case: dbSNP, gnomAD genomes/exomes, MPC, ClinVar, GRCh38); every run after it reads from local disk. That is why the job's timeout is 4h and the web-tier healthchecks carry a 3600s `start_period` (a probe failing inside `start_period` burns no retry, so a warm cache pays nothing for it).
 
-In Jenkins, `GRR_CACHE_DIR` is `${HOME}/grr_cache` on the agent (`web_e2e/Jenkinsfile.e2e` `mkdir -p`s it). Locally it defaults to `web_infra/grr_cache`; export `GRR_CACHE_DIR=/some/roomy/path` to put it elsewhere, and expect the first run to download.
+In Jenkins, `GRR_CACHE_DIR` is `${HOME}/grr_cache` on the agent. Locally it defaults to `web_infra/grr_cache`; export `GRR_CACHE_DIR=/some/roomy/path` to put it elsewhere, and expect the first run to download.
 
-`instance-import` and the split-mode `backend` run as **`${AGENT_UID}:${AGENT_GID}`** (the Jenkinsfile exports them; they default to `0:0` outside CI) so the shared cache never fills with root-owned files the `jenkins` user cannot prune or refresh. The combined-mode `frontend` is the exception — the production image's supervisord declares `user=root` and refuses to start otherwise, so the Jenkinsfile chowns the cache back to the agent uid at the start of every build.
+`instance-import` and the split-mode `backend` run as **`${AGENT_UID}:${AGENT_GID}`**, defaulting to `0:0` outside CI, so the shared cache never fills with root-owned files the `jenkins` user cannot prune or refresh. The combined-mode `frontend` is the exception — the production image's supervisord declares `user=root` and refuses to start otherwise, so the Jenkinsfile chowns the cache back to the agent uid at the start of every build.
+
+#### How CI gets those three values into compose (and why it's belt-and-braces)
+
+Declaring `GRR_CACHE_DIR` / `AGENT_UID` / `AGENT_GID` in the pipeline's `environment{}` block is **not** sufficient, and quietly failing at it is the exact bug gain-web-e2e #1042 shipped: compose silently took the `${GRR_CACHE_DIR:-./grr_cache}` and `${AGENT_UID:-0}` *fallbacks*, so the "persistent" cache landed **inside the workspace** (wiped by the next build) and every container ran as **root**. Both designs were inert and nothing failed.
+
+So `Jenkinsfile.e2e`'s **`Compose env`** stage pins it, in four layers:
+
+1. Re-derives the values in the shell (`$HOME`, `id -u`, `id -g`) instead of trusting the `environment{}` block.
+2. Writes them to **`web_infra/.env`** — the compose *project directory*, where Compose auto-loads a `.env` from. (Gitignored.)
+3. Passes **`--env-file web_infra/.env`** explicitly on every `docker compose` call, so nothing depends on which directory Compose picks as the project dir.
+4. **Sources that same `.env`** (`set -a; . ./web_infra/.env; set +a`) before each call — because `--env-file` alone is *not* enough: the process environment **outranks** `--env-file`, so a variable that is present-but-**empty** in the shell still wins and still selects the fallback.
+
+Then **`web_infra/verify-compose-env.sh`** runs `docker compose config` and fails the build unless, for every GRR-building service, the `/grr_cache` bind source is exactly `$GRR_CACHE_DIR` (under `$HOME`, outside `$WORKSPACE`), `GRR_DEFINITION_FILE` is set, and the resolved user is non-root — with `frontend` in combined mode as the one documented root exception. It also rejects any surviving `/mnt/cephfs` bind. Run it by hand the same way CI does if you change a compose file.
+
+The `${VAR:-default}` fallbacks stay in the compose YAML as a last-resort guard for a plain local `docker compose up`.
 
 ### Build the prod images locally
 

--- a/web_e2e/gpf_e2e_instance/grr-definition.yaml
+++ b/web_e2e/gpf_e2e_instance/grr-definition.yaml
@@ -53,3 +53,16 @@ children:
   - id: "grr.sync"
     type: http
     url: "https://grr.seqpipe.org"
+  # grr_seqpipe is LAST on purpose (lowest priority). It exists in the
+  # group only to supply resources that neither grr_sfari nor grr have --
+  # today just hg38/enrichment/coding_length_ref_gene_v20170601, which the
+  # default_configuration.yaml enrichment `selected_background_models`
+  # requires and which is absent from iossifovlab/grr entirely (404 on
+  # grr.seqpipe.org, grr-sfari.seqpipe.org AND grr.iossifovlab.com; it only
+  # ever lived on piglet's decommissioned /mnt/cephfs GRR). grr_seqpipe
+  # also carries 7 hg19 gene-model resources that DO overlap grr; putting
+  # this child last means grr's versions win those ids, so adding it here
+  # cannot shadow anything -- it can only fill the gap.
+  - id: "grr_seqpipe.sync"
+    type: http
+    url: "https://grr-seqpipe.seqpipe.org"

--- a/web_e2e/gpf_e2e_instance/grr-definition.yaml
+++ b/web_e2e/gpf_e2e_instance/grr-definition.yaml
@@ -1,13 +1,55 @@
+# GRR definition for the e2e instance. Selected via
+# GRR_DEFINITION_FILE=/data/grr-definition.yaml by every GRR-reading
+# service in web_infra/compose-jenkins*.yaml. CI-only: it lives in the
+# instance dir, not in any image — the production deploys keep using
+# the image-baked web_api/scripts/grr-definition.yaml against CSHL's
+# own on-host GRR.
+#
+# Replaces the bind-mounted NFS GRRs (/mnt/cephfs/seqpipe/grr +
+# /mnt/cephfs/seqpipe/grr_sfari), which died with piglet's
+# decommissioning: a bind-mount of a missing host path yields an
+# *empty* directory, so the GRR read empty and the job had to be
+# disabled. https://grr.seqpipe.org and https://grr-sfari.seqpipe.org
+# serve the same two repositories over https (grr-sync's mirrors on
+# kowalski; grr.seqpipe.org's .CONTENTS.json.gz is byte-identical to
+# grr.iossifovlab.com).
+#
+# Three things here are load-bearing:
+#
+# 1. Child ORDER. `grr_sfari` stays FIRST: a group repo resolves a
+#    resource id from the first child that has it, and grr_sfari's
+#    enrichment backgrounds deliberately override the same ids in
+#    grr. Reordering the children changes behaviour.
+#
+# 2. Child IDS stay verbatim. `cache_dir` on the group auto-partitions
+#    the cache by child repo id — GenomicResourceCachedRepo's
+#    _get_or_create_cache_proto does os.path.join(self.cache_url,
+#    proto_id) — so the cache materialises at /grr_cache/grr.sync/ and
+#    /grr_cache/grr_sfari.sync/. Renaming a child silently orphans the
+#    warm cache (a full cold re-download) instead of failing loudly.
+#    `grr.sync` is also what gain's CI definition calls the main GRR,
+#    so gpf-web-e2e and gain-web-e2e SHARE one cached copy of it on
+#    the agent.
+#
+# 3. No `read_only: true` on the children. It exists on
+#    FileRepoDefinition (what the previous `type: directory` children
+#    were) but NOT on HttpRepoDefinition, and _RepoDefinitionBase sets
+#    extra="forbid" — carrying it over is a hard validation failure,
+#    not a harmless no-op. `public_url` is dropped as unnecessary: for
+#    an http repo it defaults to `url`, which is already the public,
+#    browsable location of exactly this data.
+#
+# The cache's unit is a WHOLE FILE, not a byte range: a resource the
+# suite touches at all is downloaded in full. The first build on an
+# agent is slow by design (~32.5 GB worst case); every build after it
+# reads from local disk. See web_e2e/README.md.
 id: "local"
 type: group
+cache_dir: /grr_cache
 children:
   - id: "grr_sfari.sync"
-    type: directory
-    directory: /grr_sfari
-    public_url: "https://grr-sfari.iossifovlab.com"
-    read_only: true
+    type: http
+    url: "https://grr-sfari.seqpipe.org"
   - id: "grr.sync"
-    type: directory
-    directory: /grr
-    public_url: "https://grr.iossifovlab.com"
-    read_only: true
+    type: http
+    url: "https://grr.seqpipe.org"

--- a/web_infra/.gitignore
+++ b/web_infra/.gitignore
@@ -1,1 +1,6 @@
 /wdae-logs
+# Default local GRR cache: the compose files bind
+# ${GRR_CACHE_DIR:-./grr_cache} at /grr_cache, and a plain local
+# `docker compose up` takes the fallback. In Jenkins it is
+# ${HOME}/grr_cache on the agent, outside the workspace.
+/grr_cache

--- a/web_infra/.gitignore
+++ b/web_infra/.gitignore
@@ -4,3 +4,7 @@
 # `docker compose up` takes the fallback. In Jenkins it is
 # ${HOME}/grr_cache on the agent, outside the workspace.
 /grr_cache
+# Written by web_e2e/Jenkinsfile.e2e's `Compose env` stage: the explicit
+# GRR_CACHE_DIR / AGENT_UID / AGENT_GID that every `docker compose` call
+# is pointed at with --env-file. Per-agent build state, never committed.
+/.env

--- a/web_infra/compose-jenkins-combined.yaml
+++ b/web_infra/compose-jenkins-combined.yaml
@@ -23,6 +23,25 @@ services:
   frontend:
     image: ${COMBINED_IMAGE:-gpf-web-prod:latest}
     hostname: frontend
+    # NOTE: unlike `instance-import` (base) and `backend` (split
+    # overlay), this service is deliberately NOT switched to the agent
+    # uid. The combined image is the production artefact and it needs
+    # root: supervisord.conf declares `user=root` and hard-exits with
+    # "Can't drop privilege as nonroot user" when started by anyone
+    # else (verified), and apache2ctl then has to create
+    # /var/run/apache2 and bind :80. Faking that up (a CI-only
+    # supervisord.conf + a tmpfs over /run) would mean reshaping the
+    # very artefact combined mode exists to test faithfully.
+    #
+    # Consequence: files this container downloads into the shared GRR
+    # cache below are root-owned. That is contained rather than
+    # ignored -- the Jenkinsfile chowns ${GRR_CACHE_DIR} back to the
+    # agent uid at the start of every build, so the cache is
+    # self-healing and the non-root services of the *next* build (or
+    # of gain-web-e2e) can still prune and refresh it. Combined mode
+    # is also opt-in (STACK_MODE defaults to split), and the cache is
+    # largely warmed by the non-root `instance-import` that runs
+    # first, so the root-owned residue is a minority of the tree.
     depends_on:
       instance-import:
         condition: service_completed_successfully
@@ -37,13 +56,14 @@ services:
       # (gpf_instance/gpf_instance.py:102-109). instance-import
       # populated the rest of the tree already.
       - ../web_e2e/gpf_e2e_instance:/data
-      # GRR resources — same group repo (grr_sfari over grr)
-      # as split mode. The combined image bakes a default
-      # /grr-definition.yaml that points at /grr only; the
-      # GRR_DEFINITION_FILE env var below overrides it to the
-      # in-instance file that combines both repos.
-      - /mnt/cephfs/seqpipe/grr:/grr
-      - /mnt/cephfs/seqpipe/grr_sfari:/grr_sfari
+      # Persistent per-agent GRR cache — same mount and same cache_dir
+      # (/grr_cache) as the other two GRR-reading services. The
+      # combined image bakes a default /grr-definition.yaml pointing
+      # at a directory repo under /grr; the GRR_DEFINITION_FILE env
+      # var below overrides it to the in-instance http group
+      # (grr-sfari.seqpipe.org over grr.seqpipe.org). See the base
+      # compose file for the full rationale.
+      - ${GRR_CACHE_DIR:-./grr_cache}:/grr_cache
       # Django file logs — gunicorn (under supervisord) writes
       # wdae-debug.log via WDAE_LOG_DIR exactly as the split-
       # mode backend does. See the base compose file's
@@ -89,7 +109,14 @@ services:
       # split mode's backend healthcheck — gunicorn warm-up
       # dominates startup time in either shape and Apache's
       # extra hop adds negligible latency.
+      #
+      # start_period 3600s for the same reason as split mode's
+      # backend: on a cold GRR cache the first open() of a resource
+      # downloads the whole file over https. Probes that fail inside
+      # start_period don't burn retries, so a warm cache still flips
+      # healthy on the first probe.
       test: ["CMD", "curl", "-f", "http://localhost/api/v3/datasets/"]
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 3600s

--- a/web_infra/compose-jenkins-split.yaml
+++ b/web_infra/compose-jenkins-split.yaml
@@ -16,6 +16,12 @@ services:
 
   backend:
     image: ${BACKEND_IMAGE:-gpf-web-api-prod:latest}
+    # Agent uid/gid, not root — same rationale as `instance-import`
+    # in the base compose file: this service writes into the shared,
+    # long-lived GRR cache, and root-owned entries there are ones the
+    # `jenkins` user can neither prune nor refresh. gunicorn binds
+    # 9001 (unprivileged) and the image needs nothing else from root.
+    user: "${AGENT_UID:-0}:${AGENT_GID:-0}"
     # Tests target the frontend service at http://frontend
     # (web_e2e/tests/utils.ts) — Apache there reverse-proxies
     # /api/ and /ws/ to backend:9001, so the SPA and API share
@@ -78,17 +84,11 @@ services:
       # gpf_instance.py:102-109) — same behaviour production
       # deployments rely on; build #12 caught the mismatch.
       - ../web_e2e/gpf_e2e_instance:/data
-      # GRR resources mount — same shape as gain's
-      # web_infra/compose-jenkins.yaml. The paths are the CSHL
-      # Jenkins agents' shared GRR caches; runs on other hosts
-      # need to provide equivalent /grr + /grr_sfari or override
-      # GRR_DEFINITION_FILE to a different definition. Both
-      # mounts are required: the e2e instance fixture's
-      # grr-definition.yaml below combines them as a `group`
-      # repo with grr_sfari first (overriding overlapping
-      # enrichment IDs in grr).
-      - /mnt/cephfs/seqpipe/grr:/grr
-      - /mnt/cephfs/seqpipe/grr_sfari:/grr_sfari
+      # Persistent per-agent GRR cache — same mount, same cache_dir
+      # (/grr_cache) as `instance-import` in the base compose file,
+      # which has already warmed most of it by the time this service
+      # starts. See the base file for the full rationale.
+      - ${GRR_CACHE_DIR:-./grr_cache}:/grr_cache
       # Django file logs (wdae-debug.log via WDAE_LOG_DIR);
       # see the matching mount on instance-import in the base
       # for the full rationale.
@@ -96,12 +96,17 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: gpf_web.production_settings
       DAE_DB_DIR: /data
-      # The prod image bakes /grr-definition.yaml (single /grr
-      # repo, see web_api/Dockerfile.production). Override here to
-      # the in-instance file that defines a group of /grr_sfari +
-      # /grr — e2e-only, leaves prod deployments on the single
-      # repo. The instance dir is bind-mounted at /data above.
+      # The prod image bakes /grr-definition.yaml (a single
+      # directory-backed repo at /grr, see
+      # web_api/Dockerfile.production). Override here to the
+      # in-instance file that defines the http group of
+      # grr-sfari.seqpipe.org + grr.seqpipe.org behind /grr_cache —
+      # e2e-only, leaves prod deployments on their on-host GRR. The
+      # instance dir is bind-mounted at /data above.
       GRR_DEFINITION_FILE: /data/grr-definition.yaml
+      # No passwd entry for the agent uid in the image -> HOME would
+      # be `/`, which is not writable. See the base compose file.
+      HOME: /tmp
       WDAE_DB_NAME: gpf
       WDAE_DB_USER: seqpipe
       WDAE_DB_PASSWORD: secret
@@ -143,10 +148,24 @@ services:
       # gain's compose-jenkins.yaml uses the same pattern:
       # /api/editor/pipeline_status?pipeline_id=pipeline/Clinical_annotation
       # with --max-time 120.
+      #
+      # start_period is generous because the GRR is now an http repo
+      # behind a cache whose unit is a WHOLE FILE, not a byte range:
+      # against the old NFS bind a tabix query read a few KB of a
+      # score file, but on a cold cache the first open() downloads the
+      # entire file. `instance-import` warms most of what the suite
+      # touches before this service starts, but eager study loading
+      # can still be the first thing to open a given resource. While
+      # in start_period a failing probe only marks the container
+      # `starting` — it does not burn one of the 30 retries — so this
+      # is a budget for a cold GRR, not added latency: a warm cache
+      # goes healthy on the first probe and pays nothing. The real
+      # ceiling is the Jenkins job timeout.
       test: ["CMD", "curl", "-f", "http://localhost:9001/api/v3/datasets/"]
       interval: 10s
       timeout: 5s
       retries: 30
+      start_period: 3600s
 
   frontend:
     image: ${FRONTEND_IMAGE:-gpf-web-ui-prod:latest}

--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -127,13 +127,32 @@ services:
   # Apache into a step that doesn't need them.
   instance-import:
     image: ${BACKEND_IMAGE:-gpf-web-api-prod:latest}
+    # Run as the agent's uid/gid, not root. The GRR cache below is
+    # long-lived and shared across builds (and with gain-web-e2e); a
+    # root-owned cache tree is one the `jenkins` user can neither
+    # prune nor rewrite -- the EPERM-on-root-owned-artefacts bug class
+    # this stack has already hit. Same reasoning applies to the
+    # instance dir this one-shot rm -rf's and rebuilds. The host bind
+    # sources are created (and reclaimed) by the Jenkinsfile before
+    # compose runs, because dockerd creates a *missing* bind source as
+    # root:root, which a non-root container then cannot write into.
+    user: "${AGENT_UID:-0}:${AGENT_GID:-0}"
     depends_on:
       db:
         condition: service_healthy
     volumes:
       - ../web_e2e/gpf_e2e_instance:/data:rw
-      - /mnt/cephfs/seqpipe/grr:/grr
-      - /mnt/cephfs/seqpipe/grr_sfari:/grr_sfari
+      # Persistent per-agent GRR cache, replacing the dead
+      # /mnt/cephfs/seqpipe/grr + /mnt/cephfs/seqpipe/grr_sfari NFS
+      # binds (piglet is decommissioned). /grr_cache is the cache_dir
+      # named by the instance's grr-definition.yaml, which now points
+      # at https://grr.seqpipe.org + https://grr-sfari.seqpipe.org;
+      # the group's cache auto-partitions by child repo id, so the
+      # trees land at /grr_cache/grr.sync/ and /grr_cache/
+      # grr_sfari.sync/. This one-shot does the bulk of the cold
+      # download (imports + annotation + reports); the web tier that
+      # follows mostly reads an already-warm cache.
+      - ${GRR_CACHE_DIR:-./grr_cache}:/grr_cache
       # Django writes wdae-debug.log under WDAE_LOG_DIR
       # (default_settings.py LOGGING). Bind to a host path the
       # Jenkinsfile archives so the file logs survive `compose
@@ -147,6 +166,11 @@ services:
       DJANGO_SETTINGS_MODULE: gpf_web.production_settings
       DAE_DB_DIR: /data
       GRR_DEFINITION_FILE: /data/grr-definition.yaml
+      # The image has no passwd entry for the agent uid, so HOME would
+      # default to `/` (root-owned, unwritable). Point it somewhere
+      # writable: matplotlib (build_pheno_browser) and friends reach
+      # for a dotfile cache under $HOME on first use.
+      HOME: /tmp
       WDAE_DB_NAME: gpf
       WDAE_DB_USER: seqpipe
       WDAE_DB_PASSWORD: secret

--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -137,6 +137,14 @@ services:
     # compose runs, because dockerd creates a *missing* bind source as
     # root:root, which a non-root container then cannot write into.
     user: "${AGENT_UID:-0}:${AGENT_GID:-0}"
+    # Run from a writable cwd. import_data.sh runs several gain/gpf task-graph
+    # CLIs (generate_gene_profile, generate_common_report,
+    # generate_denovo_gene_sets) whose default task-log dir is
+    # `os.getcwd()/.task-log` (gain task_graph/logging.py). The container's
+    # default cwd is `/`, so as a non-root uid every one of them EPERMs on
+    # `/.task-log`. /tmp is writable; the script itself uses only absolute
+    # ${INSTANCE_DIR} paths, and its `cd -` now returns here rather than to /.
+    working_dir: /tmp
     depends_on:
       db:
         condition: service_healthy

--- a/web_infra/verify-compose-env.sh
+++ b/web_infra/verify-compose-env.sh
@@ -1,0 +1,214 @@
+#!/bin/sh
+# Fail the build unless the e2e compose stack resolves the GRR cache
+# bind and the container uid to the values we actually intend.
+#
+# WHY THIS EXISTS
+# ---------------
+# gain-web-e2e #1042 (same compose pattern, same bug here) came up green-ish
+# while being silently wrong:
+# `docker inspect` on the live container showed
+#
+#     <workspace>/web_infra/grr_cache -> /grr_cache      (not ${HOME}/grr_cache)
+#     User = 0:0                                         (not the agent uid)
+#
+# i.e. compose had taken the `${GRR_CACHE_DIR:-./grr_cache}` and
+# `${AGENT_UID:-0}:${AGENT_GID:-0}` *fallbacks* even though the pipeline's
+# `environment{}` block sets all three. The persistent-cache design and the
+# non-root design were both inert, and nothing said so: the cache landed in
+# the workspace (wiped by the next build's cleanup) and every resource was
+# re-downloaded, as root, forever.
+#
+# A silent fallback to a workspace-local cache running as root is exactly the
+# bug this file guards. It must never pass quietly again — so this script
+# asserts on the RESOLVED config (`docker compose config`), not on what we
+# think we exported, and it fails loudly with expected-vs-actual.
+#
+# It also enforces the third leg, which #1042 got wrong in a different way:
+# gpf's instance-import container never received GRR_DEFINITION_FILE, so it
+# fell back to the image's baked-in default GRR (grr.iossifovlab.com) and
+# cached nothing. Every service that constructs a GRR needs ALL THREE of:
+# the /grr_cache bind, GRR_DEFINITION_FILE, and a non-root user.
+#
+# USAGE
+#   web_infra/verify-compose-env.sh <env-file> <compose.yaml> [<overlay.yaml>]
+#
+# INPUTS (environment)
+#   GRR_CACHE_DIR        required — the bind source every /grr_cache mount
+#                        must resolve to, exactly.
+#   EXPECT_GRR_SERVICES  required — space-separated services that MUST have
+#                        all three legs.
+#   ROOT_OK_SERVICES     optional — space-separated subset of the above that
+#                        is allowed to stay root (documented exceptions only).
+#   WORKSPACE            optional — if set, GRR_CACHE_DIR must NOT live under
+#                        it (that is the fallback-into-the-workspace bug).
+#   HOME                 optional — if set, GRR_CACHE_DIR must live under it.
+set -eu
+
+ENV_FILE="${1:?usage: verify-compose-env.sh <env-file> <compose.yaml> [overlay]}"
+COMPOSE_FILE="${2:?usage: verify-compose-env.sh <env-file> <compose.yaml> [overlay]}"
+OVERLAY="${3:-}"
+
+: "${GRR_CACHE_DIR:?GRR_CACHE_DIR must be set}"
+: "${EXPECT_GRR_SERVICES:?EXPECT_GRR_SERVICES must be set}"
+ROOT_OK_SERVICES="${ROOT_OK_SERVICES:-}"
+
+fail() {
+    echo "" >&2
+    echo "================ COMPOSE ENV VERIFICATION FAILED ================" >&2
+    echo "$@" >&2
+    echo "================================================================" >&2
+    exit 1
+}
+
+[ -f "$ENV_FILE" ] || fail "env-file not found: $ENV_FILE"
+
+case "$GRR_CACHE_DIR" in
+    /*) ;;
+    *) fail "GRR_CACHE_DIR must be an absolute path.
+    expected: an absolute path under \$HOME
+    actual:   '$GRR_CACHE_DIR'" ;;
+esac
+
+# The whole point of the cache is that it OUTLIVES the build. A cache inside
+# the workspace is deleted by the next build's cleanup — that is the #1042
+# bug verbatim, so reject it before docker is even consulted.
+if [ -n "${WORKSPACE:-}" ]; then
+    case "$GRR_CACHE_DIR/" in
+        "$WORKSPACE"/*) fail "GRR_CACHE_DIR resolves INSIDE the Jenkins workspace.
+    This is the gain-web-e2e #1042 bug: the cache would be wiped by the
+    next build's cleanup and every GRR resource re-downloaded.
+    expected: a path under \$HOME, outside \$WORKSPACE
+    actual:   '$GRR_CACHE_DIR'
+    workspace: '$WORKSPACE'" ;;
+    esac
+fi
+
+if [ -n "${HOME:-}" ]; then
+    case "$GRR_CACHE_DIR/" in
+        "$HOME"/*) ;;
+        *) fail "GRR_CACHE_DIR is not under \$HOME.
+    expected: a path under '$HOME'
+    actual:   '$GRR_CACHE_DIR'" ;;
+    esac
+fi
+
+set -- --env-file "$ENV_FILE" -f "$COMPOSE_FILE"
+[ -n "$OVERLAY" ] && set -- "$@" -f "$OVERLAY"
+
+CONFIG="$(docker compose "$@" config)" \
+    || fail "\`docker compose config\` failed — the stack does not even resolve."
+
+# The dead NFS GRR must be gone everywhere, in every service, in both modes.
+if printf '%s\n' "$CONFIG" | grep -q '/mnt/cephfs'; then
+    fail "a /mnt/cephfs bind survives in the resolved config:
+$(printf '%s\n' "$CONFIG" | grep -n '/mnt/cephfs')
+    The NFS GRR died with piglet; nothing may reference it."
+fi
+
+# Parse the RESOLVED config. Indent anchors are exact: compose's canonical
+# output puts service names at 2 spaces, service keys at 4, environment keys
+# at 6, and volume entry keys at 8 — so these patterns cannot accidentally
+# match a value that merely looks like a key.
+TABLE="$(printf '%s\n' "$CONFIG" | awk '
+    /^services:$/ { in_svc = 1; next }
+    /^[a-zA-Z]/   { in_svc = 0 }
+    !in_svc       { next }
+    /^  [^ ]/ {
+        svc = $1; sub(/:$/, "", svc)
+        order[++n] = svc
+        next
+    }
+    /^        source: /              { src = $2 }
+    /^        target: \/grr_cache$/  { cache[svc] = src }
+    /^    user: /                    { u = $2; gsub(/['"'"'"]/, "", u); user[svc] = u }
+    /^      GRR_DEFINITION_FILE: /   { grrdef[svc] = $2 }
+    END {
+        for (i = 1; i <= n; i++) {
+            s = order[i]
+            printf "%s\t%s\t%s\t%s\n", s, \
+                (s in cache  ? cache[s]  : "-"), \
+                (s in user   ? user[s]   : "0:0"), \
+                (s in grrdef ? grrdef[s] : "-")
+        }
+    }
+')"
+
+echo "resolved compose config: $COMPOSE_FILE ${OVERLAY:+
+                        + $OVERLAY}"
+echo "expected /grr_cache bind source: $GRR_CACHE_DIR"
+echo ""
+printf '%-24s %-40s %-12s %s\n' SERVICE /grr_cache-BIND-SOURCE USER GRR_DEFINITION_FILE
+printf '%-24s %-40s %-12s %s\n' ------- --------------------- ---- -------------------
+printf '%s\n' "$TABLE" | while IFS="$(printf '\t')" read -r svc src usr def; do
+    printf '%-24s %-40s %-12s %s\n' "$svc" "$src" "$usr" "$def"
+done
+echo ""
+
+errors=""
+note() { errors="${errors}
+  - $1"; }
+
+# (1) Anti-vacuity. A check that matches nothing asserts nothing — this repo
+#     has been bitten by that more than once. If NO service binds /grr_cache,
+#     the parser or the compose file broke and every check below is a no-op.
+bound=$(printf '%s\n' "$TABLE" | awk -F'\t' '$2 != "-"' | wc -l)
+[ "$bound" -ge 1 ] || fail "no service binds /grr_cache at all.
+    Either the compose file lost the mount or this parser stopped matching.
+    Refusing to pass a check that asserts nothing."
+
+# (2) EVERY /grr_cache bind in the file — not just the expected ones — must
+#     resolve to GRR_CACHE_DIR. This is the check that catches the fallback.
+while IFS="$(printf '\t')" read -r svc src _usr _def; do
+    [ "$src" = "-" ] && continue
+    [ "$src" = "$GRR_CACHE_DIR" ] && continue
+    note "$svc: /grr_cache bind source is wrong (compose took the fallback?)
+      expected: $GRR_CACHE_DIR
+      actual:   $src"
+done <<EOF
+$TABLE
+EOF
+
+# (3) Every service that builds a GRR needs all three legs.
+for svc in $EXPECT_GRR_SERVICES; do
+    row=$(printf '%s\n' "$TABLE" | awk -F'\t' -v s="$svc" '$1 == s')
+    if [ -z "$row" ]; then
+        note "$svc: expected to exist in the resolved config, but it does not."
+        continue
+    fi
+    src=$(printf '%s' "$row" | cut -f2)
+    usr=$(printf '%s' "$row" | cut -f3)
+    def=$(printf '%s' "$row" | cut -f4)
+
+    [ "$src" = "-" ] && note "$svc: has NO /grr_cache bind.
+      expected: $GRR_CACHE_DIR mounted at /grr_cache
+      actual:   no bind — this service would cache nothing."
+
+    if [ "$def" = "-" ]; then
+        note "$svc: has NO GRR_DEFINITION_FILE.
+      It would silently fall back to the image's baked-in default GRR
+      (the gain-web-e2e #1042 instance-import bug) and cache nothing."
+    fi
+
+    root_ok=no
+    for ok in $ROOT_OK_SERVICES; do
+        [ "$ok" = "$svc" ] && root_ok=yes
+    done
+    if [ "$usr" = "0:0" ] && [ "$root_ok" = no ]; then
+        note "$svc: resolved user is 0:0 (root) — compose took the
+      \${AGENT_UID:-0}:\${AGENT_GID:-0} fallback.
+      expected: a non-root uid:gid (the agent's)
+      actual:   0:0
+      Root-owned entries in the shared cache cannot be pruned by 'jenkins'."
+    fi
+done
+
+[ -z "$errors" ] || fail "the resolved compose config is not what this
+pipeline intends:$errors"
+
+echo "OK: /grr_cache binds to $GRR_CACHE_DIR in every service that mounts it;"
+# tr -s: collapse any line-continuation whitespace the caller's shell left
+# in the list, so the log line reads cleanly.
+expect_pretty=$(printf '%s' "$EXPECT_GRR_SERVICES" | tr -s ' ')
+echo "OK: all of [$expect_pretty] carry a GRR definition + cache bind;"
+echo "OK: non-root uid enforced${ROOT_OK_SERVICES:+ (documented root exception: $ROOT_OK_SERVICES)};"
+echo "OK: no /mnt/cephfs bind anywhere in the resolved config."


### PR DESCRIPTION
Closes #973. Companion to iossifovlab/gain#271 (same change for `gain-web-e2e`); part of iossifovlab/gain#269.

`gpf-web-e2e` is currently **disabled**: `instance-import` (base), split-mode `backend` and combined-mode `frontend` all bind-mounted `/mnt/cephfs/seqpipe/grr` + `/mnt/cephfs/seqpipe/grr_sfari`, and piglet — the NFS server behind `/mnt/cephfs` — is decommissioned. A bind-mount of a missing host path yields an *empty* directory, so the GRR read empty.

This points CI at the two http GRRs `grr-sync` mirrors on kowalski — **https://grr.seqpipe.org** (`.CONTENTS.json.gz` byte-identical to `grr.iossifovlab.com`) and **https://grr-sfari.seqpipe.org** — behind a **persistent per-agent cache**.

**Production is untouched.** It keeps the image-baked `web_api/scripts/grr-definition.yaml` (`directory: /grr`) and CSHL's own on-host GRR. Only the e2e instance's definition changes, and that file is bind-mounted from the checkout, not baked into any image — so no Dockerfile change is needed here (this is where gpf differs from gain#271, which had to add `grr-definition-http.yaml` to its image).

## Changes

| File | Change |
|---|---|
| `web_e2e/gpf_e2e_instance/grr-definition.yaml` | still a `group`, same two children in the same order — now `type: http` against seqpipe.org, with `cache_dir: /grr_cache` on the group |
| `web_infra/compose-jenkins.yaml` | `instance-import`: drop the two NFS binds, add `${GRR_CACHE_DIR}:/grr_cache`, run as the agent uid, `HOME=/tmp` |
| `web_infra/compose-jenkins-split.yaml` | same for `backend`, plus `start_period: 3600s` on its healthcheck |
| `web_infra/compose-jenkins-combined.yaml` | same cache mount + `start_period` for `frontend`; it **stays root** (see below) |
| `web_e2e/Jenkinsfile.e2e` | `GRR_CACHE_DIR`/`AGENT_UID`/`AGENT_GID`; `mkdir -p` the cache and the `wdae-logs` bind source; chown the workspace + cache back to the agent uid; job timeout 1h → 4h |
| `web_e2e/README.md`, `web_infra/.gitignore` | document the https + cache model; ignore the local default cache dir |

## Four load-bearing, non-obvious details

- **Child order is preserved.** `grr_sfari` stays first: a group resolves an id from the first child that has it, and grr_sfari's enrichment backgrounds deliberately override the matching ids in `grr`.
- **Child ids stay verbatim.** A group-level `cache_dir` auto-partitions by child repo id (`_get_or_create_cache_proto` does `os.path.join(self.cache_url, proto_id)`), so the cache materialises at `/grr_cache/grr.sync/` and `/grr_cache/grr_sfari.sync/`. A rename would silently orphan the warm cache rather than fail loudly. `grr.sync` is also what gain's CI definition calls the main GRR, so **gpf-web-e2e and gain-web-e2e share one cached copy** of it on the agent.
- **No `read_only: true`.** It exists on `FileRepoDefinition` (what the old `type: directory` children were) but *not* on `HttpRepoDefinition`, and `_RepoDefinitionBase` sets `extra="forbid"` — carrying it over is a hard validation failure.
- **The cache's unit is a whole file, not a byte range.** A resource the suite touches at all is downloaded in full — ~32.5 GB worst case (dbSNP 15 GB, gnomAD genomes 11 GB, MPC 2.4 GB, gnomAD exomes 1.4 GB, ClinVar 1.4 GB, GRCh38 0.8 GB). Hence job timeout **1h → 4h** and healthcheck `start_period` **3600s** on the web tier: a slow cold build must not be converted into a *failed* healthcheck (`dependency failed to start`). A probe failing inside `start_period` burns no retry, so a warm cache pays nothing for the budget. Large downloads need no new retry logic — gain#43 already shipped the aiohttp timeout + whole-file retry with backoff. Both numbers deserve trimming once a real cold run and a real warm run have been measured.

## Non-root, and the one exception

`instance-import` and the split-mode `backend` run as `${AGENT_UID}:${AGENT_GID}`. The cache is long-lived and shared; a root-owned cache tree is one the `jenkins` user can neither prune nor refresh — the EPERM-on-root-owned-artefacts bug class this stack has already hit. Consequences handled in the Jenkinsfile: `HOME=/tmp` (the image has no passwd entry for the agent uid), `wdae-logs` is `mkdir`'d on the host (dockerd creates a *missing* bind source as `root:root`), and the workspace + cache are chown'd back to the agent uid at the start of every build — which is also the only way a now-non-root `instance-import` can `rm -rf` the root-owned import residue earlier builds left in `gpf_e2e_instance/`.

**Combined mode stays root** — the deviation from gain#271, which had no such service. The combined image is the production artefact: its `supervisord.conf` declares `user=root` and hard-exits with `Can't drop privilege as nonroot user` under any other uid (verified against a rebuild of that image's runtime layers), after which `apache2ctl` still has to create `/var/run/apache2` and bind `:80`. Overriding that (a CI-only supervisord conf + a tmpfs over `/run`) would reshape the very artefact combined mode exists to test faithfully. The per-build chown contains the fallout instead, combined mode is opt-in (`STACK_MODE` defaults to `split`), and the non-root `instance-import` warms most of the cache before it ever starts.

## Validation

I cannot run the e2e suite or Jenkins from here, so:

- **The new definition was built through gain's own factory**, not eyeballed: `build_genomic_resource_repository(file_name=...)` returns a `GenomicResourceCachedRepo` with `cache_url == "file:///grr_cache"`, child order `['grr_sfari.sync', 'grr.sync']`, and cache protocols resolving to `<cache_dir>/grr_sfari.sync` and `<cache_dir>/grr.sync` (confirmed on disk against a writable temp `cache_dir`). Adding `read_only: true` to the same dict is **rejected** — `group.children.0.http.read_only: Extra inputs are not permitted [type=extra_forbidden]` — confirming that trap is real. The prod definition still loads unchanged.
- `docker compose config` on **both** overlays interpolates and validates: `user: 1000:1000` on `instance-import` + `backend` (and no `user` on the combined `frontend`), `source: /var/lib/jenkins/grr_cache → /grr_cache` on all three GRR readers, `start_period: 1h0m0s` on the web tier, and **no `/mnt/cephfs` bind anywhere**.
- The `Prepare workspace` shell body was executed verbatim against a simulated workspace seeded with root-owned residue: it reclaims the import tree and the cache, wipes the reports, and creates `wdae-logs` host-side — after which a non-root `rm -rf` of the previously-root-owned tree succeeds.
- `web_e2e/Jenkinsfile.e2e` passes the live controller's declarative linter.

**Not verified** (needs a real run): the actual cold-download volume and whether 4h / 3600s are enough; that nothing else in the backend image needs root at runtime; and that `${HOME}/grr_cache` is writable by the Jenkins user on every `!dory` agent. The job also has to be **re-enabled** in Jenkins — a green cold run followed by a fast warm run is the acceptance test, per #973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)