### PR TITLE
ci(e2e): drop `restart: always` from the e2e db service (gain#323)

### DIFF
--- a/web_infra/compose-jenkins.yaml
+++ b/web_infra/compose-jenkins.yaml
@@ -51,7 +51,22 @@ services:
     # gpf-infra/templates/compose.yaml.j2's db so an ORM migration
     # that breaks on MySQL fails here instead of on deploy.
     image: mysql:8.0.33
-    restart: always
+    # Ephemeral, per-build stack: never ask the daemon to keep this
+    # alive (gain#323). `always` also means "start on daemon start", so
+    # a container leaked by an aborted build (Jenkins never reaches
+    # post{}, so the `down -v` backstop never runs) is resurrected on
+    # every dockerd start, forever -- never idle-reaped, never aged
+    # out. Seven such db containers, the oldest from 2026-05-13, came
+    # back from the dead on piglet's 2026-07-15 reimage.
+    #
+    # Note this is NOT what covers the cold-init window below: the
+    # temporary --skip-networking init server runs inside this same
+    # container process, so a cold start is not an exit-and-retry.
+    # The #316 race was fixed by the TCP healthcheck probe, and
+    # dependents gate on `depends_on: service_healthy`. Matches the
+    # sibling services in this file. (Prod -- gpf-infra -- keeps a
+    # restart policy, correctly: it is a long-lived deployment.)
+    restart: "no"
     volumes_from:
       - mysql-data
     environment:


### PR DESCRIPTION
Half two of the two-repo fix for iossifovlab/gain#323 (filed in `gain` because it spans both). The gain half is iossifovlab/gain#408 — no ordering constraint between them: these are infra compose files with no import coupling.

## What

`web_infra/compose-jenkins.yaml`'s `db` service pinned `restart: always` while its sibling `instance-import` is `restart: "no"`. Set it to `"no"`.

The policy predates the mysql:8.0.33 swap — it came in with the original MariaDB service (`72bf4840c`), and `b98288ec8` carried it across untouched — so it was never a deliberate choice for the production-parity engine either.

## Why it matters

`restart: always` doesn't *cause* leaks: `docker compose down -v` removes the container regardless, and the `post.cleanup` backstop (`93994e3e5`, #952) closed the dominant leak path. This is about the tail — a container that leaks anyway (hard abort, agent disconnect, a branch whose Jenkinsfile predates the backstop: all cases where Jenkins never reaches `post{}`). Under `always` the daemon resurrects it on every start, forever. Never idle-reaped, never aged out.

piglet's 2026-07-15 reimage made this concrete: `/data` survived and `docker_data_root: /data/docker`, so the rebuilt daemon found the pre-reimage container definitions and honoured their restart policies. Seven e2e `db` containers from long-discarded builds came back up — five of them `gpf-web-e2e`, oldest created 2026-05-19 — holding RAM, a port binding and their volumes indefinitely.

## Was the policy load-bearing for mysql cold init?

This was the one thing gain#323 asked to check first (#845 / gpf-web-e2e #316). It is not:

- #316 was fixed by the healthcheck **probe** (socket → TCP `-h 127.0.0.1`, `b98288ec8`), not by the restart policy.
- The temporary `--skip-networking` init server runs **inside the same container process** — a cold start is not an exit-and-retry, so there is no window `always` (or `on-failure`) would cover.
- Dependents gate on `depends_on: db: condition: service_healthy`, not on the process being respawned.

## Verification

Ran a real cold (volume-less) start with the new policy:

```
port: 0                 <- temporary init server (skip-networking)
Shutdown complete
port: 3306              <- real networked server
healthy after ~30s
RestartCount = 0                          <- container never exited during init
HostConfig.RestartPolicy.Name = no        <- not resurrected by a daemon start
```

`RestartCount=0` across the full cold-init dance is the direct evidence that the policy was covering nothing. `docker compose config` also parses clean under both the split and combined overlays. The end-to-end cold-init path gets exercised by this PR's own `gpf-web-e2e` run.

## Why `"no"` and not `on-failure`

`on-failure` would need positive evidence of an exit-and-retry cold init, and there is none (see `RestartCount=0`). It would also mean a genuinely broken first boot loops against a half-seeded data dir instead of failing the build fast.

Prod (`gpf-infra`) keeps its restart policy, correctly — it is a long-lived deployment, not a per-build stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)