### PR TITLE
Fix GeneScoresListView crash on categorical gene scores (#982)

### DIFF
--- a/web_api/gpf_web/gene_scores/tests/test_gene_scores_views.py
+++ b/web_api/gpf_web/gene_scores/tests/test_gene_scores_views.py
@@ -1,9 +1,130 @@
 # pylint: disable=W0621,C0114,C0116,W0212,W0613
 import json
+import pathlib
 
 import pytest
+import pytest_mock
 from django.test.client import Client
+from gain.genomic_resources.cli import cli_manage
+from gain.genomic_resources.repository_factory import (
+    build_genomic_resource_repository,
+)
+from gain.genomic_resources.testing.builders import a_gene_score
 from gpf_instance.gpf_instance import WGPFInstance
+from studies.query_transformer import QueryTransformer
+from studies.response_transformer import ResponseTransformer
+from utils.testing import setup_t4c8_instance
+
+
+@pytest.fixture
+def categorical_wgpf_instance(
+    tmp_path: pathlib.Path,
+    db: None,  # noqa: ARG001 ; enable the Django test database
+    mocker: pytest_mock.MockFixture,
+) -> WGPFInstance:
+    """A WGPF instance carrying a number and a categorical gene score.
+
+    Built on the shared t4c8 instance (which already ships the number score
+    ``t4c8_score``); a categorical gene score ``cat_score`` is added to the
+    GRR and wired into ``gene_scores_db`` so both scores surface through the
+    gene-scores endpoints.
+    """
+    root_path = tmp_path
+    t4c8_instance = setup_t4c8_instance(root_path)
+    grr_dir = root_path / "t4c8_grr"
+
+    (
+        a_gene_score()
+        .with_score("cat_score", column_name="score", desc="categorical score")
+        .with_histogram({"type": "categorical", "value_order": [1, 2, 3]})
+        .with_data("""
+            gene score
+            t4    1
+            c8    2
+        """)
+        .realize_into(grr_dir / "gene_scores" / "cat_score")
+    )
+    cli_manage(["repo-repair", "-R", str(grr_dir), "-j", "1"])
+
+    instance_filename = (
+        pathlib.Path(t4c8_instance.dae_dir) / "gpf_instance.yaml"
+    )
+    instance_filename.write_text(
+        instance_filename.read_text().replace(
+            '  - "gene_scores/t4c8_score"',
+            '  - "gene_scores/t4c8_score"\n  - "gene_scores/cat_score"',
+        ),
+    )
+
+    grr = build_genomic_resource_repository({
+        "id": "t4c8_local",
+        "type": "directory",
+        "directory": str(grr_dir),
+    })
+    wgpf_instance = WGPFInstance.build(str(instance_filename), grr=grr)
+
+    query_transformer = QueryTransformer(
+        wgpf_instance.gene_scores_db,
+        wgpf_instance.reference_genome.chromosomes,
+        wgpf_instance.reference_genome.chrom_prefix,
+    )
+    response_transformer = ResponseTransformer(wgpf_instance.gene_scores_db)
+
+    for target in (
+        "gpf_instance.gpf_instance.get_wgpf_instance",
+        "datasets_api.permissions.get_wgpf_instance",
+        "query_base.query_base.get_wgpf_instance",
+    ):
+        mocker.patch(target, return_value=wgpf_instance)
+    mocker.patch(
+        "query_base.query_base.get_or_create_query_transformer",
+        return_value=query_transformer,
+    )
+    mocker.patch(
+        "query_base.query_base.get_or_create_response_transformer",
+        return_value=response_transformer,
+    )
+
+    return wgpf_instance
+
+
+def test_gene_scores_list_view_categorical(
+    user_client: Client,
+    categorical_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup instance
+) -> None:
+    url = "/api/v3/gene_scores"
+    response = user_client.get(url)
+    assert response.status_code == 200
+
+    data = response.json()
+    by_score = {d["score"]: d for d in data}
+    assert set(by_score) == {"t4c8_score", "cat_score"}
+
+    number_score = by_score["t4c8_score"]
+    assert "bars" in number_score
+    assert "bins" in number_score
+
+    categorical_score = by_score["cat_score"]
+    assert "bars" not in categorical_score
+    assert "bins" not in categorical_score
+    assert categorical_score["histogram"]["config"]["type"] == "categorical"
+
+
+def test_gene_scores_histograms_view_categorical(
+    user_client: Client,
+    categorical_wgpf_instance: WGPFInstance,  # noqa: ARG001 ; setup instance
+) -> None:
+    url = "/api/v3/gene_scores/histograms"
+    response = user_client.get(url)
+    assert response.status_code == 200
+
+    data = response.json()
+    by_score = {d["score"]: d for d in data}
+    assert set(by_score) == {"t4c8_score", "cat_score"}
+
+    assert (
+        by_score["cat_score"]["histogram"]["config"]["type"] == "categorical"
+    )
 
 
 def test_gene_scores_list_view(

--- a/web_api/gpf_web/gene_scores/views.py
+++ b/web_api/gpf_web/gene_scores/views.py
@@ -1,9 +1,12 @@
+from typing import Any
 
 import numpy as np
 from datasets_api.permissions import get_instance_timestamp_etag
 from django.http.response import StreamingHttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import etag
+from gain.gene_scores.gene_scores import ScoreDesc
+from gain.genomic_resources.histogram import NumberHistogram
 from query_base.query_base import QueryBaseView
 from rest_framework import status
 from rest_framework.request import Request
@@ -25,26 +28,40 @@ class GeneScoresListView(QueryBaseView):
         else:
             gene_scores = self.gpf_instance.get_all_gene_score_descs()
         return Response(
-            [
-                {
-                    "score": score.score_id,
-                    "desc": f"{score.score_id} - {score.description}",
-                    "bars": score.hist.bars,
-                    "bins": score.hist.bins,
-                    "xscale":
-                        "log" if score.hist.config.x_log_scale else
-                        "linear",
-                    "yscale":
-                        "log" if score.hist.config.y_log_scale else
-                        "linear",
-                    "range": score.hist.config.view_range,
-                    "help": score.help,
-                    "small_values_desc": score.small_values_desc,
-                    "large_values_desc": score.large_values_desc,
-                }
-                for score in gene_scores
-            ],
+            [self._score_record(score) for score in gene_scores],
         )
+
+    @staticmethod
+    def _score_record(score: ScoreDesc) -> dict[str, Any]:
+        """Serialize a gene score description into a flat record.
+
+        A numeric score keeps today's byte-identical
+        ``bars``/``bins``/``xscale``/``yscale``/``range`` shape; a categorical
+        (or null) score drops those number-only keys and carries the
+        polymorphic ``histogram`` payload instead.
+        """
+        record: dict[str, Any] = {
+            "score": score.score_id,
+            "desc": f"{score.score_id} - {score.description}",
+        }
+        if isinstance(score.hist, NumberHistogram):
+            record.update({
+                "bars": score.hist.bars,
+                "bins": score.hist.bins,
+                "xscale":
+                    "log" if score.hist.config.x_log_scale else "linear",
+                "yscale":
+                    "log" if score.hist.config.y_log_scale else "linear",
+                "range": score.hist.config.view_range,
+            })
+        else:
+            record["histogram"] = score.hist.to_dict()
+        record.update({
+            "help": score.help,
+            "small_values_desc": score.small_values_desc,
+            "large_values_desc": score.large_values_desc,
+        })
+        return record
 
 
 class HistogramView(QueryBaseView):

--- a/web_api/gpf_web/gpf_web/default_settings.py
+++ b/web_api/gpf_web/gpf_web/default_settings.py
@@ -124,10 +124,7 @@ STATIC_ROOT = ""
 # /<prefix>/static/ — where the combined image's Apache aliases
 # it. Root keeps the relative "static/" it has always used.
 # WDAE_PREFIX is read above (next to LOGIN_URL/FORCE_SCRIPT_NAME).
-if WDAE_PREFIX:
-    STATIC_URL = f"/{WDAE_PREFIX}/static/"
-else:
-    STATIC_URL = "static/"
+STATIC_URL = f"/{WDAE_PREFIX}/static/" if WDAE_PREFIX else "static/"
 
 APPEND_SLASH = False
 

--- a/web_api/gpf_web/pheno_browser_api/views.py
+++ b/web_api/gpf_web/pheno_browser_api/views.py
@@ -178,7 +178,9 @@ class PhenoMeasuresView(QueryBaseView):
         return Response(res)
 
 
-class PhenoMeasuresDownload(FeatureFlagMixin, QueryBaseView, DatasetAccessRightsView):
+class PhenoMeasuresDownload(
+    FeatureFlagMixin, QueryBaseView, DatasetAccessRightsView,
+):
     """Phenotype measure downloads view."""
 
     feature_flag = "pheno_browser_download"


### PR DESCRIPTION
## What changed and why

`GET /api/v3/gene_scores` (`GeneScoresListView`) unconditionally read
`score.hist.bars` / `.bins` / `.config.*`, which raised `AttributeError`
for any gene score whose histogram is **categorical** (or null) rather
than numeric — the flat list endpoint 500'd instead of listing the score.

Per gain's post-#303 contract (`GeneScore.get_score_histogram() ->
Histogram`, "callers that need numeric-only attributes must narrow with
`isinstance(hist, NumberHistogram)` first"), the view now narrows before
touching number-only attributes:

- **Numeric** scores keep today's exact
  `bars`/`bins`/`xscale`/`yscale`/`range` record — byte-identical.
- **Categorical / null** scores drop those number-only keys and carry the
  polymorphic `histogram: score.hist.to_dict()` payload the Angular
  gene-scores view already renders from the `/histograms` endpoint.

`HistogramView` already delegated to `hist.to_dict()` and never crashed —
it is **left unchanged**, with new test-only coverage asserting it stays
well-formed for a categorical score. No frontend work is required
(`web_ui` already renders categorical from `/histograms`; the flat
endpoint has no `web_ui`/`web_e2e`/Python consumer).

## Acceptance evidence & how to run

```bash
cd gpf/web_api
uv run pytest -v gpf_web/gene_scores/tests/test_gene_scores_views.py
uv run ruff check gpf_web/gene_scores/
uv run mypy gpf_web/gene_scores/
```

- `test_gene_scores_list_view_categorical` — `GET /api/v3/gene_scores` →
  200; number score keeps `bars`/`bins`; categorical score carries
  `histogram` with `config.type == "categorical"` and **no** `bars`/`bins`.
- `test_gene_scores_histograms_view_categorical` — `GET
  /api/v3/gene_scores/histograms` → 200; categorical score's
  `histogram.config.type == "categorical"`.
- `test_gene_scores_list_view` (unchanged) still passes → number-typed
  scores byte-identical to today.
- All 11 tests in the module pass. `ruff` and `mypy` clean on the changed
  files (verified full `mypy gpf_web` clean, 253 source files).

Develop/verify against the **post-#303** gain wheel (meta-repo pin
`c3c6819`) — mypy only flags the original `.bars` read and validates the
`isinstance` guard against the retyped gain.

## Issue

Refs iossifovlab/gpf#982. Closes #982.

---

This PR is being converged by an automated adversarial review loop and
will be marked ready-for-review only if it converges.
